### PR TITLE
docs(slides): update meeting-02 notes for ViSTA-SLAM Streamlit integration and runtime work

### DIFF
--- a/docs/slides/update-meetings/meeting-02/lr.typ
+++ b/docs/slides/update-meetings/meeting-02/lr.typ
@@ -1,31 +1,34 @@
 #let done_table_row = (
   [LR],
-  [ViSTA-SLAM integration],
+  [ViSTA-SLAM implementation in Streamlit runtime],
 )
 #let challenges_table_row = (
   [LR],
-  [CUDA version mismatch],
+  [Runtime orchestration and environment setup],
 )
 #let next_steps_table_row = (
   [LR],
-  [CUDA 13.0 toolkit, streaming validation],
+  [Async stability and streaming validation],
 )
 
 #let done_detail_body = [
   == Done
-  - Integrated ViSTA-SLAM as submodule with offline + streaming backend
-  - CLI `run` command and Streamlit pipeline page wired to real backend
-  - Built DBoW3Py C extension for loop detection
+  - Integrated ViSTA-SLAM into the Streamlit pipeline page as the active backend path.
+  - Implemented async execution flow so long-running steps do not block the app UI.
+  - Added rerun-safe state handling so results persist correctly across Streamlit reruns.
+  - Wired the CLI `run` command and Streamlit pipeline flow to share the same runtime behavior.
+  - Built and linked DBoW3Py for loop-detection support in the integrated pipeline.
 ]
 
 #let challenges_detail_body = [
   == Challenges
-  - Driver (CUDA 13.0) vs toolkit (12.6) vs torch version alignment
-  - GPU hardware fault required system reboot
+  - Main effort was coordinating async task lifecycle with Streamlit rerun semantics.
+  - Environment was standardized via Conda to keep builds and runtime behavior consistent.
 ]
 
 #let next_steps_detail_body = [
   == Next Steps
-  - Install CUDA 13.0 toolkit, rebuild RoPE2D extension
-  - End-to-end streaming test on ADVIO sequences
+  - Harden async + rerun behavior under repeated user interactions.
+  - Run full streaming validation on ADVIO sequences and capture regressions.
+  - Finalize reproducible Conda setup notes for smoother team onboarding.
 ]


### PR DESCRIPTION
### Motivation
- Record the recent work integrating ViSTA-SLAM into the Streamlit pipeline and the changes made to runtime behavior.
- Surface key challenges around async task lifecycle and environment reproducibility to guide next steps and team onboarding.

### Description
- Updated slide table rows `done_table_row`, `challenges_table_row`, and `next_steps_table_row` to reflect the Streamlit integration and runtime work.
- Documented that ViSTA-SLAM was wired into the Streamlit pipeline and the CLI `run` command to share the same runtime behavior.
- Noted implementation of async execution flow and rerun-safe state handling, plus building and linking `DBoW3Py` for loop detection.
- Added notes about standardizing the environment with Conda and planned streaming validation on ADVIO sequences.

### Testing
- No automated tests were run for this slide/documentation update.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de662837048324aeada9163267ef5e)