### PR TITLE
fix(streaming): restore streaming lifecycle contracts and harden multiprocess error handling

### DIFF
--- a/src/prml_vslam/methods/contracts.py
+++ b/src/prml_vslam/methods/contracts.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from enum import StrEnum
-from pathlib import Path
+
+from pydantic import Field
 
 from prml_vslam.utils import BaseConfig
 
@@ -41,6 +42,9 @@ class SlamBackendConfig(BaseConfig):
 
     max_frames: int | None = None
     """Optional frame cap used for debugging or short smoke runs."""
+
+    slam: dict[str, object] = Field(default_factory=dict)
+    """Backend-specific nested overrides preserved from `[slam.backend.slam]` TOML blocks."""
 
 
 __all__ = ["MethodId", "SlamBackendConfig", "SlamOutputPolicy"]

--- a/src/prml_vslam/methods/multiprocess.py
+++ b/src/prml_vslam/methods/multiprocess.py
@@ -5,16 +5,16 @@ from __future__ import annotations
 import multiprocessing as mp
 import queue
 from collections.abc import Callable
-from pathlib import Path
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from prml_vslam.utils import Console
 
 if TYPE_CHECKING:
     from prml_vslam.interfaces import FramePacket
+    from prml_vslam.methods.protocols import SlamSession
     from prml_vslam.methods.updates import SlamUpdate
     from prml_vslam.pipeline.contracts.artifacts import SlamArtifacts
-    from prml_vslam.methods.protocols import SlamSession
 
 
 class MultiprocessSlamSession:
@@ -28,7 +28,7 @@ class MultiprocessSlamSession:
     ) -> None:
         self._console = console.child("MultiprocessSlamSession")
         ctx = mp.get_context("spawn")
-        # Bound the input queue so that if the SLAM backend falls behind, 
+        # Bound the input queue so that if the SLAM backend falls behind,
         # the producer blocks (backpressure), keeping the pipeline in sync.
         self._input_queue: mp.Queue = ctx.Queue(maxsize=2)
         self._output_queue: mp.Queue = ctx.Queue()
@@ -45,7 +45,7 @@ class MultiprocessSlamSession:
     def step(self, frame: FramePacket) -> None:
         """Push one frame to the background worker, blocking if the queue is full (backpressure)."""
         # Block until there is space in the queue.
-        # This causes the upstream ingestion loop to wait, naturally slowing down 
+        # This causes the upstream ingestion loop to wait, naturally slowing down
         # the entire pipeline to the speed of the SLAM backend without dropping frames.
         self._input_queue.put(frame)
 
@@ -54,10 +54,16 @@ class MultiprocessSlamSession:
         updates = []
         while True:
             try:
-                update = self._output_queue.get_nowait()
-                if update is None:  # Sentinel for errors or unexpected exit
-                    break
-                updates.append(update)
+                message = self._output_queue.get_nowait()
+                match message:
+                    case WorkerUpdate(update=update):
+                        updates.append(update)
+                    case WorkerError(error_message=error_message):
+                        raise RuntimeError(error_message)
+                    case WorkerDone():
+                        break
+                    case _:
+                        raise RuntimeError(f"Unexpected worker message type: {type(message).__name__}")
             except queue.Empty:
                 break
         return updates
@@ -65,7 +71,11 @@ class MultiprocessSlamSession:
     def close(self) -> SlamArtifacts:
         """Signal the worker to exit and retrieve final artifacts."""
         self._console.info("Closing multiprocess SLAM worker...")
-        self._input_queue.put(None)  # Sentinel for exit
+        try:
+            self._input_queue.put(None, timeout=1.0)
+        except queue.Full:
+            self._console.error("Worker input queue is full during close; terminating worker process.")
+            self._process.terminate()
         self._process.join(timeout=30.0)
         if self._process.is_alive():
             self._console.error("Worker process did not exit gracefully; terminating.")
@@ -79,6 +89,25 @@ class MultiprocessSlamSession:
             return artifacts
 
         raise RuntimeError("Failed to retrieve artifacts from the background worker.")
+
+
+@dataclass(slots=True)
+class WorkerUpdate:
+    """One successful incremental update emitted by the worker."""
+
+    update: SlamUpdate
+
+
+@dataclass(slots=True)
+class WorkerError:
+    """One frame-level worker failure that should fail the parent session."""
+
+    error_message: str
+
+
+@dataclass(slots=True)
+class WorkerDone:
+    """Terminal worker marker after session close."""
 
 
 def _session_worker(
@@ -105,13 +134,14 @@ def _session_worker(
             try:
                 session.step(packet)
                 for update in session.try_get_updates():
-                    output_queue.put(update)
+                    output_queue.put(WorkerUpdate(update=update))
             except Exception as exc:
                 logger.exception("Error during SLAM step in background worker: %s", exc)
-                # We don't break here, try to continue with next frames
-                # but we could send a sentinel if it's fatal.
+                output_queue.put(WorkerError(error_message=str(exc)))
+                raise
 
         artifacts = session.close()
+        output_queue.put(WorkerDone())
         result_pipe.send(artifacts)
     except Exception as exc:
         logger.exception("Fatal error in background worker: %s", exc)

--- a/src/prml_vslam/pipeline/streaming.py
+++ b/src/prml_vslam/pipeline/streaming.py
@@ -34,7 +34,6 @@ from .finalization import finalize_run_outputs, write_json
 from .runner_runtime import RunnerRuntime
 
 _STOP_JOIN_TIMEOUT_SECONDS = 10.0
-_KEYFRAME_ROTATION_THRESHOLD_RAD = 0.15
 
 
 class StreamingRunner:
@@ -71,7 +70,10 @@ class StreamingRunner:
 
     def stop(self) -> None:
         """Stop the active streaming run."""
-        self._runtime.stop(join_timeout_seconds=_STOP_JOIN_TIMEOUT_SECONDS)
+        self._runtime.stop(
+            snapshot_update=_to_stopped_snapshot,
+            join_timeout_seconds=_STOP_JOIN_TIMEOUT_SECONDS,
+        )
 
     def snapshot(self) -> StreamingRunSnapshot:
         """Return the latest streaming runtime snapshot."""
@@ -79,10 +81,13 @@ class StreamingRunner:
 
     def set_failed_start(self, *, plan: RunPlan, error_message: str) -> None:
         """Set the initial snapshot state for a run that failed to start."""
-        self._runtime.update_fields(
-            state=RunState.FAILED,
-            plan=plan,
-            error_message=error_message,
+        self.stop()
+        self._runtime.replace_snapshot(
+            StreamingRunSnapshot(
+                state=RunState.FAILED,
+                plan=plan,
+                error_message=error_message,
+            )
         )
 
     def _run_worker(
@@ -107,9 +112,11 @@ class StreamingRunner:
         slam_artifacts = None
         visualization_artifacts = None
         latest_preview_update = None
+        slam_session = None
 
         start_timestamp_ns: int | None = None
         live_recording = None
+        final_state = RunState.COMPLETED
 
         def _record_runtime_error(exc: Exception) -> None:
             nonlocal final_state, pipeline_failed, error_message
@@ -142,14 +149,14 @@ class StreamingRunner:
                     attach_grpc_sink(live_recording, grpc_url=request.visualization.grpc_url)
                 if request.visualization.export_viewer_rrd:
                     attach_file_sink(live_recording, target_path=run_paths.viewer_rrd_path)
-            slam_started = True
             slam_session = slam_backend.start_session(
                 request.slam.backend,
                 request.slam.outputs,
                 plan.artifact_root,
             )
+            slam_started = True
             self._runtime.update_fields(state=RunState.RUNNING, error_message="")
-            
+
             max_frames = request.slam.backend.max_frames
             frames_pushed = 0
 
@@ -160,24 +167,29 @@ class StreamingRunner:
 
                 packet = stream.wait_for_packet(timeout_seconds=self.frame_timeout_seconds)
                 frames_pushed += 1
-                
+
                 arrival_time_s = time.monotonic()
                 if start_timestamp_ns is None:
                     start_timestamp_ns = packet.timestamp_ns
 
                 metrics.record_packet(arrival_time_s=arrival_time_s)
+                self._runtime.update_fields(
+                    state=RunState.RUNNING,
+                    latest_packet=packet,
+                    **metrics.packet_snapshot_fields(),
+                )
                 slam_session.step(packet)
 
                 for update in slam_session.try_get_updates():
                     if _has_renderable_preview(update):
                         latest_preview_update = update
-                    is_keyframe_update = update.is_keyframe or (update.pose is not None and update.keyframe_index is None)
+                    is_keyframe_update = _is_keyframe_like_update(update)
                     if is_keyframe_update:
                         keyframe_position_xyz = extract_pose_position(update)
                         metrics.record_keyframe(
                             arrival_time_s=arrival_time_s,
                             position_xyz=keyframe_position_xyz,
-                            trajectory_time_s=(packet.timestamp_ns - start_timestamp_ns) / 1e9
+                            trajectory_time_s=(update.timestamp_ns - start_timestamp_ns) / 1e9
                             if update.pose is not None
                             else None,
                         )
@@ -204,7 +216,6 @@ class StreamingRunner:
                     metrics_fields = metrics.snapshot_fields()
                     self._runtime.update_fields(
                         state=RunState.RUNNING,
-                        latest_packet=packet,
                         latest_slam_update=update,
                         latest_preview_update=latest_preview_update,
                         num_sparse_points=update.num_sparse_points,
@@ -219,25 +230,22 @@ class StreamingRunner:
             if stop_event.is_set() and final_state is not RunState.FAILED:
                 final_state = RunState.STOPPED
             try:
-                if slam_started:
+                if slam_session is not None:
                     slam_artifacts = slam_session.close()
-                if (
-                    request.visualization.export_viewer_rrd
-                    and sequence_manifest is not None
-                    and slam_artifacts is not None
-                ):
+                if sequence_manifest is not None and slam_artifacts is not None:
                     visualization_artifacts = collect_native_visualization_artifacts(
                         native_output_dir=run_paths.native_output_dir,
                         preserve_native_rerun=request.visualization.preserve_native_rerun,
                     )
-                    repo_rrd_ref = ArtifactRef(
-                        path=run_paths.viewer_rrd_path.resolve(),
-                        kind="rrd",
-                        fingerprint=f"viewer-rrd-{plan.run_id}",
-                    )
-                    if visualization_artifacts is None:
-                        visualization_artifacts = VisualizationArtifacts()
-                    visualization_artifacts.extras["viewer_rrd"] = repo_rrd_ref
+                    if request.visualization.export_viewer_rrd:
+                        repo_rrd_ref = ArtifactRef(
+                            path=run_paths.viewer_rrd_path.resolve(),
+                            kind="rrd",
+                            fingerprint=f"viewer-rrd-{plan.run_id}",
+                        )
+                        if visualization_artifacts is None:
+                            visualization_artifacts = VisualizationArtifacts()
+                        visualization_artifacts.extras["viewer_rrd"] = repo_rrd_ref
 
                 summary, stage_manifests = finalize_run_outputs(
                     request=request,
@@ -252,15 +260,26 @@ class StreamingRunner:
                     pipeline_failed=pipeline_failed,
                     error_message=error_message,
                 )
-                self._runtime.update_fields(
-                    state=final_state,
-                    summary=summary,
-                    stage_manifests=stage_manifests,
-                    error_message=error_message,
+                self._runtime.finalize(
+                    stop_event=stop_event,
+                    snapshot_update=lambda snapshot: snapshot.model_copy(
+                        update={
+                            "state": final_state,
+                            "summary": summary,
+                            "stage_manifests": stage_manifests,
+                            "error_message": error_message,
+                        }
+                    ),
                 )
             except Exception as exc:
                 self._console.error(f"Finalization failed: {exc}")
-                self._runtime.update_fields(state=RunState.FAILED, error_message=str(exc))
+                finalization_error = str(exc)
+                self._runtime.finalize(
+                    stop_event=stop_event,
+                    snapshot_update=lambda snapshot: snapshot.model_copy(
+                        update={"state": RunState.FAILED, "error_message": finalization_error}
+                    ),
+                )
 
 
 def _is_keyframe_like_update(update: SlamUpdate) -> bool:
@@ -276,6 +295,11 @@ def _has_renderable_preview(update: SlamUpdate) -> bool:
         return False
     pointmap = np.asarray(update.pointmap)
     return pointmap.size > 0 and pointmap.ndim in {2, 3}
+
+
+def _to_stopped_snapshot(snapshot: StreamingRunSnapshot) -> StreamingRunSnapshot:
+    """Return a STOPPED snapshot that preserves the latest visual state."""
+    return snapshot.model_copy(update={"state": RunState.STOPPED, "error_message": ""})
 
 
 __all__ = ["StreamingRunner"]

--- a/tests/test_methods.py
+++ b/tests/test_methods.py
@@ -11,6 +11,8 @@ import pytest
 from prml_vslam.interfaces import FramePacket, FrameTransform
 from prml_vslam.methods import MockSlamBackendConfig, VistaSlamBackend, VistaSlamBackendConfig
 from prml_vslam.methods.contracts import SlamOutputPolicy
+from prml_vslam.methods.multiprocess import MultiprocessSlamSession
+from prml_vslam.methods.updates import SlamUpdate
 from prml_vslam.pipeline import SequenceManifest
 from prml_vslam.utils import Console
 
@@ -424,3 +426,24 @@ def test_vista_pose_normalization_rejects_clearly_invalid_rotations() -> None:
 
     with pytest.raises(ValueError, match="too far from SO\\(3\\)"):
         _frame_transform_from_vista_pose(pose)
+
+
+def test_multiprocess_session_surfaces_worker_frame_errors(tmp_path: Path) -> None:
+    class FailingSession:
+        def step(self, frame: FramePacket) -> None:
+            del frame
+            raise RuntimeError("worker step failed")
+
+        def try_get_updates(self) -> list[SlamUpdate]:
+            return []
+
+        def close(self) -> object:
+            return object()
+
+    session = MultiprocessSlamSession(
+        session_factory=lambda: FailingSession(),  # type: ignore[arg-type]
+        console=Console(__name__),
+    )
+    session.step(FramePacket(seq=0, timestamp_ns=0, rgb=np.zeros((4, 4, 3), dtype=np.uint8)))
+    with pytest.raises(RuntimeError, match="worker step failed"):
+        session.try_get_updates()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import time
 from pathlib import Path
+from threading import Event
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -68,6 +69,30 @@ def test_run_request_build_respects_disabled_optional_stage_toggles(tmp_path: Pa
     plan = request.build(path_config)
 
     assert RunPlanStageId.BENCHMARK not in [stage.id for stage in plan.stages]
+
+
+def test_run_request_parses_vista_specific_backend_overrides_from_toml() -> None:
+    request = RunRequest.from_toml(
+        """
+experiment_name = "vista-config"
+mode = "streaming"
+output_dir = ".artifacts"
+
+[source]
+dataset_id = "advio"
+sequence_id = "advio-15"
+
+[slam]
+method = "vista"
+
+[slam.backend.slam]
+flow_thres = 3.5
+max_view_num = 123
+"""
+    )
+
+    assert request.slam.backend.slam["flow_thres"] == 3.5
+    assert request.slam.backend.slam["max_view_num"] == 123
 
 
 def test_pipeline_protocols_accept_current_structural_implementations(tmp_path: Path) -> None:
@@ -247,6 +272,117 @@ def test_streaming_runner_retains_last_renderable_preview_update(tmp_path: Path)
     assert snapshot.latest_preview_update.preview_rgb is not None
 
 
+def test_streaming_runner_stop_preserves_last_preview_and_trajectory_via_run_service(tmp_path: Path) -> None:
+    path_config = PathConfig(root=tmp_path, artifacts_dir=tmp_path / ".artifacts", captures_dir=tmp_path / "captures")
+    request = _build_request(path_config, mode=PipelineMode.STREAMING)
+    service = RunService(
+        path_config=path_config,
+        slam_backend_factory=lambda _method: PreviewRetentionStreamingBackend(),
+    )
+    source = FakeStreamingSource(
+        sequence_manifest=SequenceManifest(sequence_id="advio-15"),
+        stream=BlockingPacketStream(first_packet=_make_packet(seq=0, timestamp_ns=1_000_000_000, tx=0.0)),
+    )
+
+    service.start_run(request=request, runtime_source=source)
+    for _ in range(50):
+        snapshot = service.snapshot()
+        if isinstance(snapshot, StreamingRunSnapshot) and snapshot.received_frames >= 1:
+            break
+        time.sleep(0.02)
+    service.stop_run()
+    snapshot = service.snapshot()
+
+    assert isinstance(snapshot, StreamingRunSnapshot)
+    assert snapshot.state is RunState.STOPPED
+    assert snapshot.latest_preview_update is not None
+    assert snapshot.latest_preview_update.preview_rgb is not None
+    assert snapshot.trajectory_positions_xyz.shape[0] == 1
+
+
+def test_streaming_runner_attributes_delayed_updates_by_update_timestamp(tmp_path: Path) -> None:
+    path_config = PathConfig(root=tmp_path, artifacts_dir=tmp_path / ".artifacts", captures_dir=tmp_path / "captures")
+    request = _build_request(path_config, mode=PipelineMode.STREAMING)
+    plan = request.build(path_config)
+    source = FakeStreamingSource(
+        sequence_manifest=SequenceManifest(sequence_id="advio-15"),
+        stream=FinitePacketStream(
+            [
+                _make_packet(seq=0, timestamp_ns=1_000_000_000, tx=0.0),
+                _make_packet(seq=1, timestamp_ns=2_000_000_000, tx=0.1),
+            ]
+        ),
+    )
+    runner = StreamingRunner(frame_timeout_seconds=0.01)
+    runner.start(
+        request=request,
+        plan=plan,
+        source=source,
+        slam_backend=DelayedUpdateStreamingBackend(),
+    )
+    snapshot = _wait_for_terminal_snapshot(runner)
+
+    assert isinstance(snapshot, StreamingRunSnapshot)
+    assert snapshot.state is RunState.COMPLETED
+    assert snapshot.accepted_keyframes == 1
+    np.testing.assert_allclose(snapshot.trajectory_timestamps_s, np.array([0.0]))
+
+
+def test_streaming_runner_failed_start_surfaces_startup_error_without_unboundlocal(tmp_path: Path) -> None:
+    path_config = PathConfig(root=tmp_path, artifacts_dir=tmp_path / ".artifacts", captures_dir=tmp_path / "captures")
+    request = _build_request(path_config, mode=PipelineMode.STREAMING)
+    plan = request.build(path_config)
+    runner = StreamingRunner(frame_timeout_seconds=0.01)
+    source = FakeStreamingSource(
+        sequence_manifest=SequenceManifest(sequence_id="advio-15"),
+        stream=FinitePacketStream([_make_packet(seq=0, timestamp_ns=1_000_000_000, tx=0.0)]),
+    )
+    runner.start(
+        request=request,
+        plan=plan,
+        source=source,
+        slam_backend=StartFailureStreamingBackend(),
+    )
+    snapshot = _wait_for_terminal_snapshot(runner)
+
+    assert isinstance(snapshot, StreamingRunSnapshot)
+    assert snapshot.state is RunState.FAILED
+    assert "start session failed" in snapshot.error_message
+
+
+def test_streaming_runner_finalize_runs_registered_cleanup_on_completion_and_failure(tmp_path: Path) -> None:
+    path_config = PathConfig(root=tmp_path, artifacts_dir=tmp_path / ".artifacts", captures_dir=tmp_path / "captures")
+    request = _build_request(path_config, mode=PipelineMode.STREAMING)
+    plan = request.build(path_config)
+
+    completion_stream = DisconnectSpyPacketStream(packets=[_make_packet(seq=0, timestamp_ns=1_000_000_000, tx=0.0)])
+    completion_runner = StreamingRunner(frame_timeout_seconds=0.01)
+    completion_runner.start(
+        request=request,
+        plan=plan,
+        source=FakeStreamingSource(
+            sequence_manifest=SequenceManifest(sequence_id="advio-15"), stream=completion_stream
+        ),
+        slam_backend=PreviewRetentionStreamingBackend(),
+    )
+    completion_snapshot = _wait_for_terminal_snapshot(completion_runner)
+
+    failure_stream = DisconnectSpyPacketStream(packets=[_make_packet(seq=0, timestamp_ns=1_000_000_000, tx=0.0)])
+    failure_runner = StreamingRunner(frame_timeout_seconds=0.01)
+    failure_runner.start(
+        request=request,
+        plan=plan,
+        source=FakeStreamingSource(sequence_manifest=SequenceManifest(sequence_id="advio-15"), stream=failure_stream),
+        slam_backend=FailingStepStreamingBackend(),
+    )
+    failure_snapshot = _wait_for_terminal_snapshot(failure_runner)
+
+    assert completion_snapshot.state is RunState.COMPLETED
+    assert failure_snapshot.state is RunState.FAILED
+    assert completion_stream.disconnect_calls >= 1
+    assert failure_stream.disconnect_calls >= 1
+
+
 class KeyframeStreamingBackend:
     """Small streaming backend double that emits explicit keyframe metadata."""
 
@@ -380,6 +516,94 @@ class PreviewRetentionStreamingSession:
         return SlamArtifacts(
             trajectory_tum=ArtifactRef(path=trajectory_path, kind="tum", fingerprint="preview-retention-streaming"),
         )
+
+
+class DelayedUpdateStreamingBackend:
+    method_id = MethodId.VISTA
+
+    def start_session(
+        self,
+        backend_config: SlamBackendConfig,
+        output_policy: SlamOutputPolicy,
+        artifact_root: Path,
+    ) -> SlamSession:
+        del backend_config, output_policy
+        return DelayedUpdateStreamingSession(artifact_root=artifact_root)
+
+
+class DelayedUpdateStreamingSession:
+    def __init__(self, *, artifact_root: Path) -> None:
+        self._artifact_root = artifact_root
+        self._pending: list[SlamUpdate] = []
+        self._frames: list[FramePacket] = []
+
+    def step(self, frame: FramePacket) -> None:
+        self._frames.append(frame)
+        if len(self._frames) == 2:
+            self._pending.append(
+                SlamUpdate(
+                    seq=self._frames[0].seq,
+                    timestamp_ns=self._frames[0].timestamp_ns,
+                    pose=FrameTransform(qx=0.0, qy=0.0, qz=0.0, qw=1.0, tx=0.0, ty=0.0, tz=0.0),
+                    is_keyframe=True,
+                    keyframe_index=0,
+                )
+            )
+
+    def try_get_updates(self) -> list[SlamUpdate]:
+        updates = self._pending
+        self._pending = []
+        return updates
+
+    def close(self) -> SlamArtifacts:
+        trajectory_path = self._artifact_root / "slam" / "trajectory.tum"
+        trajectory_path.parent.mkdir(parents=True, exist_ok=True)
+        trajectory_path.write_text("0 0 0 0 0 0 1\n", encoding="utf-8")
+        return SlamArtifacts(trajectory_tum=ArtifactRef(path=trajectory_path, kind="tum", fingerprint="delayed"))
+
+
+class StartFailureStreamingBackend:
+    method_id = MethodId.VISTA
+
+    def start_session(
+        self,
+        backend_config: SlamBackendConfig,
+        output_policy: SlamOutputPolicy,
+        artifact_root: Path,
+    ) -> SlamSession:
+        del backend_config, output_policy, artifact_root
+        raise RuntimeError("start session failed")
+
+
+class FailingStepStreamingBackend:
+    method_id = MethodId.VISTA
+
+    def start_session(
+        self,
+        backend_config: SlamBackendConfig,
+        output_policy: SlamOutputPolicy,
+        artifact_root: Path,
+    ) -> SlamSession:
+        del backend_config, output_policy
+        return FailingStepStreamingSession(artifact_root=artifact_root)
+
+
+class FailingStepStreamingSession:
+    def __init__(self, *, artifact_root: Path) -> None:
+        self._artifact_root = artifact_root
+
+    def step(self, frame: FramePacket) -> None:
+        del frame
+        raise RuntimeError("frame step failed")
+
+    def try_get_updates(self) -> list[SlamUpdate]:
+        return []
+
+    def close(self) -> SlamArtifacts:
+        trajectory_path = self._artifact_root / "slam" / "trajectory.tum"
+        trajectory_path.parent.mkdir(parents=True, exist_ok=True)
+        trajectory_path.write_text("0 0 0 0 0 0 1\n", encoding="utf-8")
+        return SlamArtifacts(trajectory_tum=ArtifactRef(path=trajectory_path, kind="tum", fingerprint="failing-step"))
 
 
 def test_run_service_dispatches_offline_without_runtime_source(tmp_path: Path) -> None:
@@ -530,6 +754,36 @@ class FinitePacketStream:
 
     def disconnect(self) -> None:
         pass
+
+
+class DisconnectSpyPacketStream(FinitePacketStream):
+    def __init__(self, packets: list[FramePacket]) -> None:
+        super().__init__(packets)
+        self.disconnect_calls = 0
+
+    def disconnect(self) -> None:
+        self.disconnect_calls += 1
+
+
+class BlockingPacketStream:
+    def __init__(self, *, first_packet: FramePacket) -> None:
+        self._first_packet = first_packet
+        self._served = False
+        self._unblock = Event()
+
+    def connect(self) -> None:
+        return None
+
+    def wait_for_packet(self, timeout_seconds: float) -> FramePacket:
+        if not self._served:
+            self._served = True
+            return self._first_packet
+        if not self._unblock.wait(timeout_seconds):
+            raise TimeoutError("waiting for stop")
+        raise EOFError
+
+    def disconnect(self) -> None:
+        self._unblock.set()
 
 
 class OfflineRunnerSpy:


### PR DESCRIPTION
### Motivation
- Restore the correct streaming lifecycle semantics so `stop()` preserves the last visible preview/trajectory and `finalize()` runs registered cleanup callbacks.
- Prevent startup cleanup masking and UnboundLocalError by making session startup/cleanup robust.
- Fix attribution and telemetry regressions caused by asynchronous `try_get_updates()` draining and make multiprocess IPC deterministic for per-frame errors.
- Preserve backend-specific TOML overrides so ViSTA tuning keys under `[slam.backend.slam]` are not lost silently.

### Description
- Streaming lifecycle and snapshot semantics: `StreamingRunner.stop()` now calls `RunnerRuntime.stop(...)` with a `_to_stopped_snapshot(...)` callback so STOPPED preserves the last preview/trajectory, and `set_failed_start()` now stops any active run then replaces the snapshot with an explicit failed-start snapshot. The worker finalization path now uses `RunnerRuntime.finalize(...)` so registered cleanup callbacks execute on both success and failure. (see `src/prml_vslam/pipeline/streaming.py`).
- Worker startup/cleanup safety and telemetry: initialize `slam_session = None` and only call `close()` when assigned to avoid masking startup errors; update packet-facing runtime fields immediately on packet receipt; use each `SlamUpdate.timestamp_ns` when attributing trajectory timestamps; and consolidate keyframe-like logic into `_is_keyframe_like_update(...)`. (see `src/prml_vslam/pipeline/streaming.py`).
- Multiprocess IPC and shutdown hardening: replace ad-hoc queue payloads with typed messages (`WorkerUpdate`, `WorkerError`, `WorkerDone`) and make the background worker emit these; the parent now raises on `WorkerError` and handles `WorkerDone` explicitly; `close()` enqueues the sentinel with a timeout and will terminate the worker if the input queue is full to avoid indefinite blocking. (see `src/prml_vslam/methods/multiprocess.py`).
- Preserve backend TOML overrides: add `slam: dict[str, object]` to `SlamBackendConfig` so `[slam.backend.slam]` keys are preserved in parsed requests (and exposed to downstream adapters). (see `src/prml_vslam/methods/contracts.py`).
- Tests: added regression tests covering STOPPED snapshot retention, delayed-update attribution, startup failure propagation, cleanup invocation on completion and failure, `[slam.backend.slam]` parsing, and multiprocess worker frame-error propagation. (see `tests/test_pipeline.py` and `tests/test_methods.py`).

### Testing
- Ran formatting and static checks: `ruff format` / `uv run ruff check` on changed files — these checks passed. (success)
- Attempted targeted pytest runs for the new regression tests using `uv run pytest ...` but collection/import failed due to the environment missing the system OpenCV runtime (`libGL.so.1`), so pytest could not be executed here. (blocked: OpenCV runtime missing)
- Attempted full `make ci` but it failed in this environment because `pre-commit` is not available in the runner shell, so the full CI job could not be executed. (blocked: pre-commit missing)
- Tried the repo graph rebuild step required by local agent guidance but the `graphify` module is not installed in the environment, so the rebuild could not run. (blocked: graphify missing)

Notes: All code changes are focused to restore lifecycle semantics, improve attribution, and harden the multiprocess and shutdown paths; environment-specific runtime deps prevented executing the new pytest regressions end-to-end in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de64a719648324b8385bb1f78007d3)