### PR TITLE
fix(ci): guard Claude review workflow

### DIFF
--- a/.agents/resolved.toml
+++ b/.agents/resolved.toml
@@ -1,8 +1,32 @@
 [meta]
 schema_version = 2
 repo = "prml-vslam"
-updated_on = "2026-04-06"
+updated_on = "2026-04-07"
 source = "Resolved or retired issue and todo records moved out of the active backlogs, plus imported review items assessed as already addressed in the current tree or superseded by the current architecture policy."
+
+[[resolved_issues]]
+id = "ISSUE-0034"
+title = "Claude PR review workflow fails on workflow-maintenance pull requests"
+status = "resolved"
+priority = "medium"
+category = "ci"
+summary = "Anthropic's GitHub App rejects pull_request review runs when `.github/workflows/claude-code-review.yml` differs from the default branch version, which turned workflow-maintenance PRs red even though the review setup itself was otherwise valid."
+files = [
+    ".github/workflows/claude-code-review.yml",
+]
+notes = [
+    "Validated from the failing `Claude Code Review` runs on 2026-04-07 and Anthropic's matching public issue guidance for the same workflow-validation error.",
+    "The workflow now compares its own file against the default branch and exits early with a notice instead of invoking the action in that unsupported case.",
+    "The workflow token permissions were also widened so buffered review comments can be posted when the action does run.",
+]
+sources = [
+    ".github/workflows/claude-code-review.yml",
+    "https://github.com/anthropics/claude-code-action/issues/522",
+]
+previous_status = "open"
+resolved_on = "2026-04-07"
+resolution_note = "Added a default-branch workflow guard for self-edits and corrected the Claude review workflow token permissions."
+source_collection = "maintenance"
 
 [[resolved_issues]]
 id = "ISSUE-PR15-0001"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -20,22 +20,42 @@ jobs:
 
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
 
+      - name: Skip when workflow differs from default branch
+        id: workflow-guard
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          WORKFLOW_PATH: .github/workflows/claude-code-review.yml
+        run: |
+          git fetch --no-tags --depth=1 origin "$DEFAULT_BRANCH"
+
+          if ! git diff --quiet FETCH_HEAD -- "$WORKFLOW_PATH"; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+            echo "::notice title=Claude review skipped::Skipping Claude Code Review because ${WORKFLOW_PATH} differs from the default branch version, which Anthropic's GitHub App refuses to review on pull_request runs."
+            exit 0
+          fi
+
+          echo "skip=false" >> "$GITHUB_OUTPUT"
+
       - name: Run Claude Code Review
+        if: steps.workflow-guard.outputs.skip != 'true'
         id: claude-review
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Summary
This PR fixes the existing Claude review workflow so workflow-maintenance PRs no longer fail on Anthropic's default-branch validation guard.

## What changed
- update `.github/workflows/claude-code-review.yml` to:
  - skip with a notice when the workflow file itself differs from `main`
  - grant the permissions needed for review posting and action-read access
- record the validated Claude workflow defect in `.agents/resolved.toml`

## Why
Anthropic's GitHub App rejects `pull_request` review runs when the workflow file being executed does not match the version on the default branch. That made PRs which edit `claude-code-review.yml` fail even when the workflow definition itself was correct.

## Impact
- Claude review no longer turns workflow-edit PRs red for the known unsupported case
- normal Claude review runs retain the existing plugin-based review behavior

## Validation
- `make ci`
- `git diff --check`

## Notes
- left the existing untracked `.agents/skills/beautiful-mermaid/` directory out of this PR so the change stays scoped
