### PR TITLE
ci: add Typst docs checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,29 @@ jobs:
 
       - name: Run tests
         run: uv run pytest
+
+  typst-docs:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+
+      - name: Install Typst
+        uses: typst-community/setup-typst@v5
+
+      - name: Install typstyle
+        run: |
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL -o "$HOME/.local/bin/typstyle" \
+            https://github.com/typstyle-rs/typstyle/releases/download/v0.14.4/typstyle-x86_64-unknown-linux-gnu
+          chmod +x "$HOME/.local/bin/typstyle"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Install project
+        run: uv sync --extra dev
+
+      - name: Lint and compile Typst docs
+        run: make typst-check

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ NC := \033[0m
 
 # Tooling
 TYPST ?= typst
+TYPSTYLE ?= typstyle
 
 # Bibliography
 BIB_FILE ?= docs/references.bib
@@ -33,7 +34,7 @@ UPDATE_SLIDES_PDF ?= docs/slides/build/update-meetings.pdf
 FINAL_TYP ?= docs/slides/final/main.typ
 FINAL_PDF ?= docs/slides/build/final.pdf
 
-.PHONY: help fmt lint test bib-check bib-check-strict report-pdf slides-pdf final-slides docs-build
+.PHONY: help fmt lint typst-lint typst-check test bib-check bib-check-strict report-pdf slides-pdf final-slides docs-build
 
 #  ═══════════════════════════════════════════════════════════════════════
 #  🔧 Quality
@@ -46,6 +47,11 @@ fmt: ## Auto-format Python files and apply Ruff fixes
 lint: ## Run non-mutating Ruff format and lint checks
 	uv run ruff format --check .
 	uv run ruff check .
+
+typst-lint: ## Run non-mutating Typst formatting checks
+	$(TYPSTYLE) --check $(REPORT_TYP) $(UPDATE_SLIDES_TYP)
+
+typst-check: typst-lint report-pdf slides-pdf ## Lint and compile the report and update slides
 
 test: ## Run the Python test suite
 	uv run pytest

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ This repository addresses an off-device monocular VSLAM pipeline for smartphone 
 ### Requirements
 
 - [uv](https://docs.astral.sh/uv/getting-started/installation/) package manager
-- [typst](https://typst.app/open-source/#download) for slides & report.
+- [typst](https://typst.app/open-source/#download) for slides & report
+- [typstyle](https://github.com/typstyle-rs/typstyle/releases) for Typst formatting checks
 
 ### Bootstrap
 
@@ -16,6 +17,7 @@ uv sync --extra dev --extra eval
 uv run pre-commit install
 uv run pre-commit run --all-files
 uv run pytest
+make typst-check
 ```
 
 ## Challenge

--- a/docs/slides/update-meetings/update-slides.typ
+++ b/docs/slides/update-meetings/update-slides.typ
@@ -28,7 +28,9 @@
 #import "meeting-05/ck.typ" as m05_ck
 #import "meeting-05/jd.typ" as m05_jd
 
-#let deck_title = [#text(size: 37pt)[Challenge 5 \ Uncalibrated Monocular VSLAM]]
+#let deck_title = [#text(
+  size: 37pt,
+)[Challenge 5 \ Uncalibrated Monocular VSLAM]]
 #let extra = [Pattern Recognition & Machine Learning \ Prof. Dr. Friedrich]
 
 #let meeting_items_01 = (
@@ -57,7 +59,9 @@
   datetime(year: 2026, month: 6, day: 12),
 )
 
-#let display_meeting_date(date) = date.display("[day padding:none]. [month repr:short] [year]")
+#let display_meeting_date(date) = date.display(
+  "[day padding:none]. [month repr:short] [year]",
+)
 
 #let meeting_subtitle(items) = [
   #items.at(1) \
@@ -145,7 +149,11 @@
       title: section.table_title,
       rows: status_rows(members, section.row_picker),
     )
-    #for detail_body in collect_detail_bodies(items, members, section.detail_picker) [
+    #for detail_body in collect_detail_bodies(
+      items,
+      members,
+      section.detail_picker,
+    ) [
       #detail_body
     ]
   ]
@@ -168,7 +176,10 @@
     ]
   ]
 
-  #section-slide(title: meeting_items_01.at(0), subtitle: meeting_subtitle(meeting_items_01))
+  #section-slide(
+    title: meeting_items_01.at(0),
+    subtitle: meeting_subtitle(meeting_items_01),
+  )
 
   #meeting_slide(meeting_items_01, title: [Team Leader])[
     #team.leader_note
@@ -186,7 +197,10 @@
     #meeting_01.non_goals
   ]
 
-  #section-slide(title: meeting_items_02.at(0), subtitle: meeting_subtitle(meeting_items_02))
+  #section-slide(
+    title: meeting_items_02.at(0),
+    subtitle: meeting_subtitle(meeting_items_02),
+  )
 
   #meeting_slide(meeting_items_02, title: [Goals (refined)])[
     #meeting_02.goals_refined


### PR DESCRIPTION
## Summary
- add a dedicated CI job for Typst docs
- lint the report and update-meeting deck entrypoints with typstyle
- compile the report and update-meeting slides in CI

## Verification
- make typst-check
