### PR TITLE
[feat] add pipeline config workflow core

### DIFF
--- a/.configs/pipelines/advio-offline-advio-15-vista.toml
+++ b/.configs/pipelines/advio-offline-advio-15-vista.toml
@@ -1,0 +1,20 @@
+experiment_name = "advio-offline-advio-15-vista"
+mode            = "offline"
+output_dir      = ".artifacts"
+
+[source]
+dataset_id  = "advio"
+sequence_id = "advio-3"
+
+[slam]
+method             = "vista"
+emit_dense_points  = true
+emit_sparse_points = true
+
+[reference]
+enabled = false
+
+[evaluation]
+compare_to_arcore   = false
+evaluate_cloud      = false
+evaluate_efficiency = false

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ Pipeline contract and extension guidance lives in
 
 ### TOML-First Run Planning
 
-For durable/reproducible planning, store a `RunRequest` as TOML and resolve it
-through the CLI:
+For durable/reproducible planning, store a `RunRequest` as TOML under
+`.configs/pipelines/` and resolve it through the CLI:
 
 ```toml
 experiment_name = "advio-office-offline-vista"
@@ -80,8 +80,26 @@ evaluate_efficiency = true
 ```
 
 ```bash
-uv run prml-vslam plan-run-config configs/advio-office-vista.toml
+uv run prml-vslam plan-run-config advio-office-vista.toml
 ```
+
+The TOML shape mirrors the nested `RunRequest` model:
+
+- top-level fields configure the run itself: `experiment_name`, `mode`, `output_dir`
+- `[source]` configures the ingest boundary
+- `[slam]` configures the SLAM stage
+- `[reference]` configures the reference-reconstruction stage toggle
+- `[evaluation]` configures benchmark evaluation toggles
+
+Current stage-specific TOML configuration is therefore done by nesting the
+stage config tables directly under the request. For example, the optional
+method-specific backend config path belongs in `[slam]` as `config_path = "..."`
+because it is owned by `SlamConfig`.
+
+`plan-run-config` resolves the TOML file path itself relative to the
+repository. Nested TOML paths are then hydrated as written; resolve those
+explicitly through `PathConfig` in runtime code when repo-relative behavior is
+required.
 
 ## Challenge
 

--- a/src/prml_vslam/app/models.py
+++ b/src/prml_vslam/app/models.py
@@ -10,8 +10,6 @@ from pydantic import Field
 from prml_vslam.datasets.advio import AdvioDownloadPreset, AdvioModality, AdvioPoseSource
 from prml_vslam.datasets.contracts import DatasetId
 from prml_vslam.io.record3d import Record3DTransportId
-from prml_vslam.methods import MethodId
-from prml_vslam.pipeline.contracts import PipelineMode
 from prml_vslam.utils import BaseData
 from prml_vslam.utils.packet_session import PacketSessionSnapshot
 
@@ -139,14 +137,8 @@ class Record3DPageState(BaseData):
 class PipelinePageState(BaseData):
     """Persisted selector state for the interactive Pipeline demo."""
 
-    sequence_id: int | None = None
-    """Selected ADVIO sequence shown in the demo runner."""
-
-    mode: PipelineMode = PipelineMode.OFFLINE
-    """Whether the demo should run one pass or keep looping."""
-
-    method: MethodId = MethodId.VISTA
-    """Selected mock SLAM backend label."""
+    config_path: Path | None = None
+    """Selected pipeline request TOML used to instantiate the demo run."""
 
     pose_source: AdvioPoseSource = AdvioPoseSource.GROUND_TRUTH
     """Selected pose source injected into the ADVIO replay packets."""

--- a/src/prml_vslam/app/pages/pipeline.py
+++ b/src/prml_vslam/app/pages/pipeline.py
@@ -13,16 +13,17 @@ from evo.core import metrics as evo_metrics
 from evo.core import sync as evo_sync
 
 from prml_vslam.datasets.advio import AdvioPoseSource
+from prml_vslam.datasets.contracts import DatasetId
 from prml_vslam.eval.contracts import ErrorSeries, MetricStats, TrajectorySeries
-from prml_vslam.methods import MethodId
-from prml_vslam.pipeline import PipelineMode
+from prml_vslam.pipeline import RunRequest
 from prml_vslam.pipeline.contracts import (
+    DatasetSourceSpec,
     StageManifest,
 )
-from prml_vslam.pipeline.demo import build_advio_demo_request
+from prml_vslam.pipeline.demo import load_run_request_toml
 from prml_vslam.pipeline.session import PipelineSessionSnapshot, PipelineSessionState
 from prml_vslam.plotting import build_evo_ape_colormap_figure
-from prml_vslam.utils import BaseData
+from prml_vslam.utils import BaseData, PathConfig
 from prml_vslam.utils.geometry import load_tum_trajectory
 from prml_vslam.utils.image_utils import normalize_grayscale_image
 
@@ -50,14 +51,8 @@ _EVO_ASSOCIATION_MAX_DIFF_S = 0.01
 class PipelinePageAction(BaseData):
     """Typed action payload for the pipeline page controls."""
 
-    sequence_id: int
-    """Selected ADVIO sequence id."""
-
-    mode: PipelineMode
-    """Selected pipeline mode."""
-
-    method: MethodId
-    """Selected mock SLAM backend label."""
+    config_path: Path
+    """Selected pipeline request TOML."""
 
     pose_source: AdvioPoseSource
     """Selected pose source for the ADVIO replay stream."""
@@ -92,43 +87,40 @@ def render(context: AppContext) -> None:
         ),
     )
     statuses = context.advio_service.local_scene_statuses()
-    previewable_ids = [status.scene.sequence_id for status in statuses if status.replay_ready]
+    previewable_statuses = [status for status in statuses if status.replay_ready]
     snapshot = context.run_service.snapshot()
     is_active = snapshot.state in _ACTIVE_SESSION_STATES
     with st.container(border=True):
         st.subheader("ADVIO Replay Demo")
         st.caption(
-            "Use one replay-ready ADVIO scene as a bounded offline or looped streaming session for the current pipeline demo."
+            "Select a persisted ADVIO pipeline request TOML and run it as a bounded offline or looped streaming session."
         )
-        if not previewable_ids:
+        if not previewable_statuses:
             st.info(
                 "Download the ADVIO streaming bundle for at least one scene to unlock the interactive pipeline demo."
             )
             return
+        config_paths = _discover_pipeline_config_paths(context.path_config)
+        if not config_paths:
+            st.info("Persist at least one pipeline request TOML under `.configs/pipelines/` to unlock this demo.")
+            return
         page_state = context.state.pipeline
-        selected_sequence_id = (
-            page_state.sequence_id if page_state.sequence_id in previewable_ids else previewable_ids[0]
+        selected_config_path = page_state.config_path if page_state.config_path in config_paths else config_paths[0]
+        selected_config_path = st.selectbox(
+            "Pipeline Config",
+            options=config_paths,
+            index=config_paths.index(selected_config_path),
+            format_func=lambda config_path: _pipeline_config_label(context.path_config, config_path),
         )
-        selected_sequence_id = st.selectbox(
-            "ADVIO Scene",
-            options=previewable_ids,
-            index=previewable_ids.index(selected_sequence_id),
-            format_func=lambda sequence_id: context.advio_service.scene(sequence_id).display_name,
-        )
+        request, request_error = _load_pipeline_request(context.path_config, selected_config_path)
+        sequence_id, request_support_error = _resolve_advio_sequence_id(request=request, statuses=statuses)
         left, right = st.columns(2, gap="large")
         with left:
-            mode = st.selectbox(
-                "Mode",
-                options=list(PipelineMode),
-                index=list(PipelineMode).index(page_state.mode),
-                format_func=lambda item: item.label,
-            )
-            method = st.selectbox(
-                "Mock Method",
-                options=list(MethodId),
-                index=list(MethodId).index(page_state.method),
-                format_func=lambda item: item.display_name,
-            )
+            st.markdown("**Resolved Request**")
+            if request is None:
+                st.warning(request_error or "Failed to load the selected pipeline config.")
+            else:
+                st.json(_request_summary_payload(request), expanded=False)
         with right:
             pose_source = st.selectbox(
                 "Pose Source",
@@ -140,15 +132,18 @@ def render(context: AppContext) -> None:
                 "Respect video rotation metadata",
                 value=page_state.respect_video_rotation,
             )
+            if request_support_error is None and request is not None and sequence_id is not None:
+                st.caption(f"Resolved demo sequence: `{context.advio_service.scene(sequence_id).display_name}`")
+            elif request_support_error is not None:
+                st.warning(request_support_error)
         start_requested, stop_requested = render_live_action_slot(
             is_active=is_active,
             start_label="Start run",
             stop_label="Stop run",
+            start_disabled=request is None or request_support_error is not None,
         )
         action = PipelinePageAction(
-            sequence_id=selected_sequence_id,
-            mode=mode,
-            method=method,
+            config_path=selected_config_path,
             pose_source=pose_source,
             respect_video_rotation=respect_video_rotation,
             start_requested=start_requested,
@@ -345,9 +340,7 @@ def _handle_pipeline_page_action(context: AppContext, action: PipelinePageAction
         context.store,
         context.state,
         context.state.pipeline,
-        sequence_id=action.sequence_id,
-        mode=action.mode,
-        method=action.method,
+        config_path=action.config_path,
         pose_source=action.pose_source,
         respect_video_rotation=action.respect_video_rotation,
     )
@@ -359,9 +352,7 @@ def _handle_pipeline_page_action(context: AppContext, action: PipelinePageAction
             return None
         _start_advio_demo_run(
             context,
-            sequence_id=action.sequence_id,
-            mode=action.mode,
-            method=action.method,
+            config_path=action.config_path,
             pose_source=action.pose_source,
             respect_video_rotation=action.respect_video_rotation,
         )
@@ -373,26 +364,100 @@ def _handle_pipeline_page_action(context: AppContext, action: PipelinePageAction
 def _start_advio_demo_run(
     context: AppContext,
     *,
-    sequence_id: int,
-    mode: PipelineMode,
-    method: MethodId,
+    config_path: Path,
     pose_source: AdvioPoseSource,
     respect_video_rotation: bool,
 ) -> None:
     """Start one bounded ADVIO demo run through the shared run facade."""
-    scene = context.advio_service.scene(sequence_id)
-    request = build_advio_demo_request(
-        path_config=context.path_config,
-        sequence_id=scene.sequence_slug,
-        mode=mode,
-        method=method,
+    request = load_run_request_toml(path_config=context.path_config, config_path=config_path)
+    sequence_id, sequence_error = _resolve_advio_sequence_id(
+        request=request,
+        statuses=context.advio_service.local_scene_statuses(),
     )
+    if sequence_error is not None or sequence_id is None:
+        raise ValueError(sequence_error or "Failed to resolve an ADVIO scene for the selected pipeline config.")
     source = context.advio_service.build_streaming_source(
         sequence_id=sequence_id,
         pose_source=pose_source,
         respect_video_rotation=respect_video_rotation,
     )
     context.run_service.start_run(request=request, source=source)
+
+
+def _discover_pipeline_config_paths(path_config: PathConfig) -> list[Path]:
+    config_dir = path_config.resolve_pipeline_configs_dir()
+    if not config_dir.exists():
+        return []
+    return sorted(path.resolve() for path in config_dir.rglob("*.toml") if path.is_file())
+
+
+def _pipeline_config_label(path_config: PathConfig, config_path: Path) -> str:
+    config_root = path_config.resolve_pipeline_configs_dir()
+    try:
+        return str(config_path.relative_to(config_root))
+    except ValueError:
+        return (
+            str(config_path.relative_to(path_config.root))
+            if config_path.is_relative_to(path_config.root)
+            else str(config_path)
+        )
+
+
+def _load_pipeline_request(path_config: PathConfig, config_path: Path) -> tuple[RunRequest | None, str | None]:
+    try:
+        return load_run_request_toml(path_config=path_config, config_path=config_path), None
+    except Exception as exc:
+        return None, str(exc)
+
+
+def _resolve_advio_sequence_id(
+    *,
+    request: RunRequest | None,
+    statuses: list[object],
+) -> tuple[int | None, str | None]:
+    if request is None:
+        return None, None
+    match request.source:
+        case DatasetSourceSpec(dataset_id=DatasetId.ADVIO, sequence_id=sequence_slug):
+            for status in statuses:
+                scene = getattr(status, "scene", None)
+                if scene is None or getattr(scene, "sequence_slug", None) != sequence_slug:
+                    continue
+                if bool(getattr(status, "replay_ready", False)):
+                    return int(scene.sequence_id), None
+                return None, f"ADVIO sequence '{sequence_slug}' is available locally but not replay-ready."
+            return None, f"ADVIO sequence '{sequence_slug}' is not available locally."
+        case DatasetSourceSpec(dataset_id=dataset_id):
+            return None, f"Dataset '{dataset_id.value}' is not supported by this demo page."
+        case _:
+            return None, "This demo page only supports dataset-backed ADVIO pipeline configs."
+
+
+def _request_summary_payload(request: RunRequest) -> dict[str, object]:
+    payload = {
+        "experiment_name": request.experiment_name,
+        "mode": request.mode.value,
+        "output_dir": request.output_dir.as_posix(),
+        "slam": {
+            "method": request.slam.method.value,
+            "config_path": None if request.slam.config_path is None else request.slam.config_path.as_posix(),
+            "max_frames": request.slam.max_frames,
+            "emit_dense_points": request.slam.emit_dense_points,
+            "emit_sparse_points": request.slam.emit_sparse_points,
+        },
+        "reference": request.reference.model_dump(mode="json"),
+        "evaluation": request.evaluation.model_dump(mode="json"),
+    }
+    match request.source:
+        case DatasetSourceSpec(dataset_id=dataset_id, sequence_id=sequence_id):
+            payload["source"] = {
+                "kind": "dataset",
+                "dataset_id": dataset_id.value,
+                "sequence_id": sequence_id,
+            }
+        case _:
+            payload["source"] = request.source.model_dump(mode="json")
+    return payload
 
 
 def _pointmap_depth_preview(pointmap: np.ndarray) -> np.ndarray:

--- a/src/prml_vslam/main.py
+++ b/src/prml_vslam/main.py
@@ -24,7 +24,7 @@ from prml_vslam.pipeline.contracts import (
     SlamConfig,
     VideoSourceSpec,
 )
-from prml_vslam.pipeline.demo import build_advio_demo_request
+from prml_vslam.pipeline.demo import build_advio_demo_request, load_run_request_toml, persist_advio_demo_request
 from prml_vslam.pipeline.run_service import RunService
 from prml_vslam.pipeline.session import PipelineSessionSnapshot, PipelineSessionState
 from prml_vslam.utils.console import Console
@@ -125,13 +125,67 @@ def plan_run_config(
     """Build a typed benchmark run plan from a TOML config file."""
     path_config = get_path_config()
     try:
-        resolved_config_path = path_config.resolve_toml_path(config_path, must_exist=True)
-        request = RunRequest.from_toml(resolved_config_path)
+        request = load_run_request_toml(path_config=path_config, config_path=config_path)
         plan = request.build(path_config)
     except Exception as exc:
         console.error(str(exc))
         raise typer.Exit(code=1) from exc
     console.plog(plan.model_dump(mode="json"))
+
+
+@app.command("write-demo-config")
+def write_demo_config(
+    sequence_id: Annotated[
+        int | None,
+        typer.Option(
+            "--sequence",
+            help="ADVIO sequence id to use. Defaults to the first replay-ready local scene.",
+        ),
+    ] = None,
+    mode: Annotated[
+        PipelineMode,
+        typer.Option(
+            "--mode",
+            help="Persist an offline or streaming ADVIO demo request.",
+            case_sensitive=False,
+        ),
+    ] = PipelineMode.OFFLINE,
+    method: Annotated[
+        MethodId,
+        typer.Option(
+            "--method",
+            help="Method id stored in the persisted demo request.",
+            case_sensitive=False,
+        ),
+    ] = MethodId.VISTA,
+    config_path: Annotated[
+        Path | None,
+        typer.Option(
+            "--config-path",
+            help="Optional output TOML path. Bare filenames resolve under .configs/pipelines/.",
+        ),
+    ] = None,
+) -> None:
+    """Persist the canonical ADVIO demo request as TOML."""
+    path_config = get_path_config()
+    advio_service = AdvioDatasetService(path_config)
+    resolved_sequence_id = _resolve_demo_sequence_id(advio_service, explicit_sequence_id=sequence_id)
+    scene = advio_service.scene(resolved_sequence_id)
+    resolved_config_path = persist_advio_demo_request(
+        path_config=path_config,
+        sequence_id=scene.sequence_slug,
+        mode=mode,
+        method=method,
+        config_path=config_path,
+    )
+    console.plog(
+        {
+            "config_path": str(resolved_config_path),
+            "sequence_id": scene.sequence_slug,
+            "mode": mode.value,
+            "method": method.value,
+        }
+    )
 
 
 @app.command("record3d-devices")

--- a/src/prml_vslam/pipeline/README.md
+++ b/src/prml_vslam/pipeline/README.md
@@ -28,6 +28,11 @@ There is one executable demo today:
 That demo lives in `prml_vslam.app`, not in `prml_vslam.pipeline`, because it
 is a bounded monitoring surface rather than the final reusable runner API.
 
+The current executable `RunService` slice only supports the `ingest`, `slam`,
+and `summary` stages. The planner can still describe reference and evaluation
+stages, but the bounded runtime rejects those stage ids until explicit runtime
+support is added.
+
 ## Current Streaming Demo Implementation
 
 The current runnable streaming demo is split across the following files.
@@ -153,6 +158,8 @@ The intended long-term flow is:
     main benchmark stages
   - points to materialized or resolved inputs such as video, frames,
     timestamps, intrinsics, and optional reference trajectories
+  - must always provide a stable `sequence_id`; populate the optional artifact
+    paths whenever the source knows them
 
 ### Stage Outputs
 
@@ -173,6 +180,25 @@ them.
     paths, and execution status
 - `RunSummary`
   - final top-level summary containing the artifact root and stage status map
+
+### Minimum Structural Requirements
+
+- source adapters
+  - offline sources must provide `label` and
+    `prepare_sequence_manifest(output_dir) -> SequenceManifest`
+  - streaming sources must additionally provide
+    `open_stream(*, loop: bool) -> FramePacketStream`
+- SLAM backends
+  - offline backends must expose `method_id` and
+    `run_sequence(sequence, cfg, artifact_root) -> SlamArtifacts`
+  - streaming backends must expose `method_id` and
+    `start_session(cfg, artifact_root) -> SlamSession`
+- SLAM sessions
+  - must implement `step(frame) -> SlamUpdate` and `close() -> SlamArtifacts`
+- SLAM artifacts
+  - must always include `trajectory_tum`
+  - `sparse_points_ply`, `dense_points_ply`, and `preview_log_jsonl` remain
+    optional
 
 ## Runtime Interfaces
 
@@ -303,6 +329,21 @@ intended topology, stage set, and artifact root for a future runner.
 `prml_vslam.main.plan_run` constructs a `RunRequest` from CLI arguments and
 prints the resulting `RunPlan`. This is the current offline planning entrypoint.
 
+### TOML Configs
+
+`prml_vslam.main.plan_run_config` resolves the TOML file itself through
+`PathConfig.resolve_toml_path(...)`, then hydrates `RunRequest` via
+`RunRequest.from_toml(...)`.
+
+Important nuance: only the TOML file path is repo-resolved automatically.
+Nested TOML paths such as `source.video_path` and `slam.config_path` are
+validated as written. If a caller wants repo-relative behavior for those inner
+paths, resolve them explicitly through `PathConfig`.
+
+`prml_vslam.main.plan_run_config` loads a persisted `RunRequest` TOML from
+`.configs/pipelines/*.toml` by default. Bare filenames resolve into that repo
+config directory through `PathConfig.resolve_pipeline_config_path(...)`.
+
 ### Streamlit Monitoring Demo
 
 The `Pipeline` page demonstrates the same contracts in an executable but
@@ -320,6 +361,194 @@ This demo supports:
 - `offline` as one replay pass
 - `streaming` as looped replay with the same incremental SLAM interface
 
+## Persisting A Pipeline Config
+
+The repo-owned way to persist a durable pipeline request is:
+
+```python
+from prml_vslam.pipeline.demo import save_run_request_toml
+from prml_vslam.utils import PathConfig
+
+path_config = PathConfig()
+request = ...
+config_path = save_run_request_toml(
+    path_config=path_config,
+    request=request,
+    config_path="advio-office-vista.toml",
+)
+```
+
+When `config_path` is a bare filename, it is written to
+`.configs/pipelines/<name>.toml`. Explicit relative paths keep their repo-root
+anchoring.
+
+## Configuring Stages Via TOML
+
+`RunRequest` owns stage-specific config as nested config models, so the TOML
+uses one table per nested config:
+
+```toml
+experiment_name = "advio-office-offline-vista"
+mode = "offline"
+output_dir = ".artifacts"
+
+[source]
+dataset_id = "advio"
+sequence_id = "advio-15"
+
+[slam]
+method = "vista"
+config_path = ".configs/methods/vista/demo.toml"
+max_frames = 300
+emit_dense_points = true
+emit_sparse_points = true
+
+[reference]
+enabled = false
+
+[evaluation]
+compare_to_arcore = true
+evaluate_cloud = false
+evaluate_efficiency = true
+```
+
+The rule is simple:
+
+- fields on `RunRequest` stay top-level
+- fields on `SlamConfig` go under `[slam]`
+- fields on `ReferenceConfig` go under `[reference]`
+- fields on `BenchmarkEvaluationConfig` go under `[evaluation]`
+
+`[source]` is a tagged-by-shape union. Choose exactly one source shape:
+
+- video source: `video_path`, optional `frame_stride`
+- dataset source: `dataset_id`, `sequence_id`
+- live source: `source_id`, optional `persist_capture`
+
+## Common Questions
+
+### Which Stages Actually Execute Today?
+
+The planner can describe:
+
+- `ingest`
+- `slam`
+- `reference_reconstruction`
+- `trajectory_evaluation`
+- `cloud_evaluation`
+- `efficiency_evaluation`
+- `summary`
+
+The current bounded `RunService` runtime only executes:
+
+- `ingest`
+- `slam`
+- `summary`
+
+Reference and evaluation stages are still planned architecture in this package.
+
+### Which Modules Own Which Boundaries?
+
+- `pipeline/contracts.py`
+  - stage DTOs, plan DTOs, manifests, summaries, and artifact bundles
+- `pipeline/services.py`
+  - planner wiring and stage selection
+- `pipeline/run_service.py`
+  - app-facing facade for the current runnable slice
+- `pipeline/session.py`
+  - current bounded runtime execution and manifest finalization
+- `protocols/source.py`
+  - source-provider behavior seams
+- `methods/protocols.py`
+  - SLAM backend and session behavior seams
+- `utils/path_config.py`
+  - canonical artifact layout and repo-owned config-path resolution
+
+### What Happens If I Omit Optional Stage Config?
+
+`ReferenceConfig.enabled` defaults to `false`.
+
+`BenchmarkEvaluationConfig` defaults to:
+
+- `compare_to_arcore = true`
+- `evaluate_cloud = false`
+- `evaluate_efficiency = true`
+
+`SlamConfig` defaults to:
+
+- `emit_dense_points = true`
+- `emit_sparse_points = true`
+
+So a minimal `RunRequest` with only `source` and `slam` plans:
+
+- `ingest`
+- `slam`
+- `trajectory_evaluation`
+- `efficiency_evaluation`
+- `summary`
+
+### Which TOML Paths Are Auto-Resolved?
+
+- the TOML file passed to `plan-run-config`
+- bare filenames passed through the repo-owned pipeline-config helpers
+
+Nested fields inside the TOML are not rewritten automatically. Paths such as:
+
+- `source.video_path`
+- `slam.config_path`
+- `output_dir`
+
+are hydrated exactly as written and should be resolved explicitly through
+`PathConfig` when a runtime wants repo-relative behavior.
+
+### What Is The Minimum Valid `SequenceManifest`?
+
+Structurally, `SequenceManifest` only requires `sequence_id`.
+
+Recommended population by source kind:
+
+- video-backed sources
+  - `sequence_id`, `video_path`
+  - add `timestamps_path` and `intrinsics_path` when known
+- dataset-backed sources
+  - `sequence_id`
+  - populate dataset-derived `video_path`, `timestamps_path`,
+    `intrinsics_path`, `reference_tum_path`, and `arcore_tum_path` whenever
+    available
+- live or replay captures
+  - `sequence_id`
+  - include whichever persisted capture artifacts are already materialized for
+    downstream stages
+
+### Which Artifacts Are Mandatory Vs Optional?
+
+- ingest
+  - required: `input/sequence_manifest.json`
+- slam
+  - required: `slam/trajectory.tum`
+  - optional: `slam/sparse_points.ply`
+  - optional: `dense/dense_points.ply`
+  - optional: live preview/event log artifact
+- summary
+  - required: `summary/run_summary.json`
+  - required: `summary/stage_manifests.json`
+
+Reference and evaluation artifact bundles should only become mandatory after
+those stages gain real runtime support.
+
+### Which Files Usually Change When Adding A Runnable Stage?
+
+At minimum, expect to touch:
+
+- `pipeline/contracts.py`
+- `pipeline/services.py`
+- `utils/path_config.py`
+- `pipeline/run_service.py`
+- `pipeline/session.py`
+- the owning protocol module when a new reusable execution seam is introduced
+- `tests/test_pipeline.py`
+- path or CLI tests when config/layout behavior changes
+
 ## How To Add A Stage
 
 When adding a stage, change the typed contracts first and the runner wiring
@@ -334,13 +563,21 @@ second.
    - The path layout belongs to `PathConfig`, not to the app or backend.
 5. Insert the stage into `RunPlannerService._build_stages(...)`.
    - Give it a stable title, summary, and explicit outputs.
-6. Define the execution protocol in `protocols.py` if the stage introduces a
-   new reusable execution seam.
+6. Define the execution protocol in the owning package protocol module if the
+   stage introduces a new reusable execution seam.
+   - source-provider seams live in `prml_vslam.protocols.source`
+   - SLAM backend/session seams live in `prml_vslam.methods.protocols`
+   - add a new `<package>/protocols.py` only when that package truly owns a
+     new reusable behavior boundary
 7. Wire the executor surface.
    - For the current demo this means `prml_vslam.pipeline.session`.
    - Keep the Streamlit page as a thin client over the pipeline-owned service.
 8. Persist `StageManifest` and update `RunSummary`.
 9. Add tests for planning, artifact-path layout, and execution behavior.
+
+For the current runnable slice, extending the planner is not enough. If the
+new stage must execute in the bounded demo, also extend the stage support in
+`RunService` and the finalization logic in `PipelineSessionService`.
 
 If the new stage needs live `FramePacket` access, challenge that decision
 first. In this repository, only ingress and streaming SLAM should normally
@@ -361,10 +598,12 @@ Use the following decision rule:
 ## Related Files
 
 - [`contracts.py`](./contracts.py)
-- [`protocols.py`](./protocols.py)
 - [`session.py`](./session.py)
+- [`run_service.py`](./run_service.py)
 - [`services.py`](./services.py)
 - [`workspace.py`](./workspace.py)
+- [`../methods/protocols.py`](../methods/protocols.py)
+- [`../protocols/source.py`](../protocols/source.py)
 - [`../app/pages/pipeline.py`](../app/pages/pipeline.py)
 - [`../methods/mock_vslam.py`](../methods/mock_vslam.py)
 - [`../datasets/advio_service.py`](../datasets/advio_service.py)

--- a/src/prml_vslam/pipeline/demo.py
+++ b/src/prml_vslam/pipeline/demo.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from prml_vslam.datasets.contracts import DatasetId
 from prml_vslam.methods import MethodId
 from prml_vslam.pipeline import PipelineMode, RunRequest
@@ -37,4 +39,49 @@ def build_advio_demo_request(
     )
 
 
-__all__ = ["build_advio_demo_request"]
+def load_run_request_toml(*, path_config: PathConfig, config_path: str | Path) -> RunRequest:
+    """Load a pipeline request TOML through the repo-owned config path helper."""
+    resolved_config_path = path_config.resolve_pipeline_config_path(config_path, must_exist=True)
+    return RunRequest.from_toml(resolved_config_path)
+
+
+def save_run_request_toml(
+    *,
+    path_config: PathConfig,
+    request: RunRequest,
+    config_path: str | Path,
+) -> Path:
+    """Persist a pipeline request TOML through the repo-owned config path helper."""
+    resolved_config_path = path_config.resolve_pipeline_config_path(config_path, create_parent=True)
+    request.save_toml(resolved_config_path)
+    return resolved_config_path
+
+
+def persist_advio_demo_request(
+    *,
+    path_config: PathConfig,
+    sequence_id: str,
+    mode: PipelineMode,
+    method: MethodId,
+    config_path: str | Path | None = None,
+) -> Path:
+    """Persist the canonical ADVIO demo request under `.configs/pipelines/` by default."""
+    request = build_advio_demo_request(
+        path_config=path_config,
+        sequence_id=sequence_id,
+        mode=mode,
+        method=method,
+    )
+    return save_run_request_toml(
+        path_config=path_config,
+        request=request,
+        config_path=(config_path or f"{request.experiment_name}.toml"),
+    )
+
+
+__all__ = [
+    "build_advio_demo_request",
+    "load_run_request_toml",
+    "persist_advio_demo_request",
+    "save_run_request_toml",
+]

--- a/src/prml_vslam/utils/path_config.py
+++ b/src/prml_vslam/utils/path_config.py
@@ -13,7 +13,7 @@ from .base_data import BaseData
 
 PROJECT_ROOT = Path(__file__).resolve().parents[3]
 _ROOT_DIR_FIELDS = (
-    "artifacts_dir captures_dir data_dir logs_dir method_repos_dir method_envs_dir checkpoints_dir".split()
+    "artifacts_dir captures_dir data_dir logs_dir configs_dir method_repos_dir method_envs_dir checkpoints_dir".split()
 )
 
 
@@ -92,6 +92,8 @@ class PathConfig(BaseConfig):
     """Root directory for repo-owned benchmark datasets."""
     logs_dir: Path = Field(default_factory=lambda: Path(".logs"))
     """Root directory for shared runtime state such as cloned upstream repos and checkpoints."""
+    configs_dir: Path = Field(default_factory=lambda: Path(".configs"))
+    """Root directory for repo-owned durable TOML configuration."""
     method_repos_dir: Path = Field(default_factory=lambda: Path(".logs/repos"))
     """Directory containing checked-out upstream method repositories."""
     method_envs_dir: Path = Field(default_factory=lambda: Path(".logs/venvs"))
@@ -157,6 +159,14 @@ class PathConfig(BaseConfig):
         """Resolve the shared runtime logs directory."""
         return self._resolve_dir(self.logs_dir, create=create)
 
+    def resolve_configs_dir(self, *, create: bool = False) -> Path:
+        """Resolve the shared repo-owned config directory."""
+        return self._resolve_dir(self.configs_dir, create=create)
+
+    def resolve_pipeline_configs_dir(self, *, create: bool = False) -> Path:
+        """Resolve the shared pipeline config directory under the repo config root."""
+        return self._resolve_dir(self.configs_dir, "pipelines", create=create)
+
     def resolve_method_repo_dir(self, method_repo_name: str, *, create: bool = False) -> Path:
         """Resolve one upstream method checkout path under the shared logs directory."""
         return self._resolve_dir(self.method_repos_dir, method_repo_name, create=create)
@@ -169,9 +179,16 @@ class PathConfig(BaseConfig):
         """Resolve one shared checkpoint directory for an external backend."""
         return self._resolve_dir(self.checkpoints_dir, method_slug, create=create)
 
-    def resolve_toml_path(self, path: str | Path, *, must_exist: bool = False, create_parent: bool = False) -> Path:
+    def resolve_toml_path(
+        self,
+        path: str | Path,
+        *,
+        base_dir: str | Path | None = None,
+        must_exist: bool = False,
+        create_parent: bool = False,
+    ) -> Path:
         """Resolve a TOML file path relative to the repository root."""
-        resolved = self.resolve_repo_path(path)
+        resolved = self.resolve_repo_path(path, base_dir=base_dir)
         if resolved.suffix != ".toml":
             raise ValueError(f"Config path must be a .toml file, got {resolved}")
         if create_parent:
@@ -179,6 +196,29 @@ class PathConfig(BaseConfig):
         if must_exist and not resolved.exists():
             raise FileNotFoundError(f"Config file not found: {resolved}")
         return resolved
+
+    def resolve_pipeline_config_path(
+        self,
+        path: str | Path,
+        *,
+        must_exist: bool = False,
+        create_parent: bool = False,
+    ) -> Path:
+        """Resolve a pipeline config TOML path.
+
+        Bare filenames are placed under `.configs/pipelines/`. Explicit relative
+        or absolute paths keep their original anchoring.
+        """
+        candidate = Path(path)
+        base_dir = (
+            self.resolve_pipeline_configs_dir() if not candidate.is_absolute() and candidate.parent == Path() else None
+        )
+        return self.resolve_toml_path(
+            candidate,
+            base_dir=base_dir,
+            must_exist=must_exist,
+            create_parent=create_parent,
+        )
 
     def slugify_experiment_name(self, experiment_name: str) -> str:
         """Convert a human-readable experiment name into a filesystem-safe slug."""

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -65,6 +65,64 @@ def _build_path_config(tmp_path: Path) -> PathConfig:
     )
 
 
+def _write_pipeline_config(
+    path_config: PathConfig,
+    *,
+    name: str = "advio-offline-advio-15-vista.toml",
+    source_block: str = 'dataset_id = "advio"\nsequence_id = "advio-15"',
+) -> Path:
+    config_path = path_config.resolve_pipeline_config_path(name, create_parent=True)
+    config_path.write_text(
+        f"""
+experiment_name = "advio-offline-advio-15-vista"
+mode = "offline"
+output_dir = ".artifacts"
+
+[source]
+{source_block}
+
+[slam]
+method = "vista"
+emit_dense_points = true
+emit_sparse_points = true
+
+[reference]
+enabled = false
+
+[evaluation]
+compare_to_arcore = false
+evaluate_cloud = false
+evaluate_efficiency = false
+""".strip(),
+        encoding="utf-8",
+    )
+    return config_path
+
+
+def _load_pipeline_request_fixture() -> SimpleNamespace:
+    return SimpleNamespace(
+        experiment_name="advio-offline-advio-15-vista",
+        mode=SimpleNamespace(value="offline"),
+        output_dir=Path(".artifacts"),
+        source=SimpleNamespace(model_dump=lambda mode="json": {"dataset_id": "advio", "sequence_id": "advio-15"}),
+        slam=SimpleNamespace(
+            method=SimpleNamespace(value="vista"),
+            config_path=None,
+            max_frames=None,
+            emit_dense_points=True,
+            emit_sparse_points=True,
+        ),
+        reference=SimpleNamespace(model_dump=lambda mode="json": {"enabled": False}),
+        evaluation=SimpleNamespace(
+            model_dump=lambda mode="json": {
+                "compare_to_arcore": False,
+                "evaluate_cloud": False,
+                "evaluate_efficiency": False,
+            }
+        ),
+    )
+
+
 def _write_advio_local_sequence(dataset_root: Path, *, sequence_id: int = 15) -> Path:
     sequence_dir = dataset_root / f"advio-{sequence_id:02d}"
     (sequence_dir / "iphone").mkdir(parents=True, exist_ok=True)
@@ -406,14 +464,24 @@ def test_pipeline_page_evo_preview_fails_when_timestamps_do_not_match(tmp_path: 
         )
 
 
-def test_pipeline_page_action_starts_pipeline_session_once_without_app_manifest_writes(tmp_path: Path) -> None:
+def test_pipeline_page_action_starts_pipeline_session_once_from_selected_toml(tmp_path: Path) -> None:
     from prml_vslam.app.pages import pipeline as pipeline_page
 
     source = object()
+    path_config = PathConfig(root=tmp_path, artifacts_dir=tmp_path / ".artifacts", captures_dir=tmp_path / "captures")
+    config_path = _write_pipeline_config(path_config)
 
     class AdvioServiceSpy:
         def __init__(self) -> None:
             self.source_calls: list[tuple[int, AdvioPoseSource, bool]] = []
+
+        def local_scene_statuses(self) -> list[SimpleNamespace]:
+            return [
+                SimpleNamespace(
+                    replay_ready=True,
+                    scene=SimpleNamespace(sequence_id=15, sequence_slug="advio-15", display_name="advio-15"),
+                )
+            ]
 
         def scene(self, sequence_id: int) -> SimpleNamespace:
             return SimpleNamespace(sequence_slug=f"advio-{sequence_id:02d}", display_name=f"advio-{sequence_id:02d}")
@@ -433,9 +501,7 @@ def test_pipeline_page_action_starts_pipeline_session_once_without_app_manifest_
 
     runtime = FakeRunService()
     context = SimpleNamespace(
-        path_config=PathConfig(
-            root=tmp_path, artifacts_dir=tmp_path / ".artifacts", captures_dir=tmp_path / "captures"
-        ),
+        path_config=path_config,
         advio_service=AdvioServiceSpy(),
         run_service=runtime,
         state=AppState(),
@@ -445,9 +511,7 @@ def test_pipeline_page_action_starts_pipeline_session_once_without_app_manifest_
     error_message = pipeline_page._handle_pipeline_page_action(
         context,
         pipeline_page.PipelinePageAction(
-            sequence_id=15,
-            mode=pipeline_page.PipelineMode.OFFLINE,
-            method=MethodId.VISTA,
+            config_path=config_path,
             pose_source=AdvioPoseSource.GROUND_TRUTH,
             respect_video_rotation=True,
             start_requested=True,
@@ -456,6 +520,7 @@ def test_pipeline_page_action_starts_pipeline_session_once_without_app_manifest_
 
     assert error_message is None
     assert context.advio_service.source_calls == [(15, AdvioPoseSource.GROUND_TRUTH, True)]
+    assert context.state.pipeline.config_path == config_path
     assert len(runtime.start_calls) == 1
     assert runtime.start_calls[0]["source"] is source
     request = runtime.start_calls[0]["request"]
@@ -484,7 +549,9 @@ def test_pipeline_demo_controls_show_only_stop_button_while_run_is_active() -> N
             return SimpleNamespace(display_name=f"advio-{sequence_id:02d} · Mall 01")
 
     seen_labels: list[str] = []
+    config_path = Path("/tmp/advio-offline-advio-15-vista.toml")
     context = SimpleNamespace(
+        path_config=SimpleNamespace(),
         advio_service=AdvioServiceSpy(),
         run_service=FakeRunService(snapshot=PipelineSessionSnapshot(state=PipelineSessionState.RUNNING)),
         state=AppState(),
@@ -493,9 +560,7 @@ def test_pipeline_demo_controls_show_only_stop_button_while_run_is_active() -> N
 
     def fake_selectbox(label: str, *args, **kwargs):
         return {
-            "ADVIO Scene": 15,
-            "Mode": pipeline_page.PipelineMode.OFFLINE,
-            "Mock Method": MethodId.VISTA,
+            "Pipeline Config": config_path,
             "Pose Source": AdvioPoseSource.GROUND_TRUTH,
         }[label]
 
@@ -511,6 +576,16 @@ def test_pipeline_demo_controls_show_only_stop_button_while_run_is_active() -> N
     monkeypatch.setattr(pipeline_page.st, "selectbox", fake_selectbox)
     monkeypatch.setattr(pipeline_page.st, "columns", lambda *args, **kwargs: (DummyContext(), DummyContext()))
     monkeypatch.setattr(pipeline_page.st, "toggle", lambda *args, **kwargs: False)
+    monkeypatch.setattr(pipeline_page.st, "markdown", lambda *args, **kwargs: None)
+    monkeypatch.setattr(pipeline_page.st, "json", lambda *args, **kwargs: None)
+    monkeypatch.setattr(pipeline_page.st, "warning", lambda *args, **kwargs: None)
+    monkeypatch.setattr(pipeline_page, "_discover_pipeline_config_paths", lambda *_args, **_kwargs: [config_path])
+    monkeypatch.setattr(
+        pipeline_page,
+        "_load_pipeline_request",
+        lambda *_args, **_kwargs: (_load_pipeline_request_fixture(), None),
+    )
+    monkeypatch.setattr(pipeline_page, "_resolve_advio_sequence_id", lambda **kwargs: (15, None))
     monkeypatch.setattr(pipeline_page.st, "button", fake_button)
     monkeypatch.setattr(pipeline_page, "_handle_pipeline_page_action", lambda **kwargs: None)
     monkeypatch.setattr(pipeline_page, "render_live_fragment", lambda *args, **kwargs: None)
@@ -532,9 +607,17 @@ def test_pipeline_page_reruns_after_successful_start_action() -> None:
             return False
 
     rerun_calls: list[bool] = []
+    config_path = Path("/tmp/advio-offline-advio-15-vista.toml")
     context = SimpleNamespace(
+        path_config=SimpleNamespace(),
         advio_service=SimpleNamespace(
-            local_scene_statuses=lambda: [SimpleNamespace(scene=SimpleNamespace(sequence_id=15), replay_ready=True)]
+            local_scene_statuses=lambda: [
+                SimpleNamespace(
+                    replay_ready=True,
+                    scene=SimpleNamespace(sequence_id=15, sequence_slug="advio-15", display_name="advio-15"),
+                )
+            ],
+            scene=lambda sequence_id: SimpleNamespace(display_name=f"advio-{sequence_id:02d} · Mall 01"),
         ),
         run_service=FakeRunService(),
         state=AppState(),
@@ -550,14 +633,22 @@ def test_pipeline_page_reruns_after_successful_start_action() -> None:
         pipeline_page.st,
         "selectbox",
         lambda label, *args, **kwargs: {
-            "ADVIO Scene": 15,
-            "Mode": pipeline_page.PipelineMode.OFFLINE,
-            "Mock Method": MethodId.VISTA,
+            "Pipeline Config": config_path,
             "Pose Source": AdvioPoseSource.GROUND_TRUTH,
         }[label],
     )
     monkeypatch.setattr(pipeline_page.st, "columns", lambda *args, **kwargs: (DummyContext(), DummyContext()))
     monkeypatch.setattr(pipeline_page.st, "toggle", lambda *args, **kwargs: False)
+    monkeypatch.setattr(pipeline_page.st, "markdown", lambda *args, **kwargs: None)
+    monkeypatch.setattr(pipeline_page.st, "json", lambda *args, **kwargs: None)
+    monkeypatch.setattr(pipeline_page.st, "warning", lambda *args, **kwargs: None)
+    monkeypatch.setattr(pipeline_page, "_discover_pipeline_config_paths", lambda *_args, **_kwargs: [config_path])
+    monkeypatch.setattr(
+        pipeline_page,
+        "_load_pipeline_request",
+        lambda *_args, **_kwargs: (_load_pipeline_request_fixture(), None),
+    )
+    monkeypatch.setattr(pipeline_page, "_resolve_advio_sequence_id", lambda **kwargs: (15, None))
     monkeypatch.setattr(
         pipeline_page.st,
         "button",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -100,7 +100,7 @@ def test_advio_download_command_builds_explicit_request(tmp_path: Path, monkeypa
 def test_plan_run_config_command_loads_toml_request(tmp_path: Path, monkeypatch) -> None:
     runner = CliRunner()
     captured: dict[str, object] = {}
-    config_path = tmp_path / "configs" / "advio-vista.toml"
+    config_path = tmp_path / ".configs" / "pipelines" / "advio-vista.toml"
     config_path.parent.mkdir(parents=True, exist_ok=True)
     config_path.write_text(
         """
@@ -131,7 +131,7 @@ evaluate_efficiency = true
     monkeypatch.setattr(main, "get_path_config", lambda: PathConfig(root=tmp_path))
     monkeypatch.setattr(main.console, "plog", lambda payload: captured.setdefault("payload", payload))
 
-    result = runner.invoke(main.app, ["plan-run-config", "configs/advio-vista.toml"])
+    result = runner.invoke(main.app, ["plan-run-config", "advio-vista.toml"])
 
     assert result.exit_code == 0
     payload = captured["payload"]
@@ -139,6 +139,35 @@ evaluate_efficiency = true
     assert payload["run_id"] == "advio-office-offline-vista"
     assert payload["method"] == "vista"
     assert payload["source"]["video_path"] == "captures/office-03.mp4"
+
+
+def test_write_demo_config_command_persists_under_pipeline_config_dir(tmp_path: Path, monkeypatch) -> None:
+    runner = CliRunner()
+    captured: dict[str, object] = {}
+
+    class FakeService:
+        def __init__(self, path_config: PathConfig) -> None:
+            captured["path_config"] = path_config
+
+        def local_scene_statuses(self) -> list[object]:
+            return [SimpleNamespace(scene=SimpleNamespace(sequence_id=15), replay_ready=True)]
+
+        def scene(self, sequence_id: int) -> object:
+            captured["sequence_id"] = sequence_id
+            return SimpleNamespace(sequence_slug="advio-15", display_name="ADVIO 15")
+
+    monkeypatch.setattr(main, "AdvioDatasetService", FakeService)
+    monkeypatch.setattr(main, "get_path_config", lambda: PathConfig(root=tmp_path))
+    monkeypatch.setattr(main.console, "plog", lambda payload: captured.setdefault("payload", payload))
+
+    result = runner.invoke(main.app, ["write-demo-config"])
+
+    assert result.exit_code == 0
+    payload = captured["payload"]
+    assert isinstance(payload, dict)
+    config_path = Path(payload["config_path"])
+    assert config_path == (tmp_path / ".configs" / "pipelines" / "advio-offline-advio-15-vista.toml").resolve()
+    assert config_path.exists()
 
 
 def test_root_cli_defaults_to_offline_pipeline_demo(monkeypatch) -> None:

--- a/tests/test_path_config.py
+++ b/tests/test_path_config.py
@@ -17,6 +17,7 @@ def test_path_config_resolves_root_relative_defaults(tmp_path: Path) -> None:
     assert path_config.captures_dir == (tmp_path / "captures").resolve()
     assert path_config.data_dir == (tmp_path / ".data").resolve()
     assert path_config.logs_dir == (tmp_path / ".logs").resolve()
+    assert path_config.configs_dir == (tmp_path / ".configs").resolve()
     assert path_config.method_repos_dir == (tmp_path / ".logs" / "repos").resolve()
     assert path_config.method_envs_dir == (tmp_path / ".logs" / "venvs").resolve()
     assert path_config.checkpoints_dir == (tmp_path / ".logs" / "ckpts").resolve()
@@ -81,6 +82,8 @@ def test_path_config_create_flags_delegate_to_shared_directory_resolver(tmp_path
     created_dirs = [
         path_config.resolve_output_dir(".artifacts/custom", create=True),
         path_config.resolve_data_dir(create=True),
+        path_config.resolve_configs_dir(create=True),
+        path_config.resolve_pipeline_configs_dir(create=True),
         path_config.resolve_dataset_dir("advio", create=True),
         path_config.resolve_logs_dir(create=True),
         path_config.resolve_method_repo_dir("vista-slam", create=True),
@@ -96,6 +99,24 @@ def test_path_config_rejects_non_toml_config_paths(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match=".toml"):
         path_config.resolve_toml_path("configs/run-config")
+
+
+def test_path_config_routes_bare_pipeline_configs_into_repo_config_dir(tmp_path: Path) -> None:
+    path_config = PathConfig(root=tmp_path)
+
+    assert (
+        path_config.resolve_pipeline_config_path("advio-demo.toml")
+        == (tmp_path / ".configs" / "pipelines" / "advio-demo.toml").resolve()
+    )
+
+
+def test_path_config_keeps_explicit_pipeline_config_paths_root_relative(tmp_path: Path) -> None:
+    path_config = PathConfig(root=tmp_path)
+
+    assert (
+        path_config.resolve_pipeline_config_path(".configs/pipelines/custom/advio-demo.toml")
+        == (tmp_path / ".configs" / "pipelines" / "custom" / "advio-demo.toml").resolve()
+    )
 
 
 def test_path_config_is_immutable_after_construction(tmp_path: Path) -> None:


### PR DESCRIPTION
## Stack Position

1 of 4.

Base: `main`

Preferred merge order:
1. #18
2. #19
3. #20
4. #21

This order is already encoded in the PR base branches, but calling it out explicitly helps reviewers and avoids noisy diffs or avoidable merge conflicts if someone tries to merge the stack out of order.

## What changed

This PR isolates the core pipeline config workflow from the mixed feature-and-doc branch.

It introduces the repo-owned path for persisted pipeline requests and wires that flow through the CLI, app, config helpers, and tests.

### Code and workflow changes

- add a committed example pipeline config under `.configs/pipelines/`
- add repo-owned helpers for locating, loading, and saving persisted pipeline request TOMLs
- extend `PathConfig` so pipeline config paths resolve through one canonical helper instead of ad hoc path handling
- route CLI planning through the shared persisted-request loader
- update the app pipeline page state and request flow so the bounded pipeline surface can work from persisted config inputs

### Main files

- `.configs/pipelines/advio-offline-advio-15-vista.toml`
- `src/prml_vslam/main.py`
- `src/prml_vslam/pipeline/demo.py`
- `src/prml_vslam/utils/path_config.py`
- `src/prml_vslam/app/models.py`
- `src/prml_vslam/app/pages/pipeline.py`
- `tests/test_app.py`
- `tests/test_main.py`
- `tests/test_path_config.py`

### Intentionally not in scope

- the ADVIO service cleanup from #19
- the shared Record3D transport controls from #20
- the broader markdown canonicalization from #21

## Why

The branch previously mixed persisted config workflow code with a large amount of documentation work. This PR keeps the code path reviewable on its own:

- where persisted pipeline requests live
- how they are loaded and saved
- how CLI and app surfaces consume the same shape
- how the path-resolution rules are tested

## Validation

- `make ci`
