### PR TITLE
Restore repo-local MemPalace startup

### DIFF
--- a/.agents/scripts/mempalace_startup_context.sh
+++ b/.agents/scripts/mempalace_startup_context.sh
@@ -8,6 +8,7 @@ helper=".agents/skills/mempalace-repo/scripts/mempalace_repo.py"
 log_dir=".artifacts/mempalace/logs"
 lock_dir=".artifacts/mempalace/startup-refresh.lock"
 log_file="$log_dir/startup-refresh.log"
+pid_file="$lock_dir/pid"
 
 echo "PRML VSLAM MemPalace startup context"
 
@@ -18,17 +19,46 @@ fi
 
 mkdir -p "$log_dir"
 
+start_refresh() {
+  refresh_script='
+    repo_root="$1"
+    helper="$2"
+    log_file="$3"
+    lock_dir="$4"
+    pid_file="$5"
+    cd "$repo_root" || exit 0
+    trap '\''rm -f "$pid_file"; rmdir "$lock_dir" 2>/dev/null || true'\'' EXIT
+    printf "%s\n" "$$" >"$pid_file"
+    {
+      printf "\n[%s] startup refresh begin\n" "$(date -Is)"
+      python3 "$helper" refresh
+      printf "[%s] startup refresh end\n" "$(date -Is)"
+    } >>"$log_file" 2>&1
+  '
+  if command -v setsid >/dev/null 2>&1; then
+    setsid bash -c "$refresh_script" _ "$repo_root" "$helper" "$log_file" "$lock_dir" "$pid_file" >/dev/null 2>&1 &
+  else
+    nohup bash -c "$refresh_script" _ "$repo_root" "$helper" "$log_file" "$lock_dir" "$pid_file" >/dev/null 2>&1 &
+  fi
+}
+
 if [ "${MEMPALACE_SKIP_STARTUP_REFRESH:-}" = "1" ]; then
   echo "- Startup refresh skipped by MEMPALACE_SKIP_STARTUP_REFRESH=1."
+elif [ -d "$lock_dir" ]; then
+  refresh_pid="$(cat "$pid_file" 2>/dev/null || true)"
+  if [ -n "$refresh_pid" ] && kill -0 "$refresh_pid" 2>/dev/null; then
+    echo "- A MemPalace startup refresh is already running."
+  else
+    rm -rf "$lock_dir"
+    if mkdir "$lock_dir" 2>/dev/null; then
+      start_refresh
+      echo "- Removed a stale MemPalace startup lock and restarted refresh."
+    else
+      echo "- A MemPalace startup refresh is already running."
+    fi
+  fi
 elif mkdir "$lock_dir" 2>/dev/null; then
-  (
-    trap 'rmdir "$lock_dir" 2>/dev/null || true' EXIT
-    {
-      printf '\n[%s] startup refresh begin\n' "$(date -Is)"
-      python3 "$helper" refresh
-      printf '[%s] startup refresh end\n' "$(date -Is)"
-    } >>"$log_file" 2>&1
-  ) &
+  start_refresh
   echo "- Refreshing docs and Codex chat histories in the background."
 else
   echo "- A MemPalace startup refresh is already running."

--- a/.agents/skills/mempalace-repo/scripts/mempalace_repo.py
+++ b/.agents/skills/mempalace-repo/scripts/mempalace_repo.py
@@ -24,16 +24,31 @@ def repo_root() -> Path:
     return Path(__file__).resolve().parents[4]
 
 
-def venv_python() -> Path:
-    return repo_root() / ".venv" / "bin" / "python"
+def shared_repo_root() -> Path:
+    result = subprocess.run(
+        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        cwd=repo_root(),
+        text=True,
+        check=True,
+        capture_output=True,
+    )
+    common_dir = Path(result.stdout.strip()).resolve()
+    return common_dir.parent if common_dir.name == ".git" else repo_root()
+
+
+def mempalace_root() -> Path:
+    local_root = repo_root() / ".artifacts" / "mempalace"
+    if (local_root / "palace").exists():
+        return local_root
+    return shared_repo_root() / ".artifacts" / "mempalace"
 
 
 def palace_path() -> Path:
-    return repo_root() / ".artifacts" / "mempalace" / "palace"
+    return mempalace_root() / "palace"
 
 
 def sources_root() -> Path:
-    return repo_root() / ".artifacts" / "mempalace" / "sources"
+    return mempalace_root() / "sources"
 
 
 def docs_source_root() -> Path:
@@ -46,10 +61,6 @@ def chats_source_root() -> Path:
 
 def exports_source_root() -> Path:
     return sources_root() / "exports"
-
-
-def windows_codex_home() -> Path:
-    return Path("/mnt/c/Users/jandu/.codex")
 
 
 def _load_codex_history_module():
@@ -65,9 +76,6 @@ def _load_codex_history_module():
 
 def _candidate_codex_homes(history) -> list[Path]:
     candidates = list(history._candidate_codex_homes())
-    windows_home = windows_codex_home()
-    if windows_home.exists():
-        candidates.append(windows_home)
     unique: list[Path] = []
     seen: set[Path] = set()
     for candidate in candidates:
@@ -119,8 +127,22 @@ def _mempalace_env() -> dict[str, str]:
     return env
 
 
-def run_python_module(module: str, *args: str, capture_output: bool = False) -> subprocess.CompletedProcess[str]:
-    command = [str(venv_python()), "-m", module, *args]
+def mempalace_executable() -> str:
+    executable = os.environ.get("MEMPALACE_BIN") or shutil.which("mempalace")
+    if executable is None:
+        raise RuntimeError("Missing mempalace executable on PATH")
+    return executable
+
+
+def mempalace_mcp_executable() -> str:
+    executable = os.environ.get("MEMPALACE_MCP_BIN") or shutil.which("mempalace-mcp")
+    if executable is None:
+        raise RuntimeError("Missing mempalace-mcp executable on PATH")
+    return executable
+
+
+def run_mempalace(*args: str, capture_output: bool = False) -> subprocess.CompletedProcess[str]:
+    command = [mempalace_executable(), "--palace", str(palace_path()), *args]
     return subprocess.run(
         command,
         cwd=repo_root(),
@@ -132,10 +154,14 @@ def run_python_module(module: str, *args: str, capture_output: bool = False) -> 
 
 
 def ensure_runtime() -> None:
-    if not venv_python().exists():
-        raise RuntimeError(f"Missing repo venv python at {venv_python()}")
-    command = [str(venv_python()), "-c", "import mempalace"]
-    subprocess.run(command, cwd=repo_root(), env=_mempalace_env(), text=True, check=True)
+    subprocess.run(
+        [mempalace_executable(), "--version"],
+        cwd=repo_root(),
+        env=_mempalace_env(),
+        text=True,
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
 
 
 def _clear_directory(path: Path) -> None:
@@ -224,12 +250,11 @@ def initialize_docs_source() -> None:
     docs_root = docs_source_root()
     if (docs_root / "mempalace.yaml").exists():
         return
-    run_python_module("mempalace", "init", str(docs_root), "--yes")
+    run_mempalace("init", str(docs_root), "--yes", "--no-llm")
 
 
 def mine_docs() -> None:
-    run_python_module(
-        "mempalace",
+    run_mempalace(
         "mine",
         str(docs_source_root()),
         "--wing",
@@ -240,8 +265,7 @@ def mine_docs() -> None:
 
 
 def mine_chats() -> None:
-    run_python_module(
-        "mempalace",
+    run_mempalace(
         "mine",
         str(chats_source_root()),
         "--mode",
@@ -268,22 +292,26 @@ def refresh() -> None:
 
 def status() -> None:
     ensure_runtime()
-    run_python_module("mempalace", "status")
+    run_mempalace("status")
 
 
 def search(query: str) -> None:
     ensure_runtime()
-    run_python_module("mempalace", "search", query)
+    run_mempalace("search", query)
 
 
 def wake_up() -> None:
     ensure_runtime()
-    run_python_module("mempalace", "wake-up")
+    run_mempalace("wake-up")
 
 
 def mcp() -> None:
     ensure_runtime()
-    run_python_module("mempalace", "--palace", str(palace_path()), "mcp")
+    os.execve(
+        mempalace_mcp_executable(),
+        [mempalace_mcp_executable(), "--palace", str(palace_path())],
+        _mempalace_env(),
+    )
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,12 +1,12 @@
-# Graph Report - prml-vslam  (2026-06-07)
+# Graph Report - mempalace-upstream-wrapper-main  (2026-06-10)
 
 ## Corpus Check
-- 269 files · ~1,062,554 words
+- 270 files · ~1,062,873 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4085 nodes · 20192 edges · 30 communities detected
-- Extraction: 29% EXTRACTED · 71% INFERRED · 0% AMBIGUOUS · INFERRED: 14347 edges (avg confidence: 0.58)
+- 4036 nodes · 18734 edges · 33 communities detected
+- Extraction: 31% EXTRACTED · 69% INFERRED · 0% AMBIGUOUS · INFERRED: 12879 edges (avg confidence: 0.59)
 - Token cost: 0 input · 0 output
 
 ## Community Hubs (Navigation)
@@ -29,7 +29,6 @@
 - [[_COMMUNITY_Community 16|Community 16]]
 - [[_COMMUNITY_Community 17|Community 17]]
 - [[_COMMUNITY_Community 18|Community 18]]
-- [[_COMMUNITY_Community 19|Community 19]]
 - [[_COMMUNITY_Community 20|Community 20]]
 - [[_COMMUNITY_Community 21|Community 21]]
 - [[_COMMUNITY_Community 22|Community 22]]
@@ -40,201 +39,217 @@
 - [[_COMMUNITY_Community 27|Community 27]]
 - [[_COMMUNITY_Community 28|Community 28]]
 - [[_COMMUNITY_Community 29|Community 29]]
+- [[_COMMUNITY_Community 30|Community 30]]
+- [[_COMMUNITY_Community 31|Community 31]]
+- [[_COMMUNITY_Community 32|Community 32]]
+- [[_COMMUNITY_Community 33|Community 33]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `StageKey` - 451 edges
-2. `SequenceManifest` - 333 edges
-3. `ArtifactRef` - 287 edges
-4. `MethodId` - 276 edges
-5. `PreparedBenchmarkInputs` - 262 edges
-6. `StageRuntimeStatus` - 243 edges
-7. `PathConfig` - 240 edges
-8. `RunConfig` - 227 edges
-9. `DatasetId` - 206 edges
-10. `StageRuntimeUpdate` - 202 edges
+1. `StageKey` - 439 edges
+2. `SequenceManifest` - 309 edges
+3. `ArtifactRef` - 273 edges
+4. `MethodId` - 254 edges
+5. `PreparedBenchmarkInputs` - 236 edges
+6. `StageRuntimeStatus` - 231 edges
+7. `PathConfig` - 218 edges
+8. `RunConfig` - 193 edges
+9. `CameraIntrinsics` - 192 edges
+10. `FrameTransform` - 185 edges
 
 ## Surprising Connections (you probably didn't know these)
-- `path()` --calls--> `test_source_materialization_does_not_import_stage_package()`  [INFERRED]
-  src/prml_vslam/pipeline/sinks/jsonl.py → tests/test_package_exports.py
-- `PathConfig` --calls--> `test_path_config_is_immutable_after_construction()`  [INFERRED]
-  src/prml_vslam/utils/path_config.py → tests/test_path_config.py
-- `Console` --uses--> `Focused tests for the Rich-backed console wrapper.`  [INFERRED]
-  src/prml_vslam/utils/console.py → tests/test_console.py
-- `SequenceManifest` --uses--> `Small runtime sources used by focused pipeline smoke tests.`  [INFERRED]
-  src/prml_vslam/sources/contracts.py → tests/pipeline_testing_support.py
-- `SequenceManifest` --uses--> `Minimal offline source for pipeline smoke tests.`  [INFERRED]
-  src/prml_vslam/sources/contracts.py → tests/pipeline_testing_support.py
+- `Small runtime sources used by focused pipeline smoke tests.` --uses--> `SequenceManifest`  [INFERRED]
+  tests/pipeline_testing_support.py → src/prml_vslam/sources/contracts.py
+- `Minimal offline source for pipeline smoke tests.` --uses--> `SequenceManifest`  [INFERRED]
+  tests/pipeline_testing_support.py → src/prml_vslam/sources/contracts.py
+- `Finite in-memory packet stream for streaming smoke tests.` --uses--> `SequenceManifest`  [INFERRED]
+  tests/pipeline_testing_support.py → src/prml_vslam/sources/contracts.py
+- `Minimal streaming-capable source for pipeline smoke tests.` --uses--> `SequenceManifest`  [INFERRED]
+  tests/pipeline_testing_support.py → src/prml_vslam/sources/contracts.py
+- `test_visualization_config_rejects_invalid_decimation_values()` --calls--> `VisualizationConfig`  [INFERRED]
+  tests/test_visualization.py → src/prml_vslam/visualization/contracts.py
 
 ## Communities
 
 ### Community 0 - "Community 0"
-Cohesion: 0.02
-Nodes (462): GroundAlignmentMetadata, InputArtifactDiagnostics, Inspection helpers for persisted pipeline run artifact roots., One submitted run attempt found in a persisted event log., Structured inspection result for one persisted pipeline run., Discover method-level run roots under the configured artifact directory., Load typed metadata and path inventory for one persisted run root., One selectable persisted method-level run artifact root. (+454 more)
+Cohesion: 0.01
+Nodes (382): resolve(), _coordinator_actor_options(), BaseConfig, _ConfigFactory, FactoryConfig, from_toml(), _normalize_value(), Shared config and config-as-factory helpers for the repository.  This module own (+374 more)
 
 ### Community 1 - "Community 1"
 Cohesion: 0.01
-Nodes (475): _build_artifacts(), Write a raw ADVIO trajectory as a normalized RDF TUM artifact., write_advio_rdf_tum(), resolve_sequence_dir(), Convert an ADVIO pose CSV into a TUM trajectory file., write_advio_pose_tum(), resolve(), _apply_snapshot_fallbacks() (+467 more)
+Nodes (317): build_advio_page_data(), _scene_rows(), AdvioDownloadManager, _ensure_directory_parent(), Return the cache directory used for downloaded scene archives., Return one catalog scene by id., Return local availability status for every catalog scene., Download selected ADVIO scenes and extract the requested modalities. (+309 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.01
-Nodes (309): _ensure_uint8_rgb_from_uimg(), _estimate_camera_intrinsics_from_frame(), _InProcessManager, _InProcessValue, Mast3rSlamBackend, Mast3rSlamSession, Canonical MASt3R-SLAM backend adapter (offline + streaming).  This adapter wraps, Estimate model-raster intrinsics from a MASt3R keyframe pointmap. (+301 more)
+Nodes (321): handle_advio_preview_action(), load_advio_explorer_sample(), Controller helpers for the ADVIO Streamlit page., Persist the current ADVIO download-form state., Persist the current explorer selection and load its offline sample., Keep persisted preview state aligned with the runtime snapshot., Apply one preview-form action and return an error message when it fails., sync_advio_download_state() (+313 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.01
-Nodes (348): build_advio_page_data(), handle_advio_preview_action(), load_advio_explorer_sample(), _scene_rows(), sync_advio_download_state(), sync_advio_preview_state(), archive_member_matches(), list_local_sequence_ids() (+340 more)
+Cohesion: 0.02
+Nodes (266): ArtifactRef, Reference one materialized repository artifact by path and fingerprint., BaseStageRuntime, clean_actor_options(), put_transient_payload(), Shared Ray runtime contracts and helpers., Store one transient array payload in Ray and return backend-neutral metadata., Flatten the typed SLAM artifact bundle into the stage artifact map. (+258 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.03
-Nodes (392): Controller helpers for the ADVIO Streamlit page., Persist the current ADVIO download-form state., Persist the current explorer selection and load its offline sample., Keep persisted preview state aligned with the runtime snapshot., Apply one preview-form action and return an error message when it fails., MethodId, BaseData, AppContext (+384 more)
+Cohesion: 0.02
+Nodes (284): _build_artifacts(), _ensure_uint8_rgb_from_uimg(), _estimate_camera_intrinsics_from_frame(), _InProcessManager, _InProcessValue, Mast3rSlamBackend, Mast3rSlamSession, Canonical MASt3R-SLAM backend adapter (offline + streaming).  This adapter wraps (+276 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.02
-Nodes (267): AdvioDownloadManager, _ensure_directory_parent(), Return the cache directory used for downloaded scene archives., Return one catalog scene by id., Return local availability status for every catalog scene., Download selected ADVIO scenes and extract the requested modalities., advio_basis_metadata(), advio_basis_provenance() (+259 more)
+Nodes (322): AdvioOfflineSample, AdvioSequencePaths, Build one sequence runtime from its validated config., Materialize benchmark-owned reference trajectories for one sequence., Emit a GT-aligned variant of one optional reference so it overlays GT.      Uses, GroundAlignmentMetadata, GroundPlaneModel, GroundPlaneVisualizationHint (+314 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.01
-Nodes (258): GroundPlaneModel, GroundPlaneVisualizationHint, Alignment result DTOs shared outside the alignment package.  These datamodels de, Dominant ground-plane hypothesis expressed in native ``world`` coordinates., Finite plane-patch geometry ready for visualization consumers., Result of one derived ground-plane alignment attempt.      When :attr:`applied`, _frame_transform_from_vista_pose(), Normalize one upstream ViSTA pose matrix into the canonical repo transform DTO. (+250 more)
+Cohesion: 0.03
+Nodes (285): InputArtifactDiagnostics, Inspection helpers for persisted pipeline run artifact roots., One submitted run attempt found in a persisted event log., Structured inspection result for one persisted pipeline run., Discover method-level run roots under the configured artifact directory., Load typed metadata and path inventory for one persisted run root., One selectable persisted method-level run artifact root., Shallow diagnostics for materialized offline input artifacts. (+277 more)
 
 ### Community 7 - "Community 7"
 Cohesion: 0.02
-Nodes (186): build_advio_comparison_trajectories(), build_crowd_density_figure(), build_local_readiness_figure(), build_scene_attribute_figure(), build_scene_mix_figure(), Plotly figure builders for the ADVIO dataset page., Build a crowd-density composition chart., Build a scene-attribute prevalence chart. (+178 more)
+Nodes (189): artifact_ref(), artifact_visualizations(), _entity_token(), observation_sequence_artifact_key(), Build one stable artifact reference for a materialized path., Return neutral visualization items for completed durable artifacts., reference_cloud_artifact_key(), reference_cloud_metadata_artifact_key() (+181 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.03
-Nodes (141): BaseConfig, _advio_native_fps(), CloudAlignmentStageConfig, CloudEvaluationStageConfig, CloudMetricId, _collect_unknown_field_warnings(), _compile_run_plan(), config_warnings() (+133 more)
+Cohesion: 0.02
+Nodes (173): build_advio_comparison_trajectories(), build_crowd_density_figure(), build_local_readiness_figure(), build_scene_attribute_figure(), build_scene_mix_figure(), Plotly figure builders for the ADVIO dataset page., Build a crowd-density composition chart., Build a scene-attribute prevalence chart. (+165 more)
 
 ### Community 9 - "Community 9"
 Cohesion: 0.03
-Nodes (73): extract_pose_position(), _measure_fps(), PacketSessionMetrics, PacketSessionRuntime, _positions_to_array(), Return packet-rate snapshot fields., Return backend-keyframe snapshot fields., Return the current metrics in snapshot-ready form. (+65 more)
+Nodes (127): BaseConfig, _advio_native_fps(), CloudAlignmentStageConfig, CloudEvaluationStageConfig, CloudMetricId, _collect_unknown_field_warnings(), _compile_run_plan(), DenseCloudSelectionConfig (+119 more)
 
 ### Community 10 - "Community 10"
+Cohesion: 0.03
+Nodes (110): ArxivSourceSpec, download_file(), fetch_pdf(), fetch_tex_source(), from_json(), load_manifest(), main(), normalize_member_path() (+102 more)
+
+### Community 11 - "Community 11"
+Cohesion: 0.05
+Nodes (82): _coerce_view_graph(), _coerce_view_graph_node(), load_vista_confidences(), load_vista_estimated_intrinsics_series(), load_vista_intrinsics_matrices(), load_vista_native_trajectory(), load_vista_vector(), load_vista_view_graph() (+74 more)
+
+### Community 12 - "Community 12"
 Cohesion: 0.07
 Nodes (34): Replay clock used by dataset and video source streams., Select whether replay follows source timing or returns observations immediately., Apply source-timestamp pacing for real-time replay., Reset the clock baseline for a new replay loop or connection., Sleep until the replay timestamp should be emitted., ReplayClock, ReplayMode, ImageSequenceObservationSource (+26 more)
 
-### Community 11 - "Community 11"
-Cohesion: 0.08
-Nodes (48): validate_modalities(), iter_sequence_manifest_observations(), _load_manifest_rgb_inputs(), _load_rgb(), _load_timestamps_ns(), _manifest_provenance(), Source-owned readers for normalized offline observations., Yield RGB observations from a normalized source sequence manifest. (+40 more)
-
-### Community 12 - "Community 12"
-Cohesion: 0.1
-Nodes (38): build_pipeline_snapshot_render_model(), _coerce_int_metric(), _compute_evo_preview(), _format_latency(), _format_optional_rate(), _format_queue(), _format_resources(), _format_tasks() (+30 more)
-
 ### Community 13 - "Community 13"
+Cohesion: 0.12
+Nodes (38): Tests for repo-owned Rerun validation helpers., test_load_recording_summary_reports_live_keyed_and_tracking_surfaces(), test_write_validation_bundle_emits_report_and_projection_images(), test_write_validation_bundle_respects_explicit_keyed_cloud_limit(), _write_synthetic_recording(), _ancestor_entity_paths(), _component_columns(), _keyed_point_cloud_snapshots() (+30 more)
+
+### Community 14 - "Community 14"
+Cohesion: 0.12
+Nodes (34): build_pipeline_snapshot_render_model(), _coerce_int_metric(), _compute_evo_preview(), _format_latency(), _format_optional_rate(), _format_queue(), _format_resources(), _format_tasks() (+26 more)
+
+### Community 15 - "Community 15"
 Cohesion: 0.1
 Nodes (21): caller_namespace(), configure_logging(), _ConsoleLogFormatter, _ConsoleLogHighlighter, _display_name(), from_callsite(), get_console(), _qualify_namespace() (+13 more)
 
-### Community 14 - "Community 14"
+### Community 16 - "Community 16"
 Cohesion: 0.17
 Nodes (2): Tests for package-root public export surfaces., test_source_materialization_does_not_import_stage_package()
 
-### Community 15 - "Community 15"
+### Community 17 - "Community 17"
+Cohesion: 0.25
+Nodes (8): _load_depth(), load_observation_sequence_index(), _load_rgb(), Source-owned file-backed observation sequence loading.  The source reads durable, Yield observations by resolving payload paths from the sequence ref.          RG, Load and validate one durable observation sequence index.      The JSON payload, _resolve_payload(), _validate_index_matches_ref()
+
+### Community 18 - "Community 18"
 Cohesion: 0.36
 Nodes (4): test_resolve_issue_moves_record_to_resolved_collection(), test_resolve_refactor_moves_record_to_resolved_collection(), test_resolve_todo_moves_record_to_resolved_collection(), _write_toml()
 
-### Community 16 - "Community 16"
+### Community 20 - "Community 20"
 Cohesion: 1.0
 Nodes (1): Thin Streamlit entrypoint for the PRML VSLAM workbench scaffold.  The file stays
 
-### Community 17 - "Community 17"
+### Community 21 - "Community 21"
 Cohesion: 1.0
 Nodes (1): Ray-specific helpers for future stage runtime deployment.  This module intention
 
-### Community 18 - "Community 18"
-Cohesion: 1.0
-Nodes (1): Return the human-readable label shown in plan previews.
-
-### Community 19 - "Community 19"
-Cohesion: 1.0
-Nodes (1): Return whether ``exc`` looks like a transient local Ray connection failure.
-
-### Community 20 - "Community 20"
-Cohesion: 1.0
-Nodes (1): Deserialize one IPC payload back into the target validated model type.
-
-### Community 21 - "Community 21"
-Cohesion: 1.0
-Nodes (1): Return the compact source label used in logs and diagnostics.
-
 ### Community 22 - "Community 22"
-Cohesion: 1.0
-Nodes (1): Return the short user-facing dataset label.
-
-### Community 23 - "Community 23"
-Cohesion: 1.0
-Nodes (1): Connect to the source and prepare subsequent blocking observation reads.
-
-### Community 24 - "Community 24"
-Cohesion: 1.0
-Nodes (1): Disconnect or release the source and any owned runtime resources.
-
-### Community 25 - "Community 25"
 Cohesion: 1.0
 Nodes (1): Build the shared transform DTO from XYZW quaternion and XYZ translation arrays.
 
-### Community 26 - "Community 26"
+### Community 23 - "Community 23"
 Cohesion: 1.0
 Nodes (1): Build the shared transform DTO from a 4x4 homogeneous matrix.
 
+### Community 24 - "Community 24"
+Cohesion: 1.0
+Nodes (1): Return the compact source label used in logs and diagnostics.
+
+### Community 25 - "Community 25"
+Cohesion: 1.0
+Nodes (1): Connect to the source and prepare subsequent blocking observation reads.
+
+### Community 26 - "Community 26"
+Cohesion: 1.0
+Nodes (1): Disconnect or release the source and any owned runtime resources.
+
 ### Community 27 - "Community 27"
 Cohesion: 1.0
-Nodes (1): Build one spec from one JSON object.
+Nodes (1): Return the short user-facing dataset label.
 
 ### Community 28 - "Community 28"
 Cohesion: 1.0
-Nodes (1): Return the net code-line delta.
+Nodes (1): Deserialize one IPC payload back into the target validated model type.
 
 ### Community 29 - "Community 29"
+Cohesion: 1.0
+Nodes (1): Return the human-readable label shown in plan previews.
+
+### Community 30 - "Community 30"
+Cohesion: 1.0
+Nodes (1): Return whether ``exc`` looks like a transient local Ray connection failure.
+
+### Community 31 - "Community 31"
+Cohesion: 1.0
+Nodes (1): Build one spec from one JSON object.
+
+### Community 32 - "Community 32"
+Cohesion: 1.0
+Nodes (1): Return the net code-line delta.
+
+### Community 33 - "Community 33"
 Cohesion: 1.0
 Nodes (1): Return the path that should own this change in reports.
 
 ## Knowledge Gaps
-- **238 isolated node(s):** `Thin Streamlit entrypoint for the PRML VSLAM workbench scaffold.  The file stays`, `Frame preprocessing helpers for ViSTA-SLAM.`, `One RGB frame prepared for upstream ViSTA ingestion.`, `Use the exact upstream ViSTA crop-and-resize helper path.`, `Convert one upstream ViSTA array-like payload into a numpy array.` (+233 more)
+- **239 isolated node(s):** `Thin Streamlit entrypoint for the PRML VSLAM workbench scaffold.  The file stays`, `Frame preprocessing helpers for ViSTA-SLAM.`, `One RGB frame prepared for upstream ViSTA ingestion.`, `Use the exact upstream ViSTA crop-and-resize helper path.`, `Convert one upstream ViSTA array-like payload into a numpy array.` (+234 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 14`** (12 nodes): `test_package_exports.py`, `Tests for package-root public export surfaces.`, `test_executable_stage_packages_export_canonical_surfaces()`, `test_interfaces_package_exports_only_canonical_pose_surface()`, `test_methods_package_exports_slam_surfaces()`, `test_pipeline_contracts_package_is_not_a_compatibility_hub()`, `test_pipeline_package_exports_only_minimal_public_surface()`, `test_reconstruction_package_exports_runtime_surfaces_without_harness()`, `test_replay_package_exports_only_replay_primitives()`, `test_source_materialization_does_not_import_stage_package()`, `test_sources_package_exports_source_owned_contracts()`, `test_vista_package_is_the_only_canonical_vista_surface()`
+- **Thin community `Community 16`** (12 nodes): `test_package_exports.py`, `Tests for package-root public export surfaces.`, `test_executable_stage_packages_export_canonical_surfaces()`, `test_interfaces_package_exports_only_canonical_pose_surface()`, `test_methods_package_exports_slam_surfaces()`, `test_pipeline_contracts_package_is_not_a_compatibility_hub()`, `test_pipeline_package_exports_only_minimal_public_surface()`, `test_reconstruction_package_exports_runtime_surfaces_without_harness()`, `test_replay_package_exports_only_replay_primitives()`, `test_source_materialization_does_not_import_stage_package()`, `test_sources_package_exports_source_owned_contracts()`, `test_vista_package_is_the_only_canonical_vista_surface()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 16`** (2 nodes): `streamlit_app.py`, `Thin Streamlit entrypoint for the PRML VSLAM workbench scaffold.  The file stays`
+- **Thin community `Community 20`** (2 nodes): `streamlit_app.py`, `Thin Streamlit entrypoint for the PRML VSLAM workbench scaffold.  The file stays`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 17`** (2 nodes): `ray.py`, `Ray-specific helpers for future stage runtime deployment.  This module intention`
+- **Thin community `Community 21`** (2 nodes): `ray.py`, `Ray-specific helpers for future stage runtime deployment.  This module intention`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 18`** (1 nodes): `Return the human-readable label shown in plan previews.`
+- **Thin community `Community 22`** (1 nodes): `Build the shared transform DTO from XYZW quaternion and XYZ translation arrays.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 19`** (1 nodes): `Return whether ``exc`` looks like a transient local Ray connection failure.`
+- **Thin community `Community 23`** (1 nodes): `Build the shared transform DTO from a 4x4 homogeneous matrix.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 20`** (1 nodes): `Deserialize one IPC payload back into the target validated model type.`
+- **Thin community `Community 24`** (1 nodes): `Return the compact source label used in logs and diagnostics.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 21`** (1 nodes): `Return the compact source label used in logs and diagnostics.`
+- **Thin community `Community 25`** (1 nodes): `Connect to the source and prepare subsequent blocking observation reads.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 22`** (1 nodes): `Return the short user-facing dataset label.`
+- **Thin community `Community 26`** (1 nodes): `Disconnect or release the source and any owned runtime resources.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 23`** (1 nodes): `Connect to the source and prepare subsequent blocking observation reads.`
+- **Thin community `Community 27`** (1 nodes): `Return the short user-facing dataset label.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 24`** (1 nodes): `Disconnect or release the source and any owned runtime resources.`
+- **Thin community `Community 28`** (1 nodes): `Deserialize one IPC payload back into the target validated model type.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 25`** (1 nodes): `Build the shared transform DTO from XYZW quaternion and XYZ translation arrays.`
+- **Thin community `Community 29`** (1 nodes): `Return the human-readable label shown in plan previews.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 26`** (1 nodes): `Build the shared transform DTO from a 4x4 homogeneous matrix.`
+- **Thin community `Community 30`** (1 nodes): `Return whether ``exc`` looks like a transient local Ray connection failure.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 27`** (1 nodes): `Build one spec from one JSON object.`
+- **Thin community `Community 31`** (1 nodes): `Build one spec from one JSON object.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 28`** (1 nodes): `Return the net code-line delta.`
+- **Thin community `Community 32`** (1 nodes): `Return the net code-line delta.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 29`** (1 nodes): `Return the path that should own this change in reports.`
+- **Thin community `Community 33`** (1 nodes): `Return the path that should own this change in reports.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `Test package helpers and suites for PRML VSLAM.` connect `Community 5` to `Community 0`, `Community 1`, `Community 2`, `Community 3`, `Community 4`, `Community 6`, `Community 7`, `Community 8`, `Community 10`?**
-  _High betweenness centrality (0.130) - this node is a cross-community bridge._
-- **Why does `StageKey` connect `Community 0` to `Community 1`, `Community 2`, `Community 4`, `Community 5`, `Community 6`, `Community 8`?**
-  _High betweenness centrality (0.079) - this node is a cross-community bridge._
-- **Why does `SequenceManifest` connect `Community 2` to `Community 0`, `Community 1`, `Community 3`, `Community 4`, `Community 5`, `Community 6`, `Community 8`, `Community 11`?**
-  _High betweenness centrality (0.067) - this node is a cross-community bridge._
-- **Are the 448 inferred relationships involving `StageKey` (e.g. with `RunConfigOverrideCommand` and `_RerunViewerProcess`) actually correct?**
-  _`StageKey` has 448 INFERRED edges - model-reasoned connections that need verification._
-- **Are the 330 inferred relationships involving `SequenceManifest` (e.g. with `OfflineSlamBackend` and `StreamingSlamBackend`) actually correct?**
-  _`SequenceManifest` has 330 INFERRED edges - model-reasoned connections that need verification._
-- **Are the 283 inferred relationships involving `ArtifactRef` (e.g. with `SlamUpdate` and `SlamArtifacts`) actually correct?**
-  _`ArtifactRef` has 283 INFERRED edges - model-reasoned connections that need verification._
-- **Are the 273 inferred relationships involving `MethodId` (e.g. with `RunConfigOverrideCommand` and `_RerunViewerProcess`) actually correct?**
-  _`MethodId` has 273 INFERRED edges - model-reasoned connections that need verification._
+- **Why does `Test package helpers and suites for PRML VSLAM.` connect `Community 1` to `Community 0`, `Community 2`, `Community 3`, `Community 4`, `Community 5`, `Community 6`, `Community 8`, `Community 9`, `Community 11`, `Community 12`?**
+  _High betweenness centrality (0.107) - this node is a cross-community bridge._
+- **Why does `StageKey` connect `Community 6` to `Community 0`, `Community 1`, `Community 2`, `Community 3`, `Community 4`, `Community 5`, `Community 7`, `Community 9`, `Community 13`?**
+  _High betweenness centrality (0.073) - this node is a cross-community bridge._
+- **Why does `FrameTransform` connect `Community 5` to `Community 0`, `Community 1`, `Community 2`, `Community 3`, `Community 4`, `Community 6`, `Community 7`, `Community 8`, `Community 9`, `Community 11`, `Community 13`?**
+  _High betweenness centrality (0.071) - this node is a cross-community bridge._
+- **Are the 436 inferred relationships involving `StageKey` (e.g. with `RunConfigOverrideCommand` and `_RerunViewerProcess`) actually correct?**
+  _`StageKey` has 436 INFERRED edges - model-reasoned connections that need verification._
+- **Are the 306 inferred relationships involving `SequenceManifest` (e.g. with `OfflineSlamBackend` and `StreamingSlamBackend`) actually correct?**
+  _`SequenceManifest` has 306 INFERRED edges - model-reasoned connections that need verification._
+- **Are the 269 inferred relationships involving `ArtifactRef` (e.g. with `SlamUpdate` and `SlamArtifacts`) actually correct?**
+  _`ArtifactRef` has 269 INFERRED edges - model-reasoned connections that need verification._
+- **Are the 251 inferred relationships involving `MethodId` (e.g. with `RunConfigOverrideCommand` and `_RerunViewerProcess`) actually correct?**
+  _`MethodId` has 251 INFERRED edges - model-reasoned connections that need verification._

--- a/graphify-out/graph.html
+++ b/graphify-out/graph.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d278487661fac648c53690483156ee8b1529c9baba533245c8f1e60a203cc79d
-size 6433540
+oid sha256:bac7bfb2b7394e9add42604434578020d27dbed5fa8e883e2f7bc634ad081873
+size 6193217

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ced7f509c765a1ac08f5665c88d223389b66f9b288ceefa677eac3d82a7b02f4
-size 10081529
+oid sha256:a338484f6b32b8827e2881f62bff230f13c3371a2c7c658bc866b102d8572d01
+size 9635591

--- a/tests/test_mempalace_repo.py
+++ b/tests/test_mempalace_repo.py
@@ -1,0 +1,131 @@
+"""Tests for the repo-local MemPalace wrapper."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_mempalace_repo_module() -> Any:
+    module_path = (
+        Path(__file__).resolve().parents[1] / ".agents" / "skills" / "mempalace-repo" / "scripts" / "mempalace_repo.py"
+    )
+    spec = importlib.util.spec_from_file_location("mempalace_repo", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_mempalace_executable_prefers_environment_override(monkeypatch) -> None:
+    mempalace_repo = _load_mempalace_repo_module()
+    monkeypatch.setenv("MEMPALACE_BIN", "/opt/bin/mempalace")
+
+    assert mempalace_repo.mempalace_executable() == "/opt/bin/mempalace"
+
+
+def test_run_mempalace_uses_cli_and_explicit_repo_palace(monkeypatch) -> None:
+    mempalace_repo = _load_mempalace_repo_module()
+    palace_path = Path("/repo/.artifacts/mempalace/palace")
+    monkeypatch.setenv("MEMPALACE_BIN", "/opt/bin/mempalace")
+    monkeypatch.setattr(mempalace_repo, "palace_path", lambda: palace_path)
+    calls = []
+
+    def fake_run(command, cwd, env, text, check, capture_output=False, stdout=None):
+        calls.append(
+            {
+                "command": command,
+                "cwd": cwd,
+                "env": env,
+                "text": text,
+                "check": check,
+                "capture_output": capture_output,
+                "stdout": stdout,
+            }
+        )
+        return subprocess.CompletedProcess(command, 0)
+
+    monkeypatch.setattr(mempalace_repo.subprocess, "run", fake_run)
+
+    mempalace_repo.run_mempalace("search", "pipeline DTO", capture_output=True)
+
+    assert calls == [
+        {
+            "command": [
+                "/opt/bin/mempalace",
+                "--palace",
+                str(palace_path),
+                "search",
+                "pipeline DTO",
+            ],
+            "cwd": mempalace_repo.repo_root(),
+            "env": {
+                **os.environ,
+                "MEMPALACE_BIN": "/opt/bin/mempalace",
+                "MEMPALACE_PALACE_PATH": str(palace_path),
+            },
+            "text": True,
+            "check": True,
+            "capture_output": True,
+            "stdout": None,
+        }
+    ]
+
+
+def test_mcp_execs_mempalace_mcp_with_explicit_repo_palace(monkeypatch) -> None:
+    mempalace_repo = _load_mempalace_repo_module()
+    palace_path = Path("/repo/.artifacts/mempalace/palace")
+    monkeypatch.setenv("MEMPALACE_BIN", "/opt/bin/mempalace")
+    monkeypatch.setenv("MEMPALACE_MCP_BIN", "/opt/bin/mempalace-mcp")
+    monkeypatch.setattr(mempalace_repo, "palace_path", lambda: palace_path)
+    commands = []
+    exec_calls = []
+
+    def fake_run(command, cwd, env, text, check, capture_output=False, stdout=None):
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0)
+
+    def fake_execve(path, argv, env):
+        exec_calls.append((path, argv, env))
+        raise SystemExit(0)
+
+    monkeypatch.setattr(mempalace_repo.subprocess, "run", fake_run)
+    monkeypatch.setattr(mempalace_repo.os, "execve", fake_execve)
+
+    try:
+        mempalace_repo.mcp()
+    except SystemExit as exc:
+        assert exc.code == 0
+
+    assert commands == [["/opt/bin/mempalace", "--version"]]
+    assert exec_calls == [
+        (
+            "/opt/bin/mempalace-mcp",
+            ["/opt/bin/mempalace-mcp", "--palace", str(palace_path)],
+            {
+                **os.environ,
+                "MEMPALACE_BIN": "/opt/bin/mempalace",
+                "MEMPALACE_MCP_BIN": "/opt/bin/mempalace-mcp",
+                "MEMPALACE_PALACE_PATH": str(palace_path),
+            },
+        )
+    ]
+
+
+def test_worktree_without_local_palace_uses_shared_repo_root(monkeypatch, tmp_path) -> None:
+    mempalace_repo = _load_mempalace_repo_module()
+    shared_root = tmp_path / "main"
+    worktree_root = tmp_path / "worktree"
+    shared_root.mkdir()
+    worktree_root.mkdir()
+    (shared_root / ".artifacts" / "mempalace" / "palace").mkdir(parents=True)
+
+    monkeypatch.setattr(mempalace_repo, "repo_root", lambda: worktree_root)
+    monkeypatch.setattr(mempalace_repo, "shared_repo_root", lambda: shared_root)
+
+    assert mempalace_repo.mempalace_root() == shared_root / ".artifacts" / "mempalace"


### PR DESCRIPTION
## Summary
This PR restores the repo-local MemPalace integration on a clean `origin/main` branch by moving the helper off the PRML VSLAM shared virtualenv and onto the upstream CLI/MCP entrypoints. The wrapper now pins the repo palace with `mempalace --palace ...`, starts the MCP server with `mempalace-mcp --palace ...`, shares the main checkout palace from linked worktrees, and hardens the startup hook so stale refresh locks do not suppress wake-up context.

Focused verification completed:
- `bash -n .agents/scripts/mempalace_startup_context.sh`
- `python3 -m py_compile .agents/skills/mempalace-repo/scripts/mempalace_repo.py tests/test_mempalace_repo.py`
- `prml-vslam-worktree-env uv run --extra dev pytest tests/test_mempalace_repo.py -q`
- `prml-vslam-worktree-env uv run --extra dev ruff check tests/test_mempalace_repo.py .agents/skills/mempalace-repo/scripts/mempalace_repo.py`
- `prml-vslam-worktree-env uv run --extra dev ruff format --check tests/test_mempalace_repo.py .agents/skills/mempalace-repo/scripts/mempalace_repo.py`
- `python3 .agents/skills/mempalace-repo/scripts/mempalace_repo.py status`
- `timeout 2s python3 .agents/skills/mempalace-repo/scripts/mempalace_repo.py mcp`
- `bash .agents/scripts/mempalace_startup_context.sh`
- `make graphify-rebuild`
- `git diff --check origin/main...HEAD`

## Work Packages
| WP | Scope | Primary surfaces | Status |
| --- | --- | --- | --- |
| WP1 | MemPalace CLI/MCP wrapper | `.agents/skills/mempalace-repo/scripts/mempalace_repo.py`, `tests/test_mempalace_repo.py` | resolved |
| WP2 | Startup refresh resilience | `.agents/scripts/mempalace_startup_context.sh` | resolved |
| WP3 | Regression and graph artifacts | `tests/test_mempalace_repo.py`, `graphify-out/*` | resolved |

## WP1 — MemPalace CLI/MCP Wrapper
### Scope
- Replaced the repo-venv import check and `python -m mempalace` invocation path with direct `mempalace --palace ...` CLI calls.
- Switched MCP startup to execute `mempalace-mcp --palace ...`, matching the upstream MCP server entrypoint instead of printing setup guidance.
- Added executable env overrides for `MEMPALACE_BIN` and `MEMPALACE_MCP_BIN` while preserving the repo-local palace environment.
- Added linked-worktree palace resolution so worktrees without their own `.artifacts/mempalace/palace` use the shared main checkout palace.

### Key files
- `.agents/skills/mempalace-repo/scripts/mempalace_repo.py`
- `tests/test_mempalace_repo.py`

### API/path mapping
- Old helper runtime check: `.venv/bin/python -c "import mempalace"`
- New helper runtime check: `mempalace --version`
- Old CLI command shape: `.venv/bin/python -m mempalace ...`
- New CLI command shape: `mempalace --palace <repo-palace> ...`
- Old MCP path: `mempalace --palace <repo-palace> mcp`
- New MCP path: `mempalace-mcp --palace <repo-palace>`

### Initial success criteria resolution
- `helper no longer depends on repo venv importing mempalace`: resolved
- `helper pins repo-local palace instead of global palace`: resolved
- `MCP server uses upstream server command`: resolved
- `linked worktrees can reuse shared palace`: resolved

## WP2 — Startup Refresh Resilience
### Scope
- Added PID tracking to the startup refresh lock so live background refreshes and stale locks are distinguishable.
- Detached refresh execution with `setsid` when available, falling back to `nohup` where needed.
- Preserved immediate wake-up output while refresh continues in the background.
- Added stale-lock recovery so a dead refresh no longer blocks future startup refreshes.

### Key files
- `.agents/scripts/mempalace_startup_context.sh`

### Initial success criteria resolution
- `startup hook still prints wake-up context`: resolved
- `stale startup lock does not permanently block refresh`: resolved
- `active refresh is not duplicated`: resolved

## WP3 — Regression And Graph Artifacts
### Scope
- Restored focused tests for the repo-local MemPalace helper contract.
- Covered env override behavior, explicit `--palace` command construction, `mempalace-mcp` execution, and linked-worktree shared palace fallback.
- Refreshed tracked graphify artifacts after the code change.

### Key files
- `tests/test_mempalace_repo.py`
- `graphify-out/GRAPH_REPORT.md`
- `graphify-out/graph.html`
- `graphify-out/graph.json`

### Initial success criteria resolution
- `wrapper command contracts are covered by regression tests`: resolved
- `graphify artifacts are current for the branch`: resolved
