### PR TITLE
[feat] share Record3D transport controls

### DIFF
--- a/.agents/references/agent_reference.md
+++ b/.agents/references/agent_reference.md
@@ -32,6 +32,7 @@
 - evo plot helpers (`traj_colormap`, trajectory plotting internals): <https://github.com/MichaelGrupp/evo/blob/master/evo/tools/plot.py>
 - Nerfstudio docs: <https://docs.nerf.studio/>
 - Nerfstudio data conventions: <https://docs.nerf.studio/quickstart/data_conventions.html>
+- ViSTA-SLAM GH pages: <https://ganlinzhang.xyz/vista-slam/>
 - ViSTA-SLAM paper: <https://arxiv.org/abs/2509.01584>
 - ViSTA-SLAM repo: <https://github.com/zhangganlin/vista-slam>
 - MASt3R-SLAM paper: <https://arxiv.org/abs/2412.12392>
@@ -66,3 +67,6 @@
 - The pipeline owns one SLAM-stage config and one SLAM artifact bundle per
   backend; dense output is a capability of the SLAM stage, not a separate
   backend contract.
+- Record3D live pipeline requests should use a transport-aware typed source
+  contract instead of encoding USB or Wi-Fi details into ad hoc `source_id`
+  strings alone.

--- a/src/prml_vslam/app/models.py
+++ b/src/prml_vslam/app/models.py
@@ -10,6 +10,8 @@ from pydantic import Field
 from prml_vslam.datasets.advio import AdvioDownloadPreset, AdvioModality, AdvioPoseSource
 from prml_vslam.datasets.contracts import DatasetId
 from prml_vslam.io.record3d import Record3DTransportId
+from prml_vslam.methods import MethodId
+from prml_vslam.pipeline import PipelineMode
 from prml_vslam.utils import BaseData
 from prml_vslam.utils.packet_session import PacketSessionSnapshot
 
@@ -134,11 +136,74 @@ class Record3DPageState(BaseData):
     """Whether the current browser session expects a live stream to be active."""
 
 
+class PipelineSourceId(StrEnum):
+    """Input-source families supported by the bounded pipeline app surface."""
+
+    ADVIO = "advio"
+    RECORD3D = "record3d"
+
+    @property
+    def label(self) -> str:
+        """Return the user-facing source label."""
+        return "Record3D" if self is PipelineSourceId.RECORD3D else "ADVIO"
+
+
 class PipelinePageState(BaseData):
     """Persisted selector state for the interactive Pipeline demo."""
 
     config_path: Path | None = None
     """Selected pipeline request TOML used to instantiate the demo run."""
+
+    experiment_name: str = ""
+    """Editable experiment name for the in-app request preview."""
+
+    source_kind: PipelineSourceId = PipelineSourceId.ADVIO
+    """Selected source family for the bounded pipeline surface."""
+
+    advio_sequence_id: int | None = None
+    """Selected ADVIO sequence id when the source family is `ADVIO`."""
+
+    mode: PipelineMode = PipelineMode.OFFLINE
+    """Selected pipeline mode."""
+
+    method: MethodId = MethodId.VISTA
+    """Selected mock SLAM backend label."""
+
+    slam_max_frames: int | None = None
+    """Optional frame cap for the current request."""
+
+    slam_config_path: Path | None = None
+    """Optional backend config path for the current request."""
+
+    emit_dense_points: bool = True
+    """Whether dense geometry artifacts should be emitted."""
+
+    emit_sparse_points: bool = True
+    """Whether sparse geometry artifacts should be emitted."""
+
+    reference_enabled: bool = False
+    """Whether the reference-reconstruction stage should be planned."""
+
+    compare_to_arcore: bool = False
+    """Whether trajectory evaluation against ARCore should be planned."""
+
+    evaluate_cloud: bool = False
+    """Whether dense-cloud evaluation should be planned."""
+
+    evaluate_efficiency: bool = False
+    """Whether efficiency evaluation should be planned."""
+
+    record3d_usb_device_index: int = 0
+    """Zero-based USB device index used by the bounded pipeline page."""
+
+    record3d_transport: Record3DTransportId = Record3DTransportId.USB
+    """Selected Record3D transport used by the bounded pipeline page."""
+
+    record3d_wifi_device_address: str = "192.168.159.24"
+    """User-supplied Record3D Wi-Fi preview device address for the pipeline page."""
+
+    record3d_persist_capture: bool = True
+    """Whether live Record3D capture should be marked for persistence."""
 
     pose_source: AdvioPoseSource = AdvioPoseSource.GROUND_TRUTH
     """Selected pose source injected into the ADVIO replay packets."""
@@ -170,6 +235,7 @@ __all__ = [
     "AdvioPreviewSnapshot",
     "MetricsPageState",
     "PipelinePageState",
+    "PipelineSourceId",
     "PreviewStreamState",
     "Record3DPageState",
     "Record3DStreamSnapshot",

--- a/src/prml_vslam/app/pages/pipeline.py
+++ b/src/prml_vslam/app/pages/pipeline.py
@@ -129,8 +129,10 @@ def render(context: AppContext) -> None:
         if template_request is None:
             st.warning(template_error or "Failed to load the selected pipeline config.")
             action = _action_from_page_state(page_state, selected_config_path)
+            identity_input_error = None
+            source_input_error = _source_input_error(action)
         else:
-            action = _render_request_editor(
+            action, identity_input_error, source_input_error = _render_request_editor(
                 context=context,
                 page_state=page_state,
                 selected_config_path=selected_config_path,
@@ -146,8 +148,7 @@ def render(context: AppContext) -> None:
             plan=preview_plan,
             previewable_statuses=previewable_statuses,
         )
-        source_input_error = _source_input_error(action)
-        start_error = support_error or source_input_error
+        start_error = support_error or identity_input_error or source_input_error
 
         preview_left, preview_right = st.columns(2, gap="large")
         with preview_left:
@@ -196,7 +197,7 @@ def _render_request_editor(
     page_state: PipelinePageState,
     selected_config_path: Path,
     previewable_statuses: list[object],
-) -> PipelinePageAction:
+) -> tuple[PipelinePageAction, str | None, str | None]:
     source_options = [PipelineSourceId.ADVIO, PipelineSourceId.RECORD3D]
     source_kind = st.segmented_control(
         "Source",
@@ -208,7 +209,14 @@ def _render_request_editor(
         key="pipeline_source_selector",
     )
     resolved_source_kind = page_state.source_kind if source_kind is None else source_kind
-    experiment_name, mode, method, slam_max_frames, slam_config_path = _render_request_identity_controls(
+    (
+        experiment_name,
+        mode,
+        method,
+        slam_max_frames,
+        slam_config_path,
+        identity_input_error,
+    ) = _render_request_identity_controls(
         page_state=page_state,
         path_config=context.path_config,
         source_kind=resolved_source_kind,
@@ -221,6 +229,7 @@ def _render_request_editor(
         record3d_persist_capture,
         pose_source,
         respect_video_rotation,
+        source_input_error,
     ) = _render_source_settings(
         context=context,
         page_state=page_state,
@@ -235,30 +244,34 @@ def _render_request_editor(
         evaluate_cloud,
         evaluate_efficiency,
     ) = _render_stage_settings(page_state)
-    return PipelinePageAction.model_validate(
-        page_state.model_dump(mode="python")
-        | {
-            "config_path": selected_config_path,
-            "experiment_name": experiment_name,
-            "source_kind": resolved_source_kind,
-            "advio_sequence_id": advio_sequence_id,
-            "mode": mode,
-            "method": method,
-            "slam_max_frames": slam_max_frames,
-            "slam_config_path": slam_config_path,
-            "emit_dense_points": emit_dense_points,
-            "emit_sparse_points": emit_sparse_points,
-            "reference_enabled": reference_enabled,
-            "compare_to_arcore": compare_to_arcore,
-            "evaluate_cloud": evaluate_cloud,
-            "evaluate_efficiency": evaluate_efficiency,
-            "record3d_transport": record3d_transport,
-            "record3d_usb_device_index": record3d_usb_device_index,
-            "record3d_wifi_device_address": record3d_wifi_device_address,
-            "record3d_persist_capture": record3d_persist_capture,
-            "pose_source": pose_source,
-            "respect_video_rotation": respect_video_rotation,
-        }
+    return (
+        PipelinePageAction.model_validate(
+            page_state.model_dump(mode="python")
+            | {
+                "config_path": selected_config_path,
+                "experiment_name": experiment_name,
+                "source_kind": resolved_source_kind,
+                "advio_sequence_id": advio_sequence_id,
+                "mode": mode,
+                "method": method,
+                "slam_max_frames": slam_max_frames,
+                "slam_config_path": slam_config_path,
+                "emit_dense_points": emit_dense_points,
+                "emit_sparse_points": emit_sparse_points,
+                "reference_enabled": reference_enabled,
+                "compare_to_arcore": compare_to_arcore,
+                "evaluate_cloud": evaluate_cloud,
+                "evaluate_efficiency": evaluate_efficiency,
+                "record3d_transport": record3d_transport,
+                "record3d_usb_device_index": record3d_usb_device_index,
+                "record3d_wifi_device_address": record3d_wifi_device_address,
+                "record3d_persist_capture": record3d_persist_capture,
+                "pose_source": pose_source,
+                "respect_video_rotation": respect_video_rotation,
+            }
+        ),
+        identity_input_error,
+        source_input_error,
     )
 
 
@@ -271,7 +284,7 @@ def _render_request_identity_controls(
     page_state: PipelinePageState,
     path_config: PathConfig,
     source_kind: PipelineSourceId,
-) -> tuple[str, PipelineMode, MethodId, int | None, Path | None]:
+) -> tuple[str, PipelineMode, MethodId, int | None, Path | None, str | None]:
     left, _ = st.columns(2, gap="large")
     with left:
         experiment_name = st.text_input("Experiment Name", value=page_state.experiment_name).strip()
@@ -289,12 +302,14 @@ def _render_request_identity_controls(
             index=list(MethodId).index(page_state.method),
             format_func=lambda item: item.display_name,
         )
-        slam_max_frames = _parse_optional_int(
-            st.text_input(
-                "SLAM Max Frames",
-                value="" if page_state.slam_max_frames is None else str(page_state.slam_max_frames),
-                placeholder="blank for no limit",
-            ).strip()
+        slam_max_frames_raw = st.text_input(
+            "SLAM Max Frames",
+            value="" if page_state.slam_max_frames is None else str(page_state.slam_max_frames),
+            placeholder="blank for no limit",
+        ).strip()
+        slam_max_frames, slam_max_frames_error = _parse_optional_int(
+            raw_value=slam_max_frames_raw,
+            field_label="SLAM Max Frames",
         )
         slam_config_path = _parse_optional_repo_path(
             path_config,
@@ -304,7 +319,7 @@ def _render_request_identity_controls(
                 placeholder=".configs/methods/vista/demo.toml",
             ).strip(),
         )
-    return experiment_name, mode, method, slam_max_frames, slam_config_path
+    return experiment_name, mode, method, slam_max_frames, slam_config_path, slam_max_frames_error
 
 
 def _render_source_settings(
@@ -313,7 +328,7 @@ def _render_source_settings(
     page_state: PipelinePageState,
     source_kind: PipelineSourceId,
     previewable_statuses: list[object],
-) -> tuple[int | None, Record3DTransportId, int, str, bool, AdvioPoseSource, bool]:
+) -> tuple[int | None, Record3DTransportId, int, str, bool, AdvioPoseSource, bool, str | None]:
     _, right = st.columns(2, gap="large")
     with right:
         advio_sequence_id = page_state.advio_sequence_id
@@ -323,18 +338,21 @@ def _render_source_settings(
         record3d_persist_capture = page_state.record3d_persist_capture
         pose_source = page_state.pose_source
         respect_video_rotation = page_state.respect_video_rotation
+        source_input_error = None
         if source_kind is PipelineSourceId.ADVIO:
             advio_sequence_id, pose_source, respect_video_rotation = _render_advio_source_settings(
                 context=context,
                 page_state=page_state,
                 previewable_statuses=previewable_statuses,
             )
+            source_input_error = None if advio_sequence_id is not None else "Select a replay-ready ADVIO scene."
         else:
             (
                 record3d_transport,
                 record3d_usb_device_index,
                 record3d_wifi_device_address,
                 record3d_persist_capture,
+                source_input_error,
             ) = _render_record3d_source_settings(page_state=page_state)
     return (
         advio_sequence_id,
@@ -344,6 +362,7 @@ def _render_source_settings(
         record3d_persist_capture,
         pose_source,
         respect_video_rotation,
+        source_input_error,
     )
 
 
@@ -383,7 +402,7 @@ def _render_advio_source_settings(
 def _render_record3d_source_settings(
     *,
     page_state: PipelinePageState,
-) -> tuple[Record3DTransportId, int, str, bool]:
+) -> tuple[Record3DTransportId, int, str, bool, str | None]:
     selection = render_record3d_transport_controls(
         transport=page_state.record3d_transport,
         usb_device_index=page_state.record3d_usb_device_index,
@@ -400,6 +419,7 @@ def _render_record3d_source_settings(
         selection.usb_device_index,
         selection.wifi_device_address,
         record3d_persist_capture,
+        selection.input_error,
     )
 
 
@@ -846,6 +866,12 @@ def _build_streaming_source_from_action(context: AppContext, action: PipelinePag
             pose_source=action.pose_source,
             respect_video_rotation=action.respect_video_rotation,
         )
+    transport_input_error = record3d_transport_input_error(
+        transport=action.record3d_transport,
+        wifi_device_address=action.record3d_wifi_device_address,
+    )
+    if transport_input_error is not None:
+        raise ValueError(transport_input_error)
     record3d_source = _record3d_source_spec_from_action(action)
     source = Record3DStreamingSourceConfig(
         transport=record3d_source.transport,
@@ -875,8 +901,13 @@ def _resolve_advio_sequence_id(*, sequence_slug: str, statuses: list[object]) ->
     return sequence_id, None
 
 
-def _parse_optional_int(raw_value: str) -> int | None:
-    return None if raw_value == "" else int(raw_value)
+def _parse_optional_int(*, raw_value: str, field_label: str) -> tuple[int | None, str | None]:
+    if raw_value == "":
+        return None, None
+    try:
+        return int(raw_value), None
+    except ValueError:
+        return None, f"Enter a whole number for `{field_label}` or leave the field blank."
 
 
 def _parse_optional_repo_path(path_config: PathConfig, raw_value: str) -> Path | None:

--- a/src/prml_vslam/app/pages/pipeline.py
+++ b/src/prml_vslam/app/pages/pipeline.py
@@ -15,9 +15,19 @@ from evo.core import sync as evo_sync
 from prml_vslam.datasets.advio import AdvioPoseSource
 from prml_vslam.datasets.contracts import DatasetId
 from prml_vslam.eval.contracts import ErrorSeries, MetricStats, TrajectorySeries
-from prml_vslam.pipeline import RunRequest
+from prml_vslam.io.record3d import Record3DTransportId
+from prml_vslam.io.record3d_source import Record3DStreamingSourceConfig
+from prml_vslam.methods import MethodId
+from prml_vslam.pipeline import PipelineMode, RunRequest
 from prml_vslam.pipeline.contracts import (
+    BenchmarkEvaluationConfig,
     DatasetSourceSpec,
+    LiveSourceSpec,
+    Record3DLiveSourceSpec,
+    ReferenceConfig,
+    RunPlan,
+    RunPlanStageId,
+    SlamConfig,
     StageManifest,
 )
 from prml_vslam.pipeline.demo import load_run_request_toml
@@ -37,6 +47,12 @@ from ..live_session import (
     render_live_trajectory,
     rerun_after_action,
 )
+from ..models import PipelinePageState, PipelineSourceId
+from ..record3d_controls import (
+    record3d_transport_input_error,
+    render_record3d_transport_controls,
+    render_record3d_transport_details,
+)
 from ..state import save_model_updates
 from ..ui import render_page_intro
 
@@ -46,19 +62,11 @@ if TYPE_CHECKING:
 
 _ACTIVE_SESSION_STATES = frozenset({PipelineSessionState.CONNECTING, PipelineSessionState.RUNNING})
 _EVO_ASSOCIATION_MAX_DIFF_S = 0.01
+_SUPPORTED_APP_STAGE_IDS = frozenset({RunPlanStageId.INGEST, RunPlanStageId.SLAM, RunPlanStageId.SUMMARY})
 
 
-class PipelinePageAction(BaseData):
+class PipelinePageAction(PipelinePageState):
     """Typed action payload for the pipeline page controls."""
-
-    config_path: Path
-    """Selected pipeline request TOML."""
-
-    pose_source: AdvioPoseSource
-    """Selected pose source for the ADVIO replay stream."""
-
-    respect_video_rotation: bool = False
-    """Whether the replay should honor video rotation metadata."""
 
     start_requested: bool = False
     """Whether the user requested a new run."""
@@ -82,8 +90,8 @@ def render(context: AppContext) -> None:
         eyebrow="Streaming Surface",
         title="Pipeline Demo",
         body=(
-            "Run the bounded ADVIO replay demo through the repository-local mock SLAM backend "
-            "and monitor frames, trajectory, planned stages, and written artifacts."
+            "Select a persisted pipeline request template, edit the bounded in-app source and stage settings, "
+            "then run the current mock pipeline slice and inspect frames, trajectory, plans, and artifacts."
         ),
     )
     statuses = context.advio_service.local_scene_statuses()
@@ -91,15 +99,11 @@ def render(context: AppContext) -> None:
     snapshot = context.run_service.snapshot()
     is_active = snapshot.state in _ACTIVE_SESSION_STATES
     with st.container(border=True):
-        st.subheader("ADVIO Replay Demo")
+        st.subheader("Pipeline Request Editor")
         st.caption(
-            "Select a persisted ADVIO pipeline request TOML and run it as a bounded offline or looped streaming session."
+            "Use a TOML request as the starting template, then configure the bounded app-supported source and stage "
+            "settings before launching the current demo slice."
         )
-        if not previewable_statuses:
-            st.info(
-                "Download the ADVIO streaming bundle for at least one scene to unlock the interactive pipeline demo."
-            )
-            return
         config_paths = _discover_pipeline_config_paths(context.path_config)
         if not config_paths:
             st.info("Persist at least one pipeline request TOML under `.configs/pipelines/` to unlock this demo.")
@@ -112,43 +116,62 @@ def render(context: AppContext) -> None:
             index=config_paths.index(selected_config_path),
             format_func=lambda config_path: _pipeline_config_label(context.path_config, config_path),
         )
-        request, request_error = _load_pipeline_request(context.path_config, selected_config_path)
-        sequence_id, request_support_error = _resolve_advio_sequence_id(request=request, statuses=statuses)
-        left, right = st.columns(2, gap="large")
-        with left:
+        template_request, template_error = _load_pipeline_request(context.path_config, selected_config_path)
+        if template_request is not None:
+            _sync_pipeline_page_state_from_template(
+                context=context,
+                config_path=selected_config_path,
+                request=template_request,
+                statuses=statuses,
+            )
+            page_state = context.state.pipeline
+
+        if template_request is None:
+            st.warning(template_error or "Failed to load the selected pipeline config.")
+            action = _action_from_page_state(page_state, selected_config_path)
+        else:
+            action = _render_request_editor(
+                context=context,
+                page_state=page_state,
+                selected_config_path=selected_config_path,
+                previewable_statuses=previewable_statuses,
+            )
+
+        preview_request, preview_error = _build_request_from_action(context, action)
+        preview_plan, preview_plan_error = (
+            (None, None) if preview_request is None else _build_preview_plan(preview_request, context.path_config)
+        )
+        support_error = _request_support_error(
+            request=preview_request,
+            plan=preview_plan,
+            previewable_statuses=previewable_statuses,
+        )
+        source_input_error = _source_input_error(action)
+        start_error = support_error or source_input_error
+
+        preview_left, preview_right = st.columns(2, gap="large")
+        with preview_left:
             st.markdown("**Resolved Request**")
-            if request is None:
-                st.warning(request_error or "Failed to load the selected pipeline config.")
+            if preview_request is None:
+                st.warning(preview_error or "The current request is invalid.")
             else:
-                st.json(_request_summary_payload(request), expanded=False)
-        with right:
-            pose_source = st.selectbox(
-                "Pose Source",
-                options=list(AdvioPoseSource),
-                index=list(AdvioPoseSource).index(page_state.pose_source),
-                format_func=lambda item: item.label,
-            )
-            respect_video_rotation = st.toggle(
-                "Respect video rotation metadata",
-                value=page_state.respect_video_rotation,
-            )
-            if request_support_error is None and request is not None and sequence_id is not None:
-                st.caption(f"Resolved demo sequence: `{context.advio_service.scene(sequence_id).display_name}`")
-            elif request_support_error is not None:
-                st.warning(request_support_error)
+                st.json(_request_summary_payload(preview_request), expanded=False)
+        with preview_right:
+            st.markdown("**Planned Stages**")
+            if preview_plan is None:
+                st.warning(preview_plan_error or "The current request could not be planned.")
+            else:
+                st.dataframe(preview_plan.stage_rows(), hide_index=True, width="stretch")
+            if start_error is not None:
+                st.warning(start_error)
         start_requested, stop_requested = render_live_action_slot(
             is_active=is_active,
             start_label="Start run",
             stop_label="Stop run",
-            start_disabled=request is None or request_support_error is not None,
+            start_disabled=preview_request is None or start_error is not None,
         )
-        action = PipelinePageAction(
-            config_path=selected_config_path,
-            pose_source=pose_source,
-            respect_video_rotation=respect_video_rotation,
-            start_requested=start_requested,
-            stop_requested=stop_requested,
-        )
+        action.start_requested = start_requested
+        action.stop_requested = stop_requested
         error_message = _handle_pipeline_page_action(
             context=context,
             action=action,
@@ -167,6 +190,243 @@ def render(context: AppContext) -> None:
         )
 
 
+def _render_request_editor(
+    *,
+    context: AppContext,
+    page_state: PipelinePageState,
+    selected_config_path: Path,
+    previewable_statuses: list[object],
+) -> PipelinePageAction:
+    source_options = [PipelineSourceId.ADVIO, PipelineSourceId.RECORD3D]
+    source_kind = st.segmented_control(
+        "Source",
+        options=source_options,
+        default=page_state.source_kind,
+        format_func=lambda item: item.label,
+        selection_mode="single",
+        width="stretch",
+        key="pipeline_source_selector",
+    )
+    resolved_source_kind = page_state.source_kind if source_kind is None else source_kind
+    experiment_name, mode, method, slam_max_frames, slam_config_path = _render_request_identity_controls(
+        page_state=page_state,
+        path_config=context.path_config,
+        source_kind=resolved_source_kind,
+    )
+    (
+        advio_sequence_id,
+        record3d_transport,
+        record3d_usb_device_index,
+        record3d_wifi_device_address,
+        record3d_persist_capture,
+        pose_source,
+        respect_video_rotation,
+    ) = _render_source_settings(
+        context=context,
+        page_state=page_state,
+        source_kind=resolved_source_kind,
+        previewable_statuses=previewable_statuses,
+    )
+    (
+        emit_sparse_points,
+        emit_dense_points,
+        reference_enabled,
+        compare_to_arcore,
+        evaluate_cloud,
+        evaluate_efficiency,
+    ) = _render_stage_settings(page_state)
+    return PipelinePageAction.model_validate(
+        page_state.model_dump(mode="python")
+        | {
+            "config_path": selected_config_path,
+            "experiment_name": experiment_name,
+            "source_kind": resolved_source_kind,
+            "advio_sequence_id": advio_sequence_id,
+            "mode": mode,
+            "method": method,
+            "slam_max_frames": slam_max_frames,
+            "slam_config_path": slam_config_path,
+            "emit_dense_points": emit_dense_points,
+            "emit_sparse_points": emit_sparse_points,
+            "reference_enabled": reference_enabled,
+            "compare_to_arcore": compare_to_arcore,
+            "evaluate_cloud": evaluate_cloud,
+            "evaluate_efficiency": evaluate_efficiency,
+            "record3d_transport": record3d_transport,
+            "record3d_usb_device_index": record3d_usb_device_index,
+            "record3d_wifi_device_address": record3d_wifi_device_address,
+            "record3d_persist_capture": record3d_persist_capture,
+            "pose_source": pose_source,
+            "respect_video_rotation": respect_video_rotation,
+        }
+    )
+
+
+def _action_from_page_state(page_state: PipelinePageState, config_path: Path) -> PipelinePageAction:
+    return PipelinePageAction.model_validate(page_state.model_dump(mode="python") | {"config_path": config_path})
+
+
+def _render_request_identity_controls(
+    *,
+    page_state: PipelinePageState,
+    path_config: PathConfig,
+    source_kind: PipelineSourceId,
+) -> tuple[str, PipelineMode, MethodId, int | None, Path | None]:
+    left, _ = st.columns(2, gap="large")
+    with left:
+        experiment_name = st.text_input("Experiment Name", value=page_state.experiment_name).strip()
+        mode_options = [PipelineMode.STREAMING] if source_kind is PipelineSourceId.RECORD3D else list(PipelineMode)
+        default_mode = page_state.mode if page_state.mode in mode_options else mode_options[0]
+        mode = st.selectbox(
+            "Mode",
+            options=mode_options,
+            index=mode_options.index(default_mode),
+            format_func=lambda item: item.label,
+        )
+        method = st.selectbox(
+            "Mock Method",
+            options=list(MethodId),
+            index=list(MethodId).index(page_state.method),
+            format_func=lambda item: item.display_name,
+        )
+        slam_max_frames = _parse_optional_int(
+            st.text_input(
+                "SLAM Max Frames",
+                value="" if page_state.slam_max_frames is None else str(page_state.slam_max_frames),
+                placeholder="blank for no limit",
+            ).strip()
+        )
+        slam_config_path = _parse_optional_repo_path(
+            path_config,
+            st.text_input(
+                "SLAM Config Path",
+                value=_display_repo_relative_path(path_config, page_state.slam_config_path),
+                placeholder=".configs/methods/vista/demo.toml",
+            ).strip(),
+        )
+    return experiment_name, mode, method, slam_max_frames, slam_config_path
+
+
+def _render_source_settings(
+    *,
+    context: AppContext,
+    page_state: PipelinePageState,
+    source_kind: PipelineSourceId,
+    previewable_statuses: list[object],
+) -> tuple[int | None, Record3DTransportId, int, str, bool, AdvioPoseSource, bool]:
+    _, right = st.columns(2, gap="large")
+    with right:
+        advio_sequence_id = page_state.advio_sequence_id
+        record3d_transport = page_state.record3d_transport
+        record3d_usb_device_index = page_state.record3d_usb_device_index
+        record3d_wifi_device_address = page_state.record3d_wifi_device_address
+        record3d_persist_capture = page_state.record3d_persist_capture
+        pose_source = page_state.pose_source
+        respect_video_rotation = page_state.respect_video_rotation
+        if source_kind is PipelineSourceId.ADVIO:
+            advio_sequence_id, pose_source, respect_video_rotation = _render_advio_source_settings(
+                context=context,
+                page_state=page_state,
+                previewable_statuses=previewable_statuses,
+            )
+        else:
+            (
+                record3d_transport,
+                record3d_usb_device_index,
+                record3d_wifi_device_address,
+                record3d_persist_capture,
+            ) = _render_record3d_source_settings(page_state=page_state)
+    return (
+        advio_sequence_id,
+        record3d_transport,
+        record3d_usb_device_index,
+        record3d_wifi_device_address,
+        record3d_persist_capture,
+        pose_source,
+        respect_video_rotation,
+    )
+
+
+def _render_advio_source_settings(
+    *,
+    context: AppContext,
+    page_state: PipelinePageState,
+    previewable_statuses: list[object],
+) -> tuple[int | None, AdvioPoseSource, bool]:
+    previewable_ids = [status.scene.sequence_id for status in previewable_statuses]
+    if previewable_ids:
+        selected_advio_sequence = (
+            page_state.advio_sequence_id if page_state.advio_sequence_id in previewable_ids else previewable_ids[0]
+        )
+        advio_sequence_id = st.selectbox(
+            "ADVIO Scene",
+            options=previewable_ids,
+            index=previewable_ids.index(selected_advio_sequence),
+            format_func=lambda sequence_id: context.advio_service.scene(sequence_id).display_name,
+        )
+    else:
+        advio_sequence_id = None
+        st.info("No replay-ready ADVIO scenes are available.")
+    pose_source = st.selectbox(
+        "Pose Source",
+        options=list(AdvioPoseSource),
+        index=list(AdvioPoseSource).index(page_state.pose_source),
+        format_func=lambda item: item.label,
+    )
+    respect_video_rotation = st.toggle(
+        "Respect video rotation metadata",
+        value=page_state.respect_video_rotation,
+    )
+    return advio_sequence_id, pose_source, respect_video_rotation
+
+
+def _render_record3d_source_settings(
+    *,
+    page_state: PipelinePageState,
+) -> tuple[Record3DTransportId, int, str, bool]:
+    selection = render_record3d_transport_controls(
+        transport=page_state.record3d_transport,
+        usb_device_index=page_state.record3d_usb_device_index,
+        wifi_device_address=page_state.record3d_wifi_device_address,
+        widget_key_prefix="pipeline_record3d",
+    )
+    record3d_persist_capture = st.toggle(
+        "Persist live capture for downstream offline use",
+        value=page_state.record3d_persist_capture,
+    )
+    render_record3d_transport_details(selection)
+    return (
+        selection.transport,
+        selection.usb_device_index,
+        selection.wifi_device_address,
+        record3d_persist_capture,
+    )
+
+
+def _render_stage_settings(
+    page_state: PipelinePageState,
+) -> tuple[bool, bool, bool, bool, bool, bool]:
+    stage_left, stage_right = st.columns(2, gap="large")
+    with stage_left:
+        st.markdown("**SLAM Stage**")
+        emit_sparse_points = st.toggle("Emit sparse geometry", value=page_state.emit_sparse_points)
+        emit_dense_points = st.toggle("Emit dense geometry", value=page_state.emit_dense_points)
+        reference_enabled = st.toggle("Plan reference reconstruction", value=page_state.reference_enabled)
+    with stage_right:
+        st.markdown("**Evaluation Stages**")
+        compare_to_arcore = st.toggle("Plan trajectory evaluation", value=page_state.compare_to_arcore)
+        evaluate_cloud = st.toggle("Plan dense-cloud evaluation", value=page_state.evaluate_cloud)
+        evaluate_efficiency = st.toggle("Plan efficiency evaluation", value=page_state.evaluate_efficiency)
+    return (
+        emit_sparse_points,
+        emit_dense_points,
+        reference_enabled,
+        compare_to_arcore,
+        evaluate_cloud,
+        evaluate_efficiency,
+    )
+
+
 def _render_pipeline_snapshot(snapshot: PipelineSessionSnapshot) -> None:
     render_live_session_shell(
         title=None,
@@ -174,6 +434,157 @@ def _render_pipeline_snapshot(snapshot: PipelineSessionSnapshot) -> None:
         metrics=_pipeline_metrics(snapshot),
         caption=_pipeline_caption(snapshot),
         body_renderer=lambda: _render_pipeline_tabs(snapshot),
+    )
+
+
+def _sync_pipeline_page_state_from_template(
+    *,
+    context: AppContext,
+    config_path: Path,
+    request: RunRequest,
+    statuses: list[object],
+) -> None:
+    page_state = context.state.pipeline
+    if page_state.config_path == config_path:
+        return
+    source_updates: dict[str, object] = {
+        "source_kind": page_state.source_kind,
+        "advio_sequence_id": page_state.advio_sequence_id,
+    }
+    match request.source:
+        case DatasetSourceSpec(dataset_id=DatasetId.ADVIO, sequence_id=sequence_slug):
+            advio_sequence_id, _ = _resolve_advio_sequence_id(sequence_slug=sequence_slug, statuses=statuses)
+            source_updates = {
+                "source_kind": PipelineSourceId.ADVIO,
+                "advio_sequence_id": advio_sequence_id,
+            }
+        case Record3DLiveSourceSpec() as record3d_source:
+            source_updates = _record3d_page_updates_from_source(record3d_source)
+        case _:
+            source_updates = {"source_kind": page_state.source_kind, "advio_sequence_id": page_state.advio_sequence_id}
+    save_model_updates(
+        context.store,
+        context.state,
+        page_state,
+        config_path=config_path,
+        experiment_name=request.experiment_name,
+        mode=request.mode,
+        method=request.slam.method,
+        slam_max_frames=request.slam.max_frames,
+        slam_config_path=request.slam.config_path,
+        emit_dense_points=request.slam.emit_dense_points,
+        emit_sparse_points=request.slam.emit_sparse_points,
+        reference_enabled=request.reference.enabled,
+        compare_to_arcore=request.evaluation.compare_to_arcore,
+        evaluate_cloud=request.evaluation.evaluate_cloud,
+        evaluate_efficiency=request.evaluation.evaluate_efficiency,
+        **source_updates,
+    )
+
+
+def _record3d_source_spec_from_action(action: PipelinePageAction) -> Record3DLiveSourceSpec:
+    """Build the typed Record3D live source contract from one pipeline action."""
+    return Record3DLiveSourceSpec(
+        persist_capture=action.record3d_persist_capture,
+        transport=action.record3d_transport,
+        device_index=action.record3d_usb_device_index if action.record3d_transport is Record3DTransportId.USB else None,
+        device_address=action.record3d_wifi_device_address
+        if action.record3d_transport is Record3DTransportId.WIFI
+        else "",
+    )
+
+
+def _record3d_page_updates_from_source(source: Record3DLiveSourceSpec) -> dict[str, object]:
+    """Build pipeline page-state updates from a typed Record3D live source contract."""
+    return {
+        "source_kind": PipelineSourceId.RECORD3D,
+        "record3d_transport": source.transport,
+        "record3d_usb_device_index": 0 if source.device_index is None else source.device_index,
+        "record3d_wifi_device_address": source.device_address,
+        "record3d_persist_capture": source.persist_capture,
+    }
+
+
+def _build_request_from_action(context: AppContext, action: PipelinePageAction) -> tuple[RunRequest | None, str | None]:
+    try:
+        if action.source_kind is PipelineSourceId.ADVIO:
+            if action.advio_sequence_id is None:
+                raise ValueError("Select a replay-ready ADVIO scene.")
+            source = DatasetSourceSpec(
+                dataset_id=DatasetId.ADVIO,
+                sequence_id=context.advio_service.scene(action.advio_sequence_id).sequence_slug,
+            )
+        else:
+            source = _record3d_source_spec_from_action(action)
+        request = RunRequest(
+            experiment_name=action.experiment_name.strip() or "pipeline-demo",
+            mode=action.mode,
+            output_dir=context.path_config.artifacts_dir,
+            source=source,
+            slam=SlamConfig(
+                method=action.method,
+                max_frames=action.slam_max_frames,
+                config_path=action.slam_config_path,
+                emit_dense_points=action.emit_dense_points,
+                emit_sparse_points=action.emit_sparse_points,
+            ),
+            reference=ReferenceConfig(enabled=action.reference_enabled),
+            evaluation=BenchmarkEvaluationConfig(
+                compare_to_arcore=action.compare_to_arcore,
+                evaluate_cloud=action.evaluate_cloud,
+                evaluate_efficiency=action.evaluate_efficiency,
+            ),
+        )
+        return request, None
+    except Exception as exc:
+        return None, str(exc)
+
+
+def _build_preview_plan(request: RunRequest, path_config: PathConfig) -> tuple[RunPlan | None, str | None]:
+    try:
+        return request.build(path_config), None
+    except Exception as exc:
+        return None, str(exc)
+
+
+def _request_support_error(
+    *,
+    request: RunRequest | None,
+    plan: RunPlan | None,
+    previewable_statuses: list[object],
+) -> str | None:
+    if request is None:
+        return None
+    if plan is None:
+        return "The current request failed validation and could not be planned."
+    unsupported_stage_ids = [stage.id.value for stage in plan.stages if stage.id not in _SUPPORTED_APP_STAGE_IDS]
+    if unsupported_stage_ids:
+        return "The current app demo can execute only ingest, slam, and summary stages. Disable: " + ", ".join(
+            unsupported_stage_ids
+        )
+    match request.source:
+        case DatasetSourceSpec(dataset_id=DatasetId.ADVIO, sequence_id=sequence_slug):
+            if _resolve_advio_sequence_id(sequence_slug=sequence_slug, statuses=previewable_statuses)[0] is None:
+                return f"ADVIO sequence '{sequence_slug}' is not replay-ready in the local dataset."
+            return None
+        case Record3DLiveSourceSpec():
+            if request.mode is not PipelineMode.STREAMING:
+                return "Record3D live sources currently require `streaming` mode."
+            return None
+        case LiveSourceSpec(source_id=source_id):
+            return f"Live source '{source_id}' is not supported by this demo page."
+        case DatasetSourceSpec(dataset_id=dataset_id):
+            return f"Dataset '{dataset_id.value}' is not supported by this demo page."
+        case _:
+            return "This demo page only supports ADVIO dataset replay and Record3D live capture."
+
+
+def _source_input_error(action: PipelinePageAction) -> str | None:
+    if action.source_kind is PipelineSourceId.ADVIO:
+        return None if action.advio_sequence_id is not None else "Select a replay-ready ADVIO scene."
+    return record3d_transport_input_error(
+        transport=action.record3d_transport,
+        wifi_device_address=action.record3d_wifi_device_address,
     )
 
 
@@ -198,6 +609,15 @@ def _pipeline_caption(snapshot: PipelineSessionSnapshot) -> str | None:
 
 
 def _render_pipeline_tabs(snapshot: PipelineSessionSnapshot) -> None:
+    if _is_offline_pipeline_run(snapshot):
+        st.caption("Offline runs skip the live replay panels and focus on stage progress plus persisted outputs.")
+        tabs = st.tabs(["Plan", "Artifacts"])
+        with tabs[0]:
+            _render_pipeline_plan_tab(snapshot)
+        with tabs[1]:
+            _render_pipeline_artifacts_tab(snapshot)
+        return
+
     packet = snapshot.latest_packet
     tabs = st.tabs(["Frames", "Trajectory", "Plan", "Artifacts"])
     with tabs[0]:
@@ -278,58 +698,83 @@ def _render_pipeline_tabs(snapshot: PipelineSessionSnapshot) -> None:
                     f"Matched pairs: `{len(evo_preview.error_series.values)}` · RMSE: `{evo_preview.stats.rmse:.4f} m`"
                 )
     with tabs[2]:
-        if snapshot.plan is None:
-            st.info("Start a run to inspect the generated plan and execution records.")
-        else:
-            left, right = st.columns(2, gap="large")
-            with left:
-                st.markdown("**Planned Stages**")
-                st.dataframe(snapshot.plan.stage_rows(), hide_index=True, width="stretch")
-            with right:
-                st.markdown("**Stage Manifests**")
-                if snapshot.stage_manifests:
-                    st.dataframe(StageManifest.table_rows(snapshot.stage_manifests), hide_index=True, width="stretch")
-                else:
-                    st.info("Stage manifests will appear once the run starts writing outputs.")
+        _render_pipeline_plan_tab(snapshot)
     with tabs[3]:
-        if snapshot.sequence_manifest is None and snapshot.slam is None and snapshot.summary is None:
-            st.info("Run the demo to inspect the materialized manifest, SLAM artifacts, and run summary.")
+        _render_pipeline_artifacts_tab(snapshot)
+
+
+def _render_pipeline_plan_tab(snapshot: PipelineSessionSnapshot) -> None:
+    if snapshot.plan is None:
+        st.info("Start a run to inspect the generated plan and execution records.")
+        return
+
+    left, right = st.columns(2, gap="large")
+    with left:
+        st.markdown("**Planned Stages**")
+        st.dataframe(snapshot.plan.stage_rows(), hide_index=True, width="stretch")
+    with right:
+        st.markdown("**Stage Manifests**")
+        if snapshot.stage_manifests:
+            st.dataframe(StageManifest.table_rows(snapshot.stage_manifests), hide_index=True, width="stretch")
         else:
-            left, right = st.columns(2, gap="large")
-            with left:
-                if snapshot.sequence_manifest is not None:
-                    st.markdown("**Sequence Manifest**")
-                    st.code(
-                        json.dumps(snapshot.sequence_manifest.model_dump(mode="json"), indent=2, sort_keys=True),
-                        language="json",
-                    )
-                if snapshot.summary is not None:
-                    st.markdown("**Run Summary**")
-                    st.code(
-                        json.dumps(snapshot.summary.model_dump(mode="json"), indent=2, sort_keys=True),
-                        language="json",
-                    )
-            with right:
-                if snapshot.slam is not None:
-                    st.markdown("**SLAM Artifacts**")
-                    st.code(
-                        json.dumps(snapshot.slam.model_dump(mode="json"), indent=2, sort_keys=True),
-                        language="json",
-                    )
+            st.info("Stage manifests will appear once the run starts writing outputs.")
+
+
+def _render_pipeline_artifacts_tab(snapshot: PipelineSessionSnapshot) -> None:
+    if snapshot.sequence_manifest is None and snapshot.slam is None and snapshot.summary is None:
+        st.info("Run the demo to inspect the materialized manifest, SLAM artifacts, and run summary.")
+        return
+
+    left, right = st.columns(2, gap="large")
+    with left:
+        if snapshot.sequence_manifest is not None:
+            st.markdown("**Sequence Manifest**")
+            st.code(
+                json.dumps(snapshot.sequence_manifest.model_dump(mode="json"), indent=2, sort_keys=True),
+                language="json",
+            )
+        if snapshot.summary is not None:
+            st.markdown("**Run Summary**")
+            st.code(
+                json.dumps(snapshot.summary.model_dump(mode="json"), indent=2, sort_keys=True),
+                language="json",
+            )
+    with right:
+        if snapshot.slam is not None:
+            st.markdown("**SLAM Artifacts**")
+            st.code(
+                json.dumps(snapshot.slam.model_dump(mode="json"), indent=2, sort_keys=True),
+                language="json",
+            )
+
+
+def _is_offline_pipeline_run(snapshot: PipelineSessionSnapshot) -> bool:
+    return snapshot.plan is not None and snapshot.plan.mode is PipelineMode.OFFLINE
 
 
 def _render_pipeline_notice(snapshot: PipelineSessionSnapshot) -> None:
     match snapshot.state:
         case PipelineSessionState.IDLE:
-            st.info("Select a replay-ready ADVIO scene and start the pipeline demo.")
+            st.info(
+                "Select a request template, configure the supported source and stages, then start the pipeline demo."
+            )
         case PipelineSessionState.CONNECTING:
             st.info("Preparing the sequence manifest and starting the mock SLAM backend.")
         case PipelineSessionState.RUNNING:
-            st.success("Processing ADVIO frames through the mock SLAM backend.")
+            if _is_offline_pipeline_run(snapshot):
+                st.success("Processing the bounded offline slice and materializing artifacts.")
+            else:
+                st.success("Processing frames through the mock SLAM backend.")
         case PipelineSessionState.COMPLETED:
-            st.success("The offline demo finished and wrote mock SLAM artifacts.")
+            if _is_offline_pipeline_run(snapshot):
+                st.success("The bounded offline demo finished and wrote artifacts.")
+            else:
+                st.success("The bounded demo finished and wrote mock SLAM artifacts.")
         case PipelineSessionState.STOPPED:
-            st.warning("The demo stopped. The last frame, trajectory, and written artifacts remain visible below.")
+            if _is_offline_pipeline_run(snapshot):
+                st.warning("The offline demo stopped. The written artifacts remain visible below.")
+            else:
+                st.warning("The demo stopped. The last frame, trajectory, and written artifacts remain visible below.")
         case PipelineSessionState.FAILED:
             st.error(snapshot.error_message or "The pipeline demo failed.")
 
@@ -340,9 +785,7 @@ def _handle_pipeline_page_action(context: AppContext, action: PipelinePageAction
         context.store,
         context.state,
         context.state.pipeline,
-        config_path=action.config_path,
-        pose_source=action.pose_source,
-        respect_video_rotation=action.respect_video_rotation,
+        **action.model_dump(mode="python", exclude={"start_requested", "stop_requested"}),
     )
     try:
         if action.stop_requested:
@@ -350,37 +793,21 @@ def _handle_pipeline_page_action(context: AppContext, action: PipelinePageAction
             return None
         if not action.start_requested:
             return None
-        _start_advio_demo_run(
+        _start_pipeline_demo_run(
             context,
-            config_path=action.config_path,
-            pose_source=action.pose_source,
-            respect_video_rotation=action.respect_video_rotation,
+            action=action,
         )
         return None
     except Exception as exc:
         return str(exc)
 
 
-def _start_advio_demo_run(
-    context: AppContext,
-    *,
-    config_path: Path,
-    pose_source: AdvioPoseSource,
-    respect_video_rotation: bool,
-) -> None:
-    """Start one bounded ADVIO demo run through the shared run facade."""
-    request = load_run_request_toml(path_config=context.path_config, config_path=config_path)
-    sequence_id, sequence_error = _resolve_advio_sequence_id(
-        request=request,
-        statuses=context.advio_service.local_scene_statuses(),
-    )
-    if sequence_error is not None or sequence_id is None:
-        raise ValueError(sequence_error or "Failed to resolve an ADVIO scene for the selected pipeline config.")
-    source = context.advio_service.build_streaming_source(
-        sequence_id=sequence_id,
-        pose_source=pose_source,
-        respect_video_rotation=respect_video_rotation,
-    )
+def _start_pipeline_demo_run(context: AppContext, *, action: PipelinePageAction) -> None:
+    """Start one bounded pipeline run through the shared app facade."""
+    request, request_error = _build_request_from_action(context, action)
+    if request is None:
+        raise ValueError(request_error or "Failed to build the current request.")
+    source = _build_streaming_source_from_action(context, action)
     context.run_service.start_run(request=request, source=source)
 
 
@@ -410,27 +837,61 @@ def _load_pipeline_request(path_config: PathConfig, config_path: Path) -> tuple[
         return None, str(exc)
 
 
-def _resolve_advio_sequence_id(
-    *,
-    request: RunRequest | None,
-    statuses: list[object],
-) -> tuple[int | None, str | None]:
-    if request is None:
-        return None, None
-    match request.source:
-        case DatasetSourceSpec(dataset_id=DatasetId.ADVIO, sequence_id=sequence_slug):
-            for status in statuses:
-                scene = getattr(status, "scene", None)
-                if scene is None or getattr(scene, "sequence_slug", None) != sequence_slug:
-                    continue
-                if bool(getattr(status, "replay_ready", False)):
-                    return int(scene.sequence_id), None
-                return None, f"ADVIO sequence '{sequence_slug}' is available locally but not replay-ready."
-            return None, f"ADVIO sequence '{sequence_slug}' is not available locally."
-        case DatasetSourceSpec(dataset_id=dataset_id):
-            return None, f"Dataset '{dataset_id.value}' is not supported by this demo page."
-        case _:
-            return None, "This demo page only supports dataset-backed ADVIO pipeline configs."
+def _build_streaming_source_from_action(context: AppContext, action: PipelinePageAction):
+    if action.source_kind is PipelineSourceId.ADVIO:
+        if action.advio_sequence_id is None:
+            raise ValueError("Select a replay-ready ADVIO scene.")
+        return context.advio_service.build_streaming_source(
+            sequence_id=action.advio_sequence_id,
+            pose_source=action.pose_source,
+            respect_video_rotation=action.respect_video_rotation,
+        )
+    record3d_source = _record3d_source_spec_from_action(action)
+    source = Record3DStreamingSourceConfig(
+        transport=record3d_source.transport,
+        device_index=0 if record3d_source.device_index is None else record3d_source.device_index,
+        device_address=record3d_source.device_address,
+    ).setup_target()
+    if source is None:
+        raise RuntimeError("Failed to initialize the Record3D streaming source.")
+    return source
+
+
+def _advio_sequence_id_from_slug(sequence_slug: str, statuses: list[object]) -> int | None:
+    for status in statuses:
+        scene = getattr(status, "scene", None)
+        if scene is not None and getattr(scene, "sequence_slug", None) == sequence_slug:
+            return int(scene.sequence_id)
+    if not sequence_slug.startswith("advio-"):
+        return None
+    suffix = sequence_slug.split("-", maxsplit=1)[1]
+    return int(suffix) if suffix.isdigit() else None
+
+
+def _resolve_advio_sequence_id(*, sequence_slug: str, statuses: list[object]) -> tuple[int | None, str | None]:
+    sequence_id = _advio_sequence_id_from_slug(sequence_slug, statuses)
+    if sequence_id is None:
+        return None, f"ADVIO sequence '{sequence_slug}' is not replay-ready in the local dataset."
+    return sequence_id, None
+
+
+def _parse_optional_int(raw_value: str) -> int | None:
+    return None if raw_value == "" else int(raw_value)
+
+
+def _parse_optional_repo_path(path_config: PathConfig, raw_value: str) -> Path | None:
+    return None if raw_value == "" else path_config.resolve_repo_path(raw_value)
+
+
+def _display_repo_relative_path(path_config: PathConfig, path: Path | None) -> str:
+    if path is None:
+        return ""
+    resolved = path if path.is_absolute() else path_config.resolve_repo_path(path)
+    return (
+        str(resolved.relative_to(path_config.root))
+        if resolved.is_relative_to(path_config.root)
+        else resolved.as_posix()
+    )
 
 
 def _request_summary_payload(request: RunRequest) -> dict[str, object]:

--- a/src/prml_vslam/app/pages/record3d.py
+++ b/src/prml_vslam/app/pages/record3d.py
@@ -7,12 +7,7 @@ from typing import TYPE_CHECKING
 import streamlit as st
 
 from prml_vslam.interfaces import FramePacket
-from prml_vslam.io.record3d import (
-    Record3DDevice,
-    Record3DTransportId,
-    build_record3d_frame_details,
-    list_record3d_usb_devices,
-)
+from prml_vslam.io.record3d import build_record3d_frame_details
 from prml_vslam.utils.image_utils import normalize_grayscale_image
 
 from ..live_session import (
@@ -26,6 +21,7 @@ from ..live_session import (
 )
 from ..models import PreviewStreamState, Record3DStreamSnapshot
 from ..record3d_controller import Record3DPageAction, handle_record3d_page_action, sync_record3d_running_state
+from ..record3d_controls import render_record3d_transport_controls, render_record3d_transport_details
 from ..ui import render_page_intro
 
 if TYPE_CHECKING:
@@ -55,55 +51,23 @@ def _render_sidebar_controls(context: AppContext) -> Record3DPageAction:
     with st.sidebar:
         st.subheader("Stream Controls")
         st.caption("Choose a source, then start or restart the active stream. USB is the recommended capture path.")
-        selected_transport = st.segmented_control(
-            "Transport",
-            options=list(Record3DTransportId),
-            default=page_state.transport,
-            format_func=lambda item: item.label,
-            selection_mode="single",
-            key="record3d_transport_selector",
-            width="stretch",
+        selection = render_record3d_transport_controls(
+            transport=page_state.transport,
+            usb_device_index=page_state.usb_device_index,
+            wifi_device_address=page_state.wifi_device_address,
+            widget_key_prefix="record3d",
         )
-        transport = selected_transport or page_state.transport
-        usb_devices: list[Record3DDevice] = []
-        usb_error_message = ""
-        if transport is Record3DTransportId.USB:
-            try:
-                usb_devices = list_record3d_usb_devices()
-            except Exception as exc:
-                usb_error_message = str(exc)
-        selected_usb_index = page_state.usb_device_index
-        wifi_device_address = page_state.wifi_device_address
-        if transport is Record3DTransportId.USB:
-            selected_usb_index = _render_usb_selector(current_index=page_state.usb_device_index, devices=usb_devices)
-        else:
-            wifi_device_address = st.text_input(
-                "Wi-Fi Preview Device Address",
-                value=page_state.wifi_device_address,
-                placeholder="myiPhone.local or 192.168.1.100",
-            ).strip()
         start_requested, stop_requested = render_live_action_slot(
             is_active=page_state.is_running,
             start_label="Start stream",
             stop_label="Stop stream",
-            start_disabled=_start_disabled(
-                transport=transport,
-                usb_devices=usb_devices,
-                wifi_device_address=wifi_device_address,
-            ),
+            start_disabled=selection.input_error is not None,
         )
-        with st.expander("Transport details", expanded=bool(usb_error_message)):
-            st.write(transport.stream_hint())
-            if usb_error_message:
-                st.warning(usb_error_message)
-            elif transport is Record3DTransportId.USB and not usb_devices:
-                st.info("No USB Record3D devices are currently connected.")
-            elif transport is Record3DTransportId.WIFI:
-                st.info("Wi-Fi Preview is optional and lower fidelity than the official USB integration.")
+        render_record3d_transport_details(selection)
     return Record3DPageAction(
-        transport=transport,
-        usb_device_index=selected_usb_index,
-        wifi_device_address=wifi_device_address,
+        transport=selection.transport,
+        usb_device_index=selection.usb_device_index,
+        wifi_device_address=selection.wifi_device_address,
         start_requested=start_requested,
         stop_requested=stop_requested,
     )
@@ -114,20 +78,6 @@ def _render_live_snapshot(context: AppContext) -> None:
         run_every=live_poll_interval(is_active=context.state.record3d.is_running, interval_seconds=0.5),
         render_body=lambda: _render_snapshot(sync_record3d_running_state(context)),
     )
-
-
-def _render_usb_selector(*, current_index: int, devices: list[Record3DDevice]) -> int:
-    if not devices:
-        st.selectbox("USB Device", options=["No USB device available"], index=0, disabled=True)
-        return 0
-    selected_index = current_index if 0 <= current_index < len(devices) else 0
-    selected_device = st.selectbox(
-        "USB Device",
-        options=devices,
-        index=selected_index,
-        format_func=lambda item: f"{item.udid} ({item.product_id})",
-    )
-    return devices.index(selected_device)
 
 
 def _render_snapshot(snapshot: Record3DStreamSnapshot) -> None:
@@ -172,17 +122,6 @@ def _render_frame_preview(packet: FramePacket) -> None:
         st.info("Depth confidence is not available for this transport.")
     else:
         st.image(normalize_grayscale_image(packet.confidence), clamp=True)
-
-
-def _start_disabled(
-    *,
-    transport: Record3DTransportId,
-    usb_devices: list[Record3DDevice],
-    wifi_device_address: str,
-) -> bool:
-    return (transport is Record3DTransportId.USB and not usb_devices) or (
-        transport is Record3DTransportId.WIFI and wifi_device_address == ""
-    )
 
 
 def _render_status_notice(snapshot: Record3DStreamSnapshot) -> None:

--- a/src/prml_vslam/app/record3d_controls.py
+++ b/src/prml_vslam/app/record3d_controls.py
@@ -1,0 +1,154 @@
+"""Shared Record3D transport controls for app pages."""
+
+from __future__ import annotations
+
+import streamlit as st
+from pydantic import Field
+
+from prml_vslam.io.record3d import Record3DDevice, Record3DTransportId, list_record3d_usb_devices
+from prml_vslam.utils import BaseData
+
+
+class Record3DTransportSelection(BaseData):
+    """Resolved Record3D transport inputs for one page render."""
+
+    transport: Record3DTransportId
+    """Selected Record3D transport."""
+
+    usb_device_index: int = 0
+    """Selected USB device index when using the USB transport."""
+
+    wifi_device_address: str = ""
+    """Entered Wi-Fi preview device address."""
+
+    usb_devices: list[Record3DDevice] = Field(default_factory=list)
+    """Discovered USB devices for the current render pass."""
+
+    usb_error_message: str = ""
+    """Discovery error surfaced while checking USB devices."""
+
+    input_error: str | None = None
+    """Transport-specific input error that should disable start actions when present."""
+
+
+def render_record3d_transport_controls(
+    *,
+    transport: Record3DTransportId,
+    usb_device_index: int,
+    wifi_device_address: str,
+    widget_key_prefix: str,
+) -> Record3DTransportSelection:
+    """Render the shared Record3D transport controls and return the selection."""
+    selected_transport = st.segmented_control(
+        "Transport",
+        options=list(Record3DTransportId),
+        default=transport,
+        format_func=lambda item: item.label,
+        selection_mode="single",
+        key=f"{widget_key_prefix}_transport_selector",
+        width="stretch",
+    )
+    resolved_transport = transport if selected_transport is None else selected_transport
+    usb_devices: list[Record3DDevice] = []
+    usb_error_message = ""
+    resolved_usb_device_index = usb_device_index
+    resolved_wifi_device_address = wifi_device_address
+
+    if resolved_transport is Record3DTransportId.USB:
+        try:
+            usb_devices = list_record3d_usb_devices()
+        except Exception as exc:
+            usb_error_message = str(exc)
+        resolved_usb_device_index = _render_usb_selector(
+            current_index=usb_device_index,
+            devices=usb_devices,
+            widget_key_prefix=widget_key_prefix,
+        )
+    else:
+        resolved_wifi_device_address = st.text_input(
+            "Wi-Fi Preview Device Address",
+            value=wifi_device_address,
+            placeholder="myiPhone.local or 192.168.1.100",
+            key=f"{widget_key_prefix}_wifi_device_address",
+        ).strip()
+
+    return Record3DTransportSelection(
+        transport=resolved_transport,
+        usb_device_index=resolved_usb_device_index,
+        wifi_device_address=resolved_wifi_device_address,
+        usb_devices=usb_devices,
+        usb_error_message=usb_error_message,
+        input_error=record3d_transport_input_error(
+            transport=resolved_transport,
+            wifi_device_address=resolved_wifi_device_address,
+            usb_devices=usb_devices,
+            usb_error_message=usb_error_message,
+        ),
+    )
+
+
+def record3d_transport_input_error(
+    *,
+    transport: Record3DTransportId,
+    wifi_device_address: str,
+    usb_devices: list[Record3DDevice] | None = None,
+    usb_error_message: str = "",
+) -> str | None:
+    """Return a surfaced input error for the selected Record3D transport."""
+    if transport is Record3DTransportId.WIFI:
+        return None if wifi_device_address != "" else "Enter a Record3D Wi-Fi preview device address."
+    if usb_error_message:
+        return usb_error_message
+    if usb_devices is None:
+        try:
+            usb_devices = list_record3d_usb_devices()
+        except Exception as exc:
+            return str(exc)
+    devices = usb_devices
+    return None if devices else "No USB Record3D devices are currently connected."
+
+
+def render_record3d_transport_details(selection: Record3DTransportSelection) -> None:
+    """Render the standard transport-detail block for one Record3D selection."""
+    with st.expander("Transport details", expanded=bool(selection.usb_error_message)):
+        st.write(selection.transport.stream_hint())
+        if selection.usb_error_message:
+            st.warning(selection.usb_error_message)
+        elif selection.transport is Record3DTransportId.USB and not selection.usb_devices:
+            st.info("No USB Record3D devices are currently connected.")
+        elif selection.transport is Record3DTransportId.WIFI:
+            st.info("Wi-Fi Preview is optional and lower fidelity than the official USB integration.")
+
+
+def _render_usb_selector(
+    *,
+    current_index: int,
+    devices: list[Record3DDevice],
+    widget_key_prefix: str,
+) -> int:
+    if not devices:
+        st.selectbox(
+            "USB Device",
+            options=["No USB device available"],
+            index=0,
+            disabled=True,
+            key=f"{widget_key_prefix}_usb_device_selector",
+        )
+        return 0
+    selected_index = current_index if 0 <= current_index < len(devices) else 0
+    selected_device = st.selectbox(
+        "USB Device",
+        options=devices,
+        index=selected_index,
+        format_func=lambda item: f"{item.udid} ({item.product_id})",
+        key=f"{widget_key_prefix}_usb_device_selector",
+    )
+    return devices.index(selected_device)
+
+
+__all__ = [
+    "Record3DTransportSelection",
+    "record3d_transport_input_error",
+    "render_record3d_transport_details",
+    "render_record3d_transport_controls",
+]

--- a/src/prml_vslam/pipeline/contracts.py
+++ b/src/prml_vslam/pipeline/contracts.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from enum import StrEnum
 from pathlib import Path
+from typing import Literal
 
 import numpy as np
 from numpy.typing import NDArray
@@ -11,6 +12,7 @@ from pydantic import Field
 
 from prml_vslam.datasets.contracts import DatasetId
 from prml_vslam.interfaces import SE3Pose
+from prml_vslam.io.record3d import Record3DTransportId
 from prml_vslam.methods.contracts import MethodId
 from prml_vslam.utils import BaseConfig, BaseData, PathConfig
 
@@ -51,12 +53,31 @@ class LiveSourceSpec(BaseConfig):
     """Live source used for preview, capture, and optional persistence."""
 
     source_id: str
-    """Live source identifier such as `record3d_usb` or `record3d_wifi`."""
+    """Live source identifier such as `record3d_usb`."""
     persist_capture: bool = True
     """Whether to persist the captured session for downstream offline use."""
 
 
-SourceSpec = VideoSourceSpec | DatasetSourceSpec | LiveSourceSpec
+class Record3DLiveSourceSpec(BaseConfig):
+    """Typed Record3D live source used by the pipeline app and planner."""
+
+    source_id: Literal["record3d"] = "record3d"
+    """Stable live-source identifier for Record3D-backed runs."""
+
+    transport: Record3DTransportId = Record3DTransportId.USB
+    """Selected Record3D transport."""
+
+    persist_capture: bool = True
+    """Whether to persist the captured session for downstream offline use."""
+
+    device_index: int | None = None
+    """Selected USB device index when using the USB transport."""
+
+    device_address: str = ""
+    """Entered Wi-Fi preview device address when using the Wi-Fi transport."""
+
+
+SourceSpec = VideoSourceSpec | DatasetSourceSpec | Record3DLiveSourceSpec | LiveSourceSpec
 
 
 class SlamConfig(BaseConfig):
@@ -302,6 +323,7 @@ __all__ = [
     "DatasetSourceSpec",
     "LiveSourceSpec",
     "PipelineMode",
+    "Record3DLiveSourceSpec",
     "ReferenceConfig",
     "RunPlan",
     "RunPlanStage",

--- a/src/prml_vslam/pipeline/demo.py
+++ b/src/prml_vslam/pipeline/demo.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 from pathlib import Path
 
 from prml_vslam.datasets.contracts import DatasetId
+from prml_vslam.io.record3d import Record3DTransportId
 from prml_vslam.methods import MethodId
 from prml_vslam.pipeline import PipelineMode, RunRequest
 from prml_vslam.pipeline.contracts import (
     BenchmarkEvaluationConfig,
     DatasetSourceSpec,
+    LiveSourceSpec,
+    Record3DLiveSourceSpec,
     ReferenceConfig,
     SlamConfig,
 )
@@ -42,7 +45,8 @@ def build_advio_demo_request(
 def load_run_request_toml(*, path_config: PathConfig, config_path: str | Path) -> RunRequest:
     """Load a pipeline request TOML through the repo-owned config path helper."""
     resolved_config_path = path_config.resolve_pipeline_config_path(config_path, must_exist=True)
-    return RunRequest.from_toml(resolved_config_path)
+    request = RunRequest.from_toml(resolved_config_path)
+    return _normalize_legacy_record3d_source(request)
 
 
 def save_run_request_toml(
@@ -85,3 +89,21 @@ __all__ = [
     "persist_advio_demo_request",
     "save_run_request_toml",
 ]
+
+
+def _normalize_legacy_record3d_source(request: RunRequest) -> RunRequest:
+    """Convert legacy Record3D live-source TOML payloads into the typed source contract."""
+    match request.source:
+        case LiveSourceSpec(source_id="record3d_usb", persist_capture=persist_capture):
+            normalized_source = Record3DLiveSourceSpec(
+                transport=Record3DTransportId.USB,
+                persist_capture=persist_capture,
+            )
+        case LiveSourceSpec(source_id="record3d_wifi", persist_capture=persist_capture):
+            normalized_source = Record3DLiveSourceSpec(
+                transport=Record3DTransportId.WIFI,
+                persist_capture=persist_capture,
+            )
+        case _:
+            return request
+    return request.model_copy(update={"source": normalized_source})

--- a/src/prml_vslam/pipeline/services.py
+++ b/src/prml_vslam/pipeline/services.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+from prml_vslam.io.record3d import Record3DTransportId
 from prml_vslam.pipeline.contracts import (
     DatasetSourceSpec,
     LiveSourceSpec,
+    Record3DLiveSourceSpec,
     RunPlan,
     RunPlanStage,
     RunPlanStageId,
@@ -148,6 +150,22 @@ class RunPlannerService:
                 return f"Decode '{video_path}' at stride {frame_stride} and materialize a normalized sequence manifest."
             case DatasetSourceSpec(dataset_id=dataset_id, sequence_id=sequence_id):
                 return f"Normalize dataset sequence '{dataset_id.value}:{sequence_id}' into a shared sequence manifest."
+            case Record3DLiveSourceSpec(
+                transport=transport,
+                persist_capture=persist_capture,
+                device_index=device_index,
+                device_address=device_address,
+            ):
+                persistence = "with persistence" if persist_capture else "without persistence"
+                source_descriptor = (
+                    f"USB device #{device_index}"
+                    if transport is Record3DTransportId.USB and device_index is not None
+                    else device_address or "Wi-Fi preview"
+                )
+                return (
+                    f"Capture the Record3D {transport.label.lower()} source '{source_descriptor}' {persistence} "
+                    "into a replayable sequence manifest."
+                )
             case LiveSourceSpec(source_id=source_id, persist_capture=persist_capture):
                 persistence = "with persistence" if persist_capture else "without persistence"
                 return f"Capture the live source '{source_id}' {persistence} into a replayable sequence manifest."

--- a/src/prml_vslam/pipeline/services.py
+++ b/src/prml_vslam/pipeline/services.py
@@ -160,6 +160,8 @@ class RunPlannerService:
                 source_descriptor = (
                     f"USB device #{device_index}"
                     if transport is Record3DTransportId.USB and device_index is not None
+                    else "default USB device"
+                    if transport is Record3DTransportId.USB
                     else device_address or "Wi-Fi preview"
                 )
                 return (

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -665,6 +665,27 @@ def test_pipeline_streaming_source_supports_record3d_wifi() -> None:
     assert source.config.device_address == "myiPhone.local"
 
 
+def test_pipeline_streaming_source_requires_wifi_device_address() -> None:
+    from prml_vslam.app.pages import pipeline as pipeline_page
+
+    context = SimpleNamespace()
+
+    with pytest.raises(ValueError, match="Enter a Record3D Wi-Fi preview device address."):
+        pipeline_page._build_streaming_source_from_action(
+            context,
+            pipeline_page.PipelinePageAction(**_record3d_pipeline_action(transport=Record3DTransportId.WIFI)),
+        )
+
+
+def test_parse_optional_int_rejects_invalid_input() -> None:
+    from prml_vslam.app.pages import pipeline as pipeline_page
+
+    value, error_message = pipeline_page._parse_optional_int(raw_value="not-a-number", field_label="SLAM Max Frames")
+
+    assert value is None
+    assert error_message == "Enter a whole number for `SLAM Max Frames` or leave the field blank."
+
+
 def test_pipeline_page_state_sync_hydrates_record3d_usb_template(tmp_path: Path) -> None:
     from prml_vslam.app.pages import pipeline as pipeline_page
 
@@ -791,13 +812,17 @@ def test_pipeline_demo_controls_show_only_stop_button_while_run_is_active() -> N
     monkeypatch.setattr(
         pipeline_page,
         "_render_request_editor",
-        lambda **kwargs: pipeline_page.PipelinePageAction(
-            config_path=config_path,
-            source_kind=PipelineSourceId.ADVIO,
-            advio_sequence_id=15,
-            mode=PipelineMode.OFFLINE,
-            method=MethodId.VISTA,
-            pose_source=AdvioPoseSource.GROUND_TRUTH,
+        lambda **kwargs: (
+            pipeline_page.PipelinePageAction(
+                config_path=config_path,
+                source_kind=PipelineSourceId.ADVIO,
+                advio_sequence_id=15,
+                mode=PipelineMode.OFFLINE,
+                method=MethodId.VISTA,
+                pose_source=AdvioPoseSource.GROUND_TRUTH,
+            ),
+            None,
+            None,
         ),
     )
     monkeypatch.setattr(
@@ -866,13 +891,17 @@ def test_pipeline_page_reruns_after_successful_start_action() -> None:
     monkeypatch.setattr(
         pipeline_page,
         "_render_request_editor",
-        lambda **kwargs: pipeline_page.PipelinePageAction(
-            config_path=config_path,
-            source_kind=PipelineSourceId.ADVIO,
-            advio_sequence_id=15,
-            mode=PipelineMode.OFFLINE,
-            method=MethodId.VISTA,
-            pose_source=AdvioPoseSource.GROUND_TRUTH,
+        lambda **kwargs: (
+            pipeline_page.PipelinePageAction(
+                config_path=config_path,
+                source_kind=PipelineSourceId.ADVIO,
+                advio_sequence_id=15,
+                mode=PipelineMode.OFFLINE,
+                method=MethodId.VISTA,
+                pose_source=AdvioPoseSource.GROUND_TRUTH,
+            ),
+            None,
+            None,
         ),
     )
     monkeypatch.setattr(

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -17,6 +17,7 @@ from prml_vslam.app.models import (
     AdvioPreviewSnapshot,
     AppPageId,
     AppState,
+    PipelineSourceId,
     PreviewStreamState,
     Record3DPageState,
     Record3DStreamSnapshot,
@@ -34,6 +35,14 @@ from prml_vslam.eval.contracts import SelectionSnapshot
 from prml_vslam.interfaces import CameraIntrinsics, FramePacket, SE3Pose
 from prml_vslam.io.record3d import Record3DDevice, Record3DTransportId
 from prml_vslam.methods import MethodId
+from prml_vslam.pipeline import PipelineMode, RunRequest
+from prml_vslam.pipeline.contracts import (
+    BenchmarkEvaluationConfig,
+    DatasetSourceSpec,
+    Record3DLiveSourceSpec,
+    ReferenceConfig,
+    SlamConfig,
+)
 from prml_vslam.pipeline.run_service import RunService
 from prml_vslam.pipeline.session import PipelineSessionSnapshot, PipelineSessionState
 from prml_vslam.utils.path_config import PathConfig
@@ -99,26 +108,70 @@ evaluate_efficiency = false
     return config_path
 
 
-def _load_pipeline_request_fixture() -> SimpleNamespace:
-    return SimpleNamespace(
+def _load_pipeline_request_fixture() -> RunRequest:
+    return RunRequest(
         experiment_name="advio-offline-advio-15-vista",
-        mode=SimpleNamespace(value="offline"),
+        mode=PipelineMode.OFFLINE,
         output_dir=Path(".artifacts"),
-        source=SimpleNamespace(model_dump=lambda mode="json": {"dataset_id": "advio", "sequence_id": "advio-15"}),
-        slam=SimpleNamespace(
-            method=SimpleNamespace(value="vista"),
+        source=DatasetSourceSpec(dataset_id=DatasetId.ADVIO, sequence_id="advio-15"),
+        slam=SlamConfig(
+            method=MethodId.VISTA,
             config_path=None,
             max_frames=None,
             emit_dense_points=True,
             emit_sparse_points=True,
         ),
-        reference=SimpleNamespace(model_dump=lambda mode="json": {"enabled": False}),
-        evaluation=SimpleNamespace(
-            model_dump=lambda mode="json": {
-                "compare_to_arcore": False,
-                "evaluate_cloud": False,
-                "evaluate_efficiency": False,
-            }
+        reference=ReferenceConfig(enabled=False),
+        evaluation=BenchmarkEvaluationConfig(
+            compare_to_arcore=False,
+            evaluate_cloud=False,
+            evaluate_efficiency=False,
+        ),
+    )
+
+
+def _record3d_pipeline_action(
+    *,
+    transport: Record3DTransportId,
+    persist_capture: bool = True,
+    usb_device_index: int = 0,
+    wifi_device_address: str = "",
+) -> dict[str, object]:
+    return {
+        "source_kind": PipelineSourceId.RECORD3D,
+        "record3d_transport": transport,
+        "record3d_usb_device_index": usb_device_index,
+        "record3d_wifi_device_address": wifi_device_address,
+        "record3d_persist_capture": persist_capture,
+        "mode": PipelineMode.STREAMING,
+        "method": MethodId.VISTA,
+    }
+
+
+def _record3d_pipeline_request(
+    *,
+    transport: Record3DTransportId,
+    output_dir: Path,
+    persist_capture: bool = True,
+    device_index: int | None = None,
+    device_address: str = "",
+) -> RunRequest:
+    return RunRequest(
+        experiment_name=f"record3d-{transport.value}-demo",
+        mode=PipelineMode.STREAMING,
+        output_dir=output_dir,
+        source=Record3DLiveSourceSpec(
+            transport=transport,
+            persist_capture=persist_capture,
+            device_index=device_index,
+            device_address=device_address,
+        ),
+        slam=SlamConfig(method=MethodId.VISTA),
+        reference=ReferenceConfig(enabled=False),
+        evaluation=BenchmarkEvaluationConfig(
+            compare_to_arcore=False,
+            evaluate_cloud=False,
+            evaluate_efficiency=False,
         ),
     )
 
@@ -512,6 +565,10 @@ def test_pipeline_page_action_starts_pipeline_session_once_from_selected_toml(tm
         context,
         pipeline_page.PipelinePageAction(
             config_path=config_path,
+            source_kind=PipelineSourceId.ADVIO,
+            advio_sequence_id=15,
+            mode=PipelineMode.OFFLINE,
+            method=MethodId.VISTA,
             pose_source=AdvioPoseSource.GROUND_TRUTH,
             respect_video_rotation=True,
             start_requested=True,
@@ -529,6 +586,158 @@ def test_pipeline_page_action_starts_pipeline_session_once_from_selected_toml(tm
     assert request.evaluation.compare_to_arcore is False
     assert request.evaluation.evaluate_cloud is False
     assert request.evaluation.evaluate_efficiency is False
+
+
+def test_pipeline_request_builds_record3d_usb_source_from_action(tmp_path: Path) -> None:
+    from prml_vslam.app.pages import pipeline as pipeline_page
+
+    context = SimpleNamespace(path_config=PathConfig(root=tmp_path, artifacts_dir=tmp_path / ".artifacts"))
+
+    request, error_message = pipeline_page._build_request_from_action(
+        context,
+        pipeline_page.PipelinePageAction(
+            **_record3d_pipeline_action(
+                transport=Record3DTransportId.USB,
+                usb_device_index=2,
+                persist_capture=False,
+            )
+        ),
+    )
+
+    assert error_message is None
+    assert request is not None
+    assert isinstance(request.source, Record3DLiveSourceSpec)
+    assert request.source.transport is Record3DTransportId.USB
+    assert request.source.device_index == 2
+    assert request.source.device_address == ""
+    assert request.source.persist_capture is False
+
+
+def test_pipeline_request_builds_record3d_wifi_source_from_action(tmp_path: Path) -> None:
+    from prml_vslam.app.pages import pipeline as pipeline_page
+
+    context = SimpleNamespace(path_config=PathConfig(root=tmp_path, artifacts_dir=tmp_path / ".artifacts"))
+
+    request, error_message = pipeline_page._build_request_from_action(
+        context,
+        pipeline_page.PipelinePageAction(
+            **_record3d_pipeline_action(
+                transport=Record3DTransportId.WIFI,
+                wifi_device_address="myiPhone.local",
+            )
+        ),
+    )
+
+    assert error_message is None
+    assert request is not None
+    assert isinstance(request.source, Record3DLiveSourceSpec)
+    assert request.source.transport is Record3DTransportId.WIFI
+    assert request.source.device_index is None
+    assert request.source.device_address == "myiPhone.local"
+    assert request.source.persist_capture is True
+
+
+def test_pipeline_source_input_error_requires_wifi_device_address() -> None:
+    from prml_vslam.app.pages import pipeline as pipeline_page
+
+    error_message = pipeline_page._source_input_error(
+        pipeline_page.PipelinePageAction(**_record3d_pipeline_action(transport=Record3DTransportId.WIFI))
+    )
+
+    assert error_message == "Enter a Record3D Wi-Fi preview device address."
+
+
+def test_pipeline_streaming_source_supports_record3d_wifi() -> None:
+    from prml_vslam.app.pages import pipeline as pipeline_page
+
+    context = SimpleNamespace()
+    source = pipeline_page._build_streaming_source_from_action(
+        context,
+        pipeline_page.PipelinePageAction(
+            **_record3d_pipeline_action(
+                transport=Record3DTransportId.WIFI,
+                wifi_device_address="myiPhone.local",
+            )
+        ),
+    )
+
+    assert source.config.transport is Record3DTransportId.WIFI
+    assert source.config.device_address == "myiPhone.local"
+
+
+def test_pipeline_page_state_sync_hydrates_record3d_usb_template(tmp_path: Path) -> None:
+    from prml_vslam.app.pages import pipeline as pipeline_page
+
+    context = SimpleNamespace(
+        state=AppState(),
+        store=FakeStore(),
+    )
+    path_config = PathConfig(root=tmp_path, artifacts_dir=tmp_path / ".artifacts")
+    request = _record3d_pipeline_request(
+        transport=Record3DTransportId.USB,
+        output_dir=path_config.artifacts_dir,
+        persist_capture=False,
+        device_index=3,
+    )
+
+    pipeline_page._sync_pipeline_page_state_from_template(
+        context=context,
+        config_path=tmp_path / "record3d-usb.toml",
+        request=request,
+        statuses=[],
+    )
+
+    assert context.state.pipeline.source_kind is PipelineSourceId.RECORD3D
+    assert context.state.pipeline.record3d_transport is Record3DTransportId.USB
+    assert context.state.pipeline.record3d_usb_device_index == 3
+    assert context.state.pipeline.record3d_persist_capture is False
+
+
+def test_pipeline_page_state_sync_hydrates_record3d_wifi_template(tmp_path: Path) -> None:
+    from prml_vslam.app.pages import pipeline as pipeline_page
+
+    context = SimpleNamespace(
+        state=AppState(),
+        store=FakeStore(),
+    )
+    path_config = PathConfig(root=tmp_path, artifacts_dir=tmp_path / ".artifacts")
+    request = _record3d_pipeline_request(
+        transport=Record3DTransportId.WIFI,
+        output_dir=path_config.artifacts_dir,
+        device_address="myiPhone.local",
+    )
+
+    pipeline_page._sync_pipeline_page_state_from_template(
+        context=context,
+        config_path=tmp_path / "record3d-wifi.toml",
+        request=request,
+        statuses=[],
+    )
+
+    assert context.state.pipeline.source_kind is PipelineSourceId.RECORD3D
+    assert context.state.pipeline.record3d_transport is Record3DTransportId.WIFI
+    assert context.state.pipeline.record3d_wifi_device_address == "myiPhone.local"
+    assert context.state.pipeline.record3d_persist_capture is True
+
+
+def test_load_pipeline_request_toml_parses_record3d_wifi_source(tmp_path: Path) -> None:
+    from prml_vslam.pipeline.demo import load_run_request_toml
+
+    path_config = PathConfig(root=tmp_path, artifacts_dir=tmp_path / ".artifacts")
+    config_path = _write_pipeline_config(
+        path_config,
+        name="record3d-wifi.toml",
+        source_block=(
+            'source_id = "record3d"\ntransport = "wifi"\npersist_capture = false\ndevice_address = "myiPhone.local"'
+        ),
+    )
+
+    request = load_run_request_toml(path_config=path_config, config_path=config_path)
+
+    assert isinstance(request.source, Record3DLiveSourceSpec)
+    assert request.source.transport is Record3DTransportId.WIFI
+    assert request.source.persist_capture is False
+    assert request.source.device_address == "myiPhone.local"
 
 
 def test_pipeline_demo_controls_show_only_stop_button_while_run_is_active() -> None:
@@ -558,12 +767,6 @@ def test_pipeline_demo_controls_show_only_stop_button_while_run_is_active() -> N
         store=FakeStore(),
     )
 
-    def fake_selectbox(label: str, *args, **kwargs):
-        return {
-            "Pipeline Config": config_path,
-            "Pose Source": AdvioPoseSource.GROUND_TRUTH,
-        }[label]
-
     def fake_button(label: str, *args, **kwargs) -> bool:
         seen_labels.append(label)
         return False
@@ -573,19 +776,38 @@ def test_pipeline_demo_controls_show_only_stop_button_while_run_is_active() -> N
     monkeypatch.setattr(pipeline_page.st, "container", lambda *args, **kwargs: DummyContext())
     monkeypatch.setattr(pipeline_page.st, "subheader", lambda *args, **kwargs: None)
     monkeypatch.setattr(pipeline_page.st, "caption", lambda *args, **kwargs: None)
-    monkeypatch.setattr(pipeline_page.st, "selectbox", fake_selectbox)
+    monkeypatch.setattr(pipeline_page.st, "selectbox", lambda *args, **kwargs: config_path)
     monkeypatch.setattr(pipeline_page.st, "columns", lambda *args, **kwargs: (DummyContext(), DummyContext()))
-    monkeypatch.setattr(pipeline_page.st, "toggle", lambda *args, **kwargs: False)
     monkeypatch.setattr(pipeline_page.st, "markdown", lambda *args, **kwargs: None)
     monkeypatch.setattr(pipeline_page.st, "json", lambda *args, **kwargs: None)
     monkeypatch.setattr(pipeline_page.st, "warning", lambda *args, **kwargs: None)
+    monkeypatch.setattr(pipeline_page.st, "dataframe", lambda *args, **kwargs: None)
     monkeypatch.setattr(pipeline_page, "_discover_pipeline_config_paths", lambda *_args, **_kwargs: [config_path])
     monkeypatch.setattr(
         pipeline_page,
         "_load_pipeline_request",
         lambda *_args, **_kwargs: (_load_pipeline_request_fixture(), None),
     )
-    monkeypatch.setattr(pipeline_page, "_resolve_advio_sequence_id", lambda **kwargs: (15, None))
+    monkeypatch.setattr(
+        pipeline_page,
+        "_render_request_editor",
+        lambda **kwargs: pipeline_page.PipelinePageAction(
+            config_path=config_path,
+            source_kind=PipelineSourceId.ADVIO,
+            advio_sequence_id=15,
+            mode=PipelineMode.OFFLINE,
+            method=MethodId.VISTA,
+            pose_source=AdvioPoseSource.GROUND_TRUTH,
+        ),
+    )
+    monkeypatch.setattr(
+        pipeline_page, "_build_request_from_action", lambda *_args, **_kwargs: (_load_pipeline_request_fixture(), None)
+    )
+    monkeypatch.setattr(
+        pipeline_page,
+        "_build_preview_plan",
+        lambda *_args, **_kwargs: (SimpleNamespace(stages=[], stage_rows=lambda: []), None),
+    )
     monkeypatch.setattr(pipeline_page.st, "button", fake_button)
     monkeypatch.setattr(pipeline_page, "_handle_pipeline_page_action", lambda **kwargs: None)
     monkeypatch.setattr(pipeline_page, "render_live_fragment", lambda *args, **kwargs: None)
@@ -629,26 +851,38 @@ def test_pipeline_page_reruns_after_successful_start_action() -> None:
     monkeypatch.setattr(pipeline_page.st, "container", lambda *args, **kwargs: DummyContext())
     monkeypatch.setattr(pipeline_page.st, "subheader", lambda *args, **kwargs: None)
     monkeypatch.setattr(pipeline_page.st, "caption", lambda *args, **kwargs: None)
-    monkeypatch.setattr(
-        pipeline_page.st,
-        "selectbox",
-        lambda label, *args, **kwargs: {
-            "Pipeline Config": config_path,
-            "Pose Source": AdvioPoseSource.GROUND_TRUTH,
-        }[label],
-    )
+    monkeypatch.setattr(pipeline_page.st, "selectbox", lambda *args, **kwargs: config_path)
     monkeypatch.setattr(pipeline_page.st, "columns", lambda *args, **kwargs: (DummyContext(), DummyContext()))
-    monkeypatch.setattr(pipeline_page.st, "toggle", lambda *args, **kwargs: False)
     monkeypatch.setattr(pipeline_page.st, "markdown", lambda *args, **kwargs: None)
     monkeypatch.setattr(pipeline_page.st, "json", lambda *args, **kwargs: None)
     monkeypatch.setattr(pipeline_page.st, "warning", lambda *args, **kwargs: None)
+    monkeypatch.setattr(pipeline_page.st, "dataframe", lambda *args, **kwargs: None)
     monkeypatch.setattr(pipeline_page, "_discover_pipeline_config_paths", lambda *_args, **_kwargs: [config_path])
     monkeypatch.setattr(
         pipeline_page,
         "_load_pipeline_request",
         lambda *_args, **_kwargs: (_load_pipeline_request_fixture(), None),
     )
-    monkeypatch.setattr(pipeline_page, "_resolve_advio_sequence_id", lambda **kwargs: (15, None))
+    monkeypatch.setattr(
+        pipeline_page,
+        "_render_request_editor",
+        lambda **kwargs: pipeline_page.PipelinePageAction(
+            config_path=config_path,
+            source_kind=PipelineSourceId.ADVIO,
+            advio_sequence_id=15,
+            mode=PipelineMode.OFFLINE,
+            method=MethodId.VISTA,
+            pose_source=AdvioPoseSource.GROUND_TRUTH,
+        ),
+    )
+    monkeypatch.setattr(
+        pipeline_page, "_build_request_from_action", lambda *_args, **_kwargs: (_load_pipeline_request_fixture(), None)
+    )
+    monkeypatch.setattr(
+        pipeline_page,
+        "_build_preview_plan",
+        lambda *_args, **_kwargs: (SimpleNamespace(stages=[], stage_rows=lambda: []), None),
+    )
     monkeypatch.setattr(
         pipeline_page.st,
         "button",
@@ -972,6 +1206,7 @@ def test_advio_page_warns_when_local_scene_is_not_offline_ready(tmp_path: Path) 
 
 
 def test_record3d_transport_change_does_not_start_stream_until_submit() -> None:
+    from prml_vslam.app import record3d_controls
     from prml_vslam.app.pages import record3d as record3d_page
     from prml_vslam.app.record3d_controller import handle_record3d_page_action
 
@@ -1008,7 +1243,7 @@ def test_record3d_transport_change_does_not_start_stream_until_submit() -> None:
 
     monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(
-        record3d_page,
+        record3d_controls,
         "list_record3d_usb_devices",
         lambda: [Record3DDevice(product_id=101, udid="device-101")],
     )
@@ -1084,6 +1319,7 @@ def test_record3d_wifi_start_button_enables_when_user_enters_address() -> None:
 
 
 def test_record3d_sidebar_shows_only_stop_button_while_stream_is_running() -> None:
+    from prml_vslam.app import record3d_controls
     from prml_vslam.app.pages import record3d as record3d_page
 
     class DummyContext:
@@ -1106,7 +1342,7 @@ def test_record3d_sidebar_shows_only_stop_button_while_stream_is_running() -> No
 
     monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(
-        record3d_page,
+        record3d_controls,
         "list_record3d_usb_devices",
         lambda: [Record3DDevice(product_id=101, udid="device-101")],
     )

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -13,12 +13,14 @@ from pydantic import ValidationError
 
 from prml_vslam.datasets.contracts import DatasetId
 from prml_vslam.interfaces import CameraIntrinsics, FramePacket, SE3Pose
+from prml_vslam.io.record3d import Record3DTransportId
 from prml_vslam.methods import MethodId, MockSlamBackendConfig
 from prml_vslam.methods.protocols import OfflineSlamBackend, SlamBackend, SlamSession, StreamingSlamBackend
 from prml_vslam.pipeline import PipelineMode, RunRequest, SequenceManifest
 from prml_vslam.pipeline.contracts import (
     BenchmarkEvaluationConfig,
     DatasetSourceSpec,
+    Record3DLiveSourceSpec,
     ReferenceConfig,
     RunPlan,
     RunPlanStage,
@@ -96,6 +98,25 @@ def test_run_request_build_keeps_legacy_default_stage_selection() -> None:
         RunPlanStageId.EFFICIENCY_EVALUATION,
         RunPlanStageId.SUMMARY,
     ]
+
+
+def test_run_request_build_uses_default_usb_descriptor_when_index_missing() -> None:
+    request = RunRequest(
+        experiment_name="Record3D Default USB",
+        mode=PipelineMode.STREAMING,
+        output_dir=Path(".artifacts"),
+        source=Record3DLiveSourceSpec(
+            transport=Record3DTransportId.USB,
+            device_index=None,
+        ),
+        slam=SlamConfig(method=MethodId.VISTA),
+    )
+
+    plan = request.build()
+
+    assert plan.stages[0].summary == (
+        "Capture the Record3D usb source 'default USB device' with persistence into a replayable sequence manifest."
+    )
 
 
 def test_run_request_build_respects_disabled_optional_stage_toggles() -> None:


### PR DESCRIPTION
## Stack Position

3 of 4.

Base: #19 (`refactor/advio-service-boilerplate`)

Preferred merge order:
1. #18
2. #19
3. #20
4. #21

## What changed

This PR isolates the shared Record3D transport-control feature from the docs work.

### App changes

- add a shared `record3d_controls.py` surface so the Record3D page and Pipeline page use the same transport-selection UI and validation rules
- update app models so the shared control state can represent transport choice, USB device selection, and Wi-Fi preview address consistently
- update both the dedicated Record3D page and the bounded Pipeline page to consume the shared control flow

### Pipeline-support changes

- extend pipeline live-source contracts so Record3D live requests carry transport-aware details instead of relying on ad hoc source identifiers alone
- update pipeline planner/demo wiring so transport-aware Record3D live requests remain consistent with the app controls

### Test coverage

- extend app tests around transport selection, request building, page-state hydration, and runtime behavior for USB and Wi-Fi preview flows

### Main files

- `src/prml_vslam/app/record3d_controls.py`
- `src/prml_vslam/app/models.py`
- `src/prml_vslam/app/pages/record3d.py`
- `src/prml_vslam/app/pages/pipeline.py`
- `src/prml_vslam/pipeline/contracts.py`
- `src/prml_vslam/pipeline/services.py`
- `src/prml_vslam/pipeline/demo.py`
- `tests/test_app.py`

### Intentionally not in scope

- no app entrypoint packaging changes
- no repo-wide docs canonicalization
- no unrelated dataset or evaluation policy work

## Why

The transport-control code was previously duplicated across app surfaces. This PR centralizes that behavior while keeping the supporting pipeline request shape and tests in the same review unit.

## Validation

- `make ci`
