### PR TITLE
[refactor] trim advio service boilerplate

### DIFF
--- a/src/prml_vslam/app/pages/advio.py
+++ b/src/prml_vslam/app/pages/advio.py
@@ -109,7 +109,7 @@ def _render_download_form(context: AppContext) -> AdvioDownloadFormData:
     with st.form("advio_download_form", border=False):
         sequence_ids = st.multiselect(
             "Scenes",
-            options=[scene.sequence_id for scene in service.list_scenes()],
+            options=[scene.sequence_id for scene in service.catalog.scenes],
             default=page_state.selected_sequence_ids,
             format_func=lambda sequence_id: service.scene(sequence_id).display_name,
             placeholder="Leave empty to download every scene, or choose a subset",

--- a/src/prml_vslam/datasets/advio/advio_service.py
+++ b/src/prml_vslam/datasets/advio/advio_service.py
@@ -13,11 +13,8 @@ from .advio_layout import load_advio_catalog
 from .advio_models import (
     AdvioCatalog,
     AdvioDatasetSummary,
-    AdvioDownloadRequest,
-    AdvioDownloadResult,
     AdvioLocalSceneStatus,
     AdvioPoseSource,
-    AdvioSceneMetadata,
     AdvioSequenceConfig,
 )
 from .advio_sequence import AdvioOfflineSample, AdvioSequence
@@ -62,29 +59,16 @@ class AdvioStreamingSequenceSource(StreamingSequenceSource):
         )
 
 
-class AdvioDatasetService:
+class AdvioDatasetService(AdvioDownloadManager):
     """Dataset service for ADVIO catalog access, download, and replay helpers."""
 
     def __init__(self, path_config: PathConfig, *, catalog: AdvioCatalog | None = None) -> None:
-        self.path_config = path_config
-        self.catalog = load_advio_catalog() if catalog is None else catalog
-        self._download_manager = AdvioDownloadManager(
-            self.dataset_root, catalog=self.catalog, console=Console(__name__).child(self.__class__.__name__)
+        resolved_catalog = load_advio_catalog() if catalog is None else catalog
+        super().__init__(
+            path_config.resolve_dataset_dir(resolved_catalog.dataset_id),
+            catalog=resolved_catalog,
+            console=Console(__name__).child(self.__class__.__name__),
         )
-
-    @property
-    def dataset_root(self) -> Path:
-        return self.path_config.resolve_dataset_dir(self.catalog.dataset_id)
-
-    @property
-    def archive_root(self) -> Path:
-        return self._download_manager.archive_root
-
-    def list_scenes(self) -> list[AdvioSceneMetadata]:
-        return list(self.catalog.scenes)
-
-    def scene(self, sequence_id: int) -> AdvioSceneMetadata:
-        return self._download_manager.scene(sequence_id)
 
     def summarize(self, statuses: list[AdvioLocalSceneStatus] | None = None) -> AdvioDatasetSummary:
         statuses = self.local_scene_statuses() if statuses is None else statuses
@@ -97,9 +81,6 @@ class AdvioDatasetService:
             cached_archive_count=sum(status.archive_path is not None for status in statuses),
             total_remote_archive_bytes=sum(scene.archive_size_bytes for scene in self.catalog.scenes),
         )
-
-    def local_scene_statuses(self) -> list[AdvioLocalSceneStatus]:
-        return self._download_manager.local_scene_statuses()
 
     def list_local_sequence_ids(self) -> list[int]:
         return [status.scene.sequence_id for status in self.local_scene_statuses() if status.offline_ready]
@@ -140,9 +121,6 @@ class AdvioDatasetService:
             replay_mode=replay_mode,
             respect_video_rotation=respect_video_rotation,
         )
-
-    def download(self, request: AdvioDownloadRequest) -> AdvioDownloadResult:
-        return self._download_manager.download(request)
 
     def _sequence(self, sequence_id: int) -> AdvioSequence:
         return AdvioSequence(


### PR DESCRIPTION
## Stack Position

2 of 4.

Base: #18 (`feat/pipeline-config-workflow-core`)

Preferred merge order:
1. #18
2. #19
3. #20
4. #21

## What changed

This PR isolates the ADVIO service cleanup into a very small refactor on top of the pipeline config workflow branch.

### Code changes

- trim boilerplate in the ADVIO service implementation
- keep the app-facing ADVIO page callsite aligned with the slimmer service shape
- preserve behavior while reducing duplication in the service layer

### Main files

- `src/prml_vslam/datasets/advio/advio_service.py`
- `src/prml_vslam/app/pages/advio.py`

### Intentionally not in scope

- no pipeline contract changes
- no Record3D transport-control changes
- no broad documentation cleanup
- no app entrypoint packaging work

## Why

This refactor is small enough to review independently, and splitting it out keeps the later app and docs PRs from carrying unrelated ADVIO service churn.

## Validation

- `make ci`
