### PR TITLE
Add offline benchmark experiment scaffold

### DIFF
--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,12 +1,12 @@
-# Graph Report - prml-vslam  (2026-06-07)
+# Graph Report - benchmark-experiments  (2026-06-10)
 
 ## Corpus Check
-- 269 files · ~1,062,554 words
+- 277 files · ~1,066,078 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4085 nodes · 20192 edges · 30 communities detected
-- Extraction: 29% EXTRACTED · 71% INFERRED · 0% AMBIGUOUS · INFERRED: 14347 edges (avg confidence: 0.58)
+- 4143 nodes · 19217 edges · 35 communities detected
+- Extraction: 31% EXTRACTED · 69% INFERRED · 0% AMBIGUOUS · INFERRED: 13198 edges (avg confidence: 0.59)
 - Token cost: 0 input · 0 output
 
 ## Community Hubs (Navigation)
@@ -30,8 +30,6 @@
 - [[_COMMUNITY_Community 17|Community 17]]
 - [[_COMMUNITY_Community 18|Community 18]]
 - [[_COMMUNITY_Community 19|Community 19]]
-- [[_COMMUNITY_Community 20|Community 20]]
-- [[_COMMUNITY_Community 21|Community 21]]
 - [[_COMMUNITY_Community 22|Community 22]]
 - [[_COMMUNITY_Community 23|Community 23]]
 - [[_COMMUNITY_Community 24|Community 24]]
@@ -40,132 +38,131 @@
 - [[_COMMUNITY_Community 27|Community 27]]
 - [[_COMMUNITY_Community 28|Community 28]]
 - [[_COMMUNITY_Community 29|Community 29]]
+- [[_COMMUNITY_Community 30|Community 30]]
+- [[_COMMUNITY_Community 31|Community 31]]
+- [[_COMMUNITY_Community 32|Community 32]]
+- [[_COMMUNITY_Community 33|Community 33]]
+- [[_COMMUNITY_Community 34|Community 34]]
+- [[_COMMUNITY_Community 35|Community 35]]
+- [[_COMMUNITY_Community 36|Community 36]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `StageKey` - 451 edges
-2. `SequenceManifest` - 333 edges
-3. `ArtifactRef` - 287 edges
-4. `MethodId` - 276 edges
-5. `PreparedBenchmarkInputs` - 262 edges
-6. `StageRuntimeStatus` - 243 edges
-7. `PathConfig` - 240 edges
-8. `RunConfig` - 227 edges
-9. `DatasetId` - 206 edges
-10. `StageRuntimeUpdate` - 202 edges
+1. `StageKey` - 445 edges
+2. `SequenceManifest` - 309 edges
+3. `ArtifactRef` - 273 edges
+4. `MethodId` - 260 edges
+5. `PreparedBenchmarkInputs` - 236 edges
+6. `PathConfig` - 234 edges
+7. `StageRuntimeStatus` - 231 edges
+8. `RunConfig` - 220 edges
+9. `CameraIntrinsics` - 192 edges
+10. `RunSnapshot` - 190 edges
 
 ## Surprising Connections (you probably didn't know these)
-- `path()` --calls--> `test_source_materialization_does_not_import_stage_package()`  [INFERRED]
-  src/prml_vslam/pipeline/sinks/jsonl.py → tests/test_package_exports.py
-- `PathConfig` --calls--> `test_path_config_is_immutable_after_construction()`  [INFERRED]
-  src/prml_vslam/utils/path_config.py → tests/test_path_config.py
-- `Console` --uses--> `Focused tests for the Rich-backed console wrapper.`  [INFERRED]
-  src/prml_vslam/utils/console.py → tests/test_console.py
-- `SequenceManifest` --uses--> `Small runtime sources used by focused pipeline smoke tests.`  [INFERRED]
-  src/prml_vslam/sources/contracts.py → tests/pipeline_testing_support.py
-- `SequenceManifest` --uses--> `Minimal offline source for pipeline smoke tests.`  [INFERRED]
-  src/prml_vslam/sources/contracts.py → tests/pipeline_testing_support.py
+- `Focused tests for derived ground-plane alignment.` --uses--> `GroundAlignmentMetadata`  [INFERRED]
+  tests/test_ground_alignment.py → src/prml_vslam/interfaces/alignment.py
+- `Small runtime sources used by focused pipeline smoke tests.` --uses--> `SequenceManifest`  [INFERRED]
+  tests/pipeline_testing_support.py → src/prml_vslam/sources/contracts.py
+- `Minimal offline source for pipeline smoke tests.` --uses--> `SequenceManifest`  [INFERRED]
+  tests/pipeline_testing_support.py → src/prml_vslam/sources/contracts.py
+- `Finite in-memory packet stream for streaming smoke tests.` --uses--> `SequenceManifest`  [INFERRED]
+  tests/pipeline_testing_support.py → src/prml_vslam/sources/contracts.py
+- `Minimal streaming-capable source for pipeline smoke tests.` --uses--> `SequenceManifest`  [INFERRED]
+  tests/pipeline_testing_support.py → src/prml_vslam/sources/contracts.py
 
 ## Communities
 
 ### Community 0 - "Community 0"
 Cohesion: 0.02
-Nodes (462): GroundAlignmentMetadata, InputArtifactDiagnostics, Inspection helpers for persisted pipeline run artifact roots., One submitted run attempt found in a persisted event log., Structured inspection result for one persisted pipeline run., Discover method-level run roots under the configured artifact directory., Load typed metadata and path inventory for one persisted run root., One selectable persisted method-level run artifact root. (+454 more)
+Nodes (383): GroundAlignmentMetadata, InputArtifactDiagnostics, Inspection helpers for persisted pipeline run artifact roots., One submitted run attempt found in a persisted event log., Structured inspection result for one persisted pipeline run., Discover method-level run roots under the configured artifact directory., Load typed metadata and path inventory for one persisted run root., One selectable persisted method-level run artifact root. (+375 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.01
-Nodes (475): _build_artifacts(), Write a raw ADVIO trajectory as a normalized RDF TUM artifact., write_advio_rdf_tum(), resolve_sequence_dir(), Convert an ADVIO pose CSV into a TUM trajectory file., write_advio_pose_tum(), resolve(), _apply_snapshot_fallbacks() (+467 more)
+Cohesion: 0.02
+Nodes (316): ArtifactRef, Reference one materialized repository artifact by path and fingerprint., BaseStageRuntime, clean_actor_options(), put_transient_payload(), Shared Ray runtime contracts and helpers., Return the stable Ray actor name for one pipeline run., Store one transient array payload in Ray and return backend-neutral metadata. (+308 more)
 
 ### Community 2 - "Community 2"
 Cohesion: 0.01
-Nodes (309): _ensure_uint8_rgb_from_uimg(), _estimate_camera_intrinsics_from_frame(), _InProcessManager, _InProcessValue, Mast3rSlamBackend, Mast3rSlamSession, Canonical MASt3R-SLAM backend adapter (offline + streaming).  This adapter wraps, Estimate model-raster intrinsics from a MASt3R keyframe pointmap. (+301 more)
+Nodes (317): AdvioDownloadManager, _ensure_directory_parent(), Return the cache directory used for downloaded scene archives., Return one catalog scene by id., Return local availability status for every catalog scene., Download selected ADVIO scenes and extract the requested modalities., advio_basis_metadata(), advio_basis_provenance() (+309 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.01
-Nodes (348): build_advio_page_data(), handle_advio_preview_action(), load_advio_explorer_sample(), _scene_rows(), sync_advio_download_state(), sync_advio_preview_state(), archive_member_matches(), list_local_sequence_ids() (+340 more)
+Cohesion: 0.02
+Nodes (255): validate_modalities(), resolve(), _coordinator_actor_options(), RayPipelineBackend, Serialize the config to deterministic TOML and optionally persist it., _enter_page(), coordinator_actor_name(), _advio_native_fps() (+247 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.03
-Nodes (392): Controller helpers for the ADVIO Streamlit page., Persist the current ADVIO download-form state., Persist the current explorer selection and load its offline sample., Keep persisted preview state aligned with the runtime snapshot., Apply one preview-form action and return an error message when it fails., MethodId, BaseData, AppContext (+384 more)
+Cohesion: 0.02
+Nodes (265): GroundPlaneModel, GroundPlaneVisualizationHint, Alignment result DTOs shared outside the alignment package.  These datamodels de, Dominant ground-plane hypothesis expressed in native ``world`` coordinates., Finite plane-patch geometry ready for visualization consumers., Result of one derived ground-plane alignment attempt.      When :attr:`applied`, artifact_ref(), artifact_visualizations() (+257 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.02
-Nodes (267): AdvioDownloadManager, _ensure_directory_parent(), Return the cache directory used for downloaded scene archives., Return one catalog scene by id., Return local availability status for every catalog scene., Download selected ADVIO scenes and extract the requested modalities., advio_basis_metadata(), advio_basis_provenance() (+259 more)
+Nodes (225): _build_artifacts(), _ensure_uint8_rgb_from_uimg(), _estimate_camera_intrinsics_from_frame(), _InProcessManager, _InProcessValue, Mast3rSlamBackend, Mast3rSlamSession, Canonical MASt3R-SLAM backend adapter (offline + streaming).  This adapter wraps (+217 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.01
-Nodes (258): GroundPlaneModel, GroundPlaneVisualizationHint, Alignment result DTOs shared outside the alignment package.  These datamodels de, Dominant ground-plane hypothesis expressed in native ``world`` coordinates., Finite plane-patch geometry ready for visualization consumers., Result of one derived ground-plane alignment attempt.      When :attr:`applied`, _frame_transform_from_vista_pose(), Normalize one upstream ViSTA pose matrix into the canonical repo transform DTO. (+250 more)
+Cohesion: 0.02
+Nodes (256): build_advio_page_data(), handle_advio_preview_action(), load_advio_explorer_sample(), Controller helpers for the ADVIO Streamlit page., Persist the current ADVIO download-form state., Persist the current explorer selection and load its offline sample., Keep persisted preview state aligned with the runtime snapshot., Apply one preview-form action and return an error message when it fails. (+248 more)
 
 ### Community 7 - "Community 7"
 Cohesion: 0.02
-Nodes (186): build_advio_comparison_trajectories(), build_crowd_density_figure(), build_local_readiness_figure(), build_scene_attribute_figure(), build_scene_mix_figure(), Plotly figure builders for the ADVIO dataset page., Build a crowd-density composition chart., Build a scene-attribute prevalence chart. (+178 more)
+Nodes (192): validate_dataset_root(), _ensure_setup_file(), _has_nvcc(), main(), _prepend_existing_paths(), _prepend_path(), Build the optional CUDA RoPE2D extension for the bundled ViSTA-SLAM checkout., Build ViSTA-SLAM's optional cuRoPE2D extension in-place. (+184 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.03
-Nodes (141): BaseConfig, _advio_native_fps(), CloudAlignmentStageConfig, CloudEvaluationStageConfig, CloudMetricId, _collect_unknown_field_warnings(), _compile_run_plan(), config_warnings() (+133 more)
+Cohesion: 0.02
+Nodes (175): build_advio_comparison_trajectories(), build_crowd_density_figure(), build_local_readiness_figure(), build_scene_attribute_figure(), build_scene_mix_figure(), Plotly figure builders for the ADVIO dataset page., Build a crowd-density composition chart., Build a scene-attribute prevalence chart. (+167 more)
 
 ### Community 9 - "Community 9"
-Cohesion: 0.03
-Nodes (73): extract_pose_position(), _measure_fps(), PacketSessionMetrics, PacketSessionRuntime, _positions_to_array(), Return packet-rate snapshot fields., Return backend-keyframe snapshot fields., Return the current metrics in snapshot-ready form. (+65 more)
+Cohesion: 0.02
+Nodes (126): Return deterministic output paths declared by this stage., Record3DTransportId, IntEnum, build_record3d_frame_details(), _camera_pose_from_binding(), _device_from_binding(), _import_record3d_module(), _intrinsics_from_binding() (+118 more)
 
 ### Community 10 - "Community 10"
+Cohesion: 0.03
+Nodes (121): BaseConfig, CloudAlignmentStageConfig, CloudEvaluationStageConfig, CloudMetricId, _compile_run_plan(), DenseCloudSelectionConfig, GroundAlignmentStageConfig, Open3dTsdfBackendConfig (+113 more)
+
+### Community 11 - "Community 11"
+Cohesion: 0.03
+Nodes (95): Log a warning message., _ape_error_colors(), attach_recording_sinks(), augment_viewer_recording_with_ground_plane(), build_default_blueprint(), create_recording_stream(), _decimate_rows(), _entity_token() (+87 more)
+
+### Community 12 - "Community 12"
+Cohesion: 0.03
+Nodes (85): BaseConfig, _ConfigFactory, FactoryConfig, from_toml(), Shared config and config-as-factory helpers for the repository.  This module own, Render the config as a Rich tree for quick human inspection., Mixin for configs that construct one runtime owner or adapter.      This pattern, Return the runtime type or owner constructed by :meth:`setup_target`. (+77 more)
+
+### Community 13 - "Community 13"
+Cohesion: 0.05
+Nodes (87): _normalize_value(), Return a JSON-serializable view suitable for UI payloads and debugging., Persist the config to TOML and return the resulting file path., to_jsonable(), deep_merge_config_snapshot(), ExperimentConfig, ExperimentItem, load_experiment_config() (+79 more)
+
+### Community 14 - "Community 14"
+Cohesion: 0.05
+Nodes (73): _coerce_view_graph(), _coerce_view_graph_node(), load_vista_confidences(), load_vista_estimated_intrinsics_series(), load_vista_intrinsics_matrices(), load_vista_native_trajectory(), load_vista_vector(), load_vista_view_graph() (+65 more)
+
+### Community 15 - "Community 15"
 Cohesion: 0.07
 Nodes (34): Replay clock used by dataset and video source streams., Select whether replay follows source timing or returns observations immediately., Apply source-timestamp pacing for real-time replay., Reset the clock baseline for a new replay loop or connection., Sleep until the replay timestamp should be emitted., ReplayClock, ReplayMode, ImageSequenceObservationSource (+26 more)
 
-### Community 11 - "Community 11"
-Cohesion: 0.08
-Nodes (48): validate_modalities(), iter_sequence_manifest_observations(), _load_manifest_rgb_inputs(), _load_rgb(), _load_timestamps_ns(), _manifest_provenance(), Source-owned readers for normalized offline observations., Yield RGB observations from a normalized source sequence manifest. (+40 more)
-
-### Community 12 - "Community 12"
+### Community 16 - "Community 16"
 Cohesion: 0.1
-Nodes (38): build_pipeline_snapshot_render_model(), _coerce_int_metric(), _compute_evo_preview(), _format_latency(), _format_optional_rate(), _format_queue(), _format_resources(), _format_tasks() (+30 more)
+Nodes (36): build_pipeline_snapshot_render_model(), _coerce_int_metric(), _compute_evo_preview(), _format_latency(), _format_optional_rate(), _format_queue(), _format_resources(), _format_tasks() (+28 more)
 
-### Community 13 - "Community 13"
-Cohesion: 0.1
-Nodes (21): caller_namespace(), configure_logging(), _ConsoleLogFormatter, _ConsoleLogHighlighter, _display_name(), from_callsite(), get_console(), _qualify_namespace() (+13 more)
+### Community 17 - "Community 17"
+Cohesion: 0.13
+Nodes (36): test_load_recording_summary_reports_live_keyed_and_tracking_surfaces(), test_write_validation_bundle_emits_report_and_projection_images(), test_write_validation_bundle_respects_explicit_keyed_cloud_limit(), _write_synthetic_recording(), _ancestor_entity_paths(), _component_columns(), _keyed_point_cloud_snapshots(), _latest_live_model_snapshot() (+28 more)
 
-### Community 14 - "Community 14"
+### Community 18 - "Community 18"
 Cohesion: 0.17
 Nodes (2): Tests for package-root public export surfaces., test_source_materialization_does_not_import_stage_package()
 
-### Community 15 - "Community 15"
+### Community 19 - "Community 19"
 Cohesion: 0.36
 Nodes (4): test_resolve_issue_moves_record_to_resolved_collection(), test_resolve_refactor_moves_record_to_resolved_collection(), test_resolve_todo_moves_record_to_resolved_collection(), _write_toml()
 
-### Community 16 - "Community 16"
+### Community 22 - "Community 22"
 Cohesion: 1.0
 Nodes (1): Thin Streamlit entrypoint for the PRML VSLAM workbench scaffold.  The file stays
 
-### Community 17 - "Community 17"
+### Community 23 - "Community 23"
 Cohesion: 1.0
 Nodes (1): Ray-specific helpers for future stage runtime deployment.  This module intention
 
-### Community 18 - "Community 18"
-Cohesion: 1.0
-Nodes (1): Return the human-readable label shown in plan previews.
-
-### Community 19 - "Community 19"
-Cohesion: 1.0
-Nodes (1): Return whether ``exc`` looks like a transient local Ray connection failure.
-
-### Community 20 - "Community 20"
-Cohesion: 1.0
-Nodes (1): Deserialize one IPC payload back into the target validated model type.
-
-### Community 21 - "Community 21"
-Cohesion: 1.0
-Nodes (1): Return the compact source label used in logs and diagnostics.
-
-### Community 22 - "Community 22"
-Cohesion: 1.0
-Nodes (1): Return the short user-facing dataset label.
-
-### Community 23 - "Community 23"
-Cohesion: 1.0
-Nodes (1): Connect to the source and prepare subsequent blocking observation reads.
-
 ### Community 24 - "Community 24"
 Cohesion: 1.0
-Nodes (1): Disconnect or release the source and any owned runtime resources.
+Nodes (1): Return true when every run succeeded or was explicitly allowed to fail.
 
 ### Community 25 - "Community 25"
 Cohesion: 1.0
@@ -177,64 +174,94 @@ Nodes (1): Build the shared transform DTO from a 4x4 homogeneous matrix.
 
 ### Community 27 - "Community 27"
 Cohesion: 1.0
-Nodes (1): Build one spec from one JSON object.
+Nodes (1): Return the compact source label used in logs and diagnostics.
 
 ### Community 28 - "Community 28"
 Cohesion: 1.0
-Nodes (1): Return the net code-line delta.
+Nodes (1): Connect to the source and prepare subsequent blocking observation reads.
 
 ### Community 29 - "Community 29"
+Cohesion: 1.0
+Nodes (1): Disconnect or release the source and any owned runtime resources.
+
+### Community 30 - "Community 30"
+Cohesion: 1.0
+Nodes (1): Return the short user-facing dataset label.
+
+### Community 31 - "Community 31"
+Cohesion: 1.0
+Nodes (1): Deserialize one IPC payload back into the target validated model type.
+
+### Community 32 - "Community 32"
+Cohesion: 1.0
+Nodes (1): Return the human-readable label shown in plan previews.
+
+### Community 33 - "Community 33"
+Cohesion: 1.0
+Nodes (1): Return whether ``exc`` looks like a transient local Ray connection failure.
+
+### Community 34 - "Community 34"
+Cohesion: 1.0
+Nodes (1): Build one spec from one JSON object.
+
+### Community 35 - "Community 35"
+Cohesion: 1.0
+Nodes (1): Return the net code-line delta.
+
+### Community 36 - "Community 36"
 Cohesion: 1.0
 Nodes (1): Return the path that should own this change in reports.
 
 ## Knowledge Gaps
-- **238 isolated node(s):** `Thin Streamlit entrypoint for the PRML VSLAM workbench scaffold.  The file stays`, `Frame preprocessing helpers for ViSTA-SLAM.`, `One RGB frame prepared for upstream ViSTA ingestion.`, `Use the exact upstream ViSTA crop-and-resize helper path.`, `Convert one upstream ViSTA array-like payload into a numpy array.` (+233 more)
+- **245 isolated node(s):** `Thin Streamlit entrypoint for the PRML VSLAM workbench scaffold.  The file stays`, `Frame preprocessing helpers for ViSTA-SLAM.`, `One RGB frame prepared for upstream ViSTA ingestion.`, `Use the exact upstream ViSTA crop-and-resize helper path.`, `Convert one upstream ViSTA array-like payload into a numpy array.` (+240 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 14`** (12 nodes): `test_package_exports.py`, `Tests for package-root public export surfaces.`, `test_executable_stage_packages_export_canonical_surfaces()`, `test_interfaces_package_exports_only_canonical_pose_surface()`, `test_methods_package_exports_slam_surfaces()`, `test_pipeline_contracts_package_is_not_a_compatibility_hub()`, `test_pipeline_package_exports_only_minimal_public_surface()`, `test_reconstruction_package_exports_runtime_surfaces_without_harness()`, `test_replay_package_exports_only_replay_primitives()`, `test_source_materialization_does_not_import_stage_package()`, `test_sources_package_exports_source_owned_contracts()`, `test_vista_package_is_the_only_canonical_vista_surface()`
+- **Thin community `Community 18`** (12 nodes): `test_package_exports.py`, `Tests for package-root public export surfaces.`, `test_executable_stage_packages_export_canonical_surfaces()`, `test_interfaces_package_exports_only_canonical_pose_surface()`, `test_methods_package_exports_slam_surfaces()`, `test_pipeline_contracts_package_is_not_a_compatibility_hub()`, `test_pipeline_package_exports_only_minimal_public_surface()`, `test_reconstruction_package_exports_runtime_surfaces_without_harness()`, `test_replay_package_exports_only_replay_primitives()`, `test_source_materialization_does_not_import_stage_package()`, `test_sources_package_exports_source_owned_contracts()`, `test_vista_package_is_the_only_canonical_vista_surface()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 16`** (2 nodes): `streamlit_app.py`, `Thin Streamlit entrypoint for the PRML VSLAM workbench scaffold.  The file stays`
+- **Thin community `Community 22`** (2 nodes): `streamlit_app.py`, `Thin Streamlit entrypoint for the PRML VSLAM workbench scaffold.  The file stays`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 17`** (2 nodes): `ray.py`, `Ray-specific helpers for future stage runtime deployment.  This module intention`
+- **Thin community `Community 23`** (2 nodes): `ray.py`, `Ray-specific helpers for future stage runtime deployment.  This module intention`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 18`** (1 nodes): `Return the human-readable label shown in plan previews.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 19`** (1 nodes): `Return whether ``exc`` looks like a transient local Ray connection failure.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 20`** (1 nodes): `Deserialize one IPC payload back into the target validated model type.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 21`** (1 nodes): `Return the compact source label used in logs and diagnostics.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 22`** (1 nodes): `Return the short user-facing dataset label.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 23`** (1 nodes): `Connect to the source and prepare subsequent blocking observation reads.`
-  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 24`** (1 nodes): `Disconnect or release the source and any owned runtime resources.`
+- **Thin community `Community 24`** (1 nodes): `Return true when every run succeeded or was explicitly allowed to fail.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 25`** (1 nodes): `Build the shared transform DTO from XYZW quaternion and XYZ translation arrays.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 - **Thin community `Community 26`** (1 nodes): `Build the shared transform DTO from a 4x4 homogeneous matrix.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 27`** (1 nodes): `Build one spec from one JSON object.`
+- **Thin community `Community 27`** (1 nodes): `Return the compact source label used in logs and diagnostics.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 28`** (1 nodes): `Return the net code-line delta.`
+- **Thin community `Community 28`** (1 nodes): `Connect to the source and prepare subsequent blocking observation reads.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 29`** (1 nodes): `Return the path that should own this change in reports.`
+- **Thin community `Community 29`** (1 nodes): `Disconnect or release the source and any owned runtime resources.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 30`** (1 nodes): `Return the short user-facing dataset label.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 31`** (1 nodes): `Deserialize one IPC payload back into the target validated model type.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 32`** (1 nodes): `Return the human-readable label shown in plan previews.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 33`** (1 nodes): `Return whether ``exc`` looks like a transient local Ray connection failure.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 34`** (1 nodes): `Build one spec from one JSON object.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 35`** (1 nodes): `Return the net code-line delta.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 36`** (1 nodes): `Return the path that should own this change in reports.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `Test package helpers and suites for PRML VSLAM.` connect `Community 5` to `Community 0`, `Community 1`, `Community 2`, `Community 3`, `Community 4`, `Community 6`, `Community 7`, `Community 8`, `Community 10`?**
-  _High betweenness centrality (0.130) - this node is a cross-community bridge._
-- **Why does `StageKey` connect `Community 0` to `Community 1`, `Community 2`, `Community 4`, `Community 5`, `Community 6`, `Community 8`?**
-  _High betweenness centrality (0.079) - this node is a cross-community bridge._
-- **Why does `SequenceManifest` connect `Community 2` to `Community 0`, `Community 1`, `Community 3`, `Community 4`, `Community 5`, `Community 6`, `Community 8`, `Community 11`?**
-  _High betweenness centrality (0.067) - this node is a cross-community bridge._
-- **Are the 448 inferred relationships involving `StageKey` (e.g. with `RunConfigOverrideCommand` and `_RerunViewerProcess`) actually correct?**
-  _`StageKey` has 448 INFERRED edges - model-reasoned connections that need verification._
-- **Are the 330 inferred relationships involving `SequenceManifest` (e.g. with `OfflineSlamBackend` and `StreamingSlamBackend`) actually correct?**
-  _`SequenceManifest` has 330 INFERRED edges - model-reasoned connections that need verification._
-- **Are the 283 inferred relationships involving `ArtifactRef` (e.g. with `SlamUpdate` and `SlamArtifacts`) actually correct?**
-  _`ArtifactRef` has 283 INFERRED edges - model-reasoned connections that need verification._
-- **Are the 273 inferred relationships involving `MethodId` (e.g. with `RunConfigOverrideCommand` and `_RerunViewerProcess`) actually correct?**
-  _`MethodId` has 273 INFERRED edges - model-reasoned connections that need verification._
+- **Why does `Test package helpers and suites for PRML VSLAM.` connect `Community 2` to `Community 0`, `Community 1`, `Community 3`, `Community 4`, `Community 5`, `Community 6`, `Community 8`, `Community 9`, `Community 10`, `Community 12`, `Community 13`, `Community 14`, `Community 15`?**
+  _High betweenness centrality (0.137) - this node is a cross-community bridge._
+- **Why does `SequenceManifest` connect `Community 5` to `Community 0`, `Community 1`, `Community 2`, `Community 3`, `Community 4`, `Community 6`, `Community 7`, `Community 9`, `Community 10`?**
+  _High betweenness centrality (0.068) - this node is a cross-community bridge._
+- **Why does `StageKey` connect `Community 1` to `Community 0`, `Community 2`, `Community 3`, `Community 4`, `Community 5`, `Community 6`, `Community 8`, `Community 9`, `Community 10`, `Community 12`, `Community 13`, `Community 16`?**
+  _High betweenness centrality (0.061) - this node is a cross-community bridge._
+- **Are the 442 inferred relationships involving `StageKey` (e.g. with `RunConfigOverrideCommand` and `_RerunViewerProcess`) actually correct?**
+  _`StageKey` has 442 INFERRED edges - model-reasoned connections that need verification._
+- **Are the 306 inferred relationships involving `SequenceManifest` (e.g. with `OfflineSlamBackend` and `StreamingSlamBackend`) actually correct?**
+  _`SequenceManifest` has 306 INFERRED edges - model-reasoned connections that need verification._
+- **Are the 269 inferred relationships involving `ArtifactRef` (e.g. with `SlamUpdate` and `SlamArtifacts`) actually correct?**
+  _`ArtifactRef` has 269 INFERRED edges - model-reasoned connections that need verification._
+- **Are the 257 inferred relationships involving `MethodId` (e.g. with `RunConfigOverrideCommand` and `_RerunViewerProcess`) actually correct?**
+  _`MethodId` has 257 INFERRED edges - model-reasoned connections that need verification._

--- a/graphify-out/graph.html
+++ b/graphify-out/graph.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d278487661fac648c53690483156ee8b1529c9baba533245c8f1e60a203cc79d
-size 6433540
+oid sha256:fc134fe5c45dd62d5106bd46a83ba5de63b6919cf825ad8b0b213db13509b3d9
+size 6319499

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ced7f509c765a1ac08f5665c88d223389b66f9b288ceefa677eac3d82a7b02f4
-size 10081529
+oid sha256:a0a87460277e03e4cfbfba45a16afd3618db435524c8bb9df37ac3e8fa8a00de
+size 9817820

--- a/src/prml_vslam/experiments/__init__.py
+++ b/src/prml_vslam/experiments/__init__.py
@@ -1,0 +1,26 @@
+"""Offline benchmark experiment scaffolding."""
+
+from prml_vslam.experiments.config import ExperimentConfig, ExperimentItem, WandbExperimentLoggingConfig
+from prml_vslam.experiments.contracts import (
+    ExperimentArtifactRecord,
+    ExperimentMetricRecord,
+    ExperimentReport,
+    ExperimentRunResult,
+    ExperimentRunSpec,
+    ExperimentValidationResult,
+)
+from prml_vslam.experiments.execution import expand_experiment_items, run_experiment
+
+__all__ = [
+    "ExperimentArtifactRecord",
+    "ExperimentConfig",
+    "ExperimentItem",
+    "ExperimentMetricRecord",
+    "ExperimentReport",
+    "ExperimentRunResult",
+    "ExperimentRunSpec",
+    "ExperimentValidationResult",
+    "WandbExperimentLoggingConfig",
+    "expand_experiment_items",
+    "run_experiment",
+]

--- a/src/prml_vslam/experiments/config.py
+++ b/src/prml_vslam/experiments/config.py
@@ -1,0 +1,136 @@
+"""Typed configuration for offline benchmark experiment groups."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any, Literal, Self
+
+from pydantic import Field, model_validator
+
+from prml_vslam.pipeline.config import RunConfig
+from prml_vslam.utils import BaseConfig, PathConfig
+
+
+class WandbExperimentLoggingConfig(BaseConfig):
+    """Configure optional Weights & Biases logging for an experiment."""
+
+    enabled: bool = False
+    """Enable W&B logging. Disabled mode imports no W&B package."""
+
+    project: str = "prml-vslam"
+    """W&B project name."""
+
+    entity: str | None = None
+    """Optional W&B entity."""
+
+    group: str | None = None
+    """Optional W&B run group. Defaults to the experiment name."""
+
+    mode: Literal["online", "offline", "disabled"] | None = None
+    """Optional W&B init mode."""
+
+    tags: list[str] = Field(default_factory=list)
+    """Tags applied to every concrete W&B run."""
+
+    log_artifacts: bool = False
+    """Whether to attach lightweight local report files as W&B artifacts."""
+
+
+class ExperimentItem(BaseConfig):
+    """One concrete pipeline run entry inside an offline experiment."""
+
+    id: str
+    """Stable item id used in reports and W&B run names."""
+
+    run_config_path: Path | None = None
+    """Path to an existing pipeline ``RunConfig`` TOML file."""
+
+    run_config: RunConfig | None = None
+    """Inline pipeline ``RunConfig`` payload."""
+
+    overrides: dict[str, Any] = Field(default_factory=dict)
+    """Declarative deep-merge updates applied before planning and execution."""
+
+    allow_failure: bool = False
+    """Record failed runs without making the whole experiment fail."""
+
+    dataset_id: str | None = None
+    """Optional dataset label for tidy analysis rows."""
+
+    sequence_id: str | None = None
+    """Optional sequence label for tidy analysis rows."""
+
+    method_id: str | None = None
+    """Optional method label for tidy analysis rows."""
+
+    preset_id: str | None = None
+    """Optional method-parameter preset label."""
+
+    @model_validator(mode="after")
+    def validate_run_config_source(self) -> Self:
+        """Require exactly one source for the concrete run config."""
+        source_count = int(self.run_config_path is not None) + int(self.run_config is not None)
+        if source_count != 1:
+            raise ValueError("ExperimentItem requires exactly one of `run_config_path` or `run_config`.")
+        return self
+
+
+class ExperimentConfig(BaseConfig):
+    """Group explicit offline run configs into one benchmark experiment."""
+
+    name: str
+    """Experiment id and default W&B group."""
+
+    output_dir: Path = Path(".artifacts/experiments")
+    """Directory for experiment reports and long-form tables."""
+
+    fail_fast: bool = False
+    """Stop after the first disallowed failed item."""
+
+    items: list[ExperimentItem] = Field(default_factory=list)
+    """Concrete experiment items to plan and execute."""
+
+    wandb: WandbExperimentLoggingConfig = Field(default_factory=WandbExperimentLoggingConfig)
+    """Optional W&B logging policy."""
+
+    @model_validator(mode="after")
+    def validate_items(self) -> Self:
+        """Reject empty experiments and duplicate item ids."""
+        if not self.items:
+            raise ValueError("ExperimentConfig requires at least one item.")
+        item_ids = [item.id for item in self.items]
+        duplicates = sorted({item_id for item_id in item_ids if item_ids.count(item_id) > 1})
+        if duplicates:
+            raise ValueError(f"Duplicate experiment item id(s): {', '.join(duplicates)}")
+        return self
+
+
+def load_experiment_config(path: Path, *, path_config: PathConfig | None = None) -> ExperimentConfig:
+    """Load an experiment config TOML path with repo-relative resolution."""
+    config_paths = PathConfig() if path_config is None else path_config
+    resolved = config_paths.resolve_toml_path(path, must_exist=True)
+    config = ExperimentConfig.from_toml(resolved)
+    return _resolve_item_paths(config, base_dir=resolved.parent)
+
+
+def _resolve_item_paths(config: ExperimentConfig, *, base_dir: Path) -> ExperimentConfig:
+    updated_items: list[ExperimentItem] = []
+    for item in config.items:
+        if item.run_config_path is None or item.run_config_path.is_absolute():
+            updated_items.append(item)
+            continue
+        updated_items.append(item.model_copy(update={"run_config_path": (base_dir / item.run_config_path).resolve()}))
+    return config.model_copy(update={"items": updated_items})
+
+
+def deep_merge_config_snapshot(base: Mapping[str, Any], updates: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a recursive config snapshot merge without mutating either input."""
+    merged: dict[str, Any] = dict(base)
+    for key, value in updates.items():
+        existing = merged.get(key)
+        if isinstance(existing, Mapping) and isinstance(value, Mapping):
+            merged[key] = deep_merge_config_snapshot(existing, value)
+        else:
+            merged[key] = value
+    return merged

--- a/src/prml_vslam/experiments/contracts.py
+++ b/src/prml_vslam/experiments/contracts.py
@@ -1,0 +1,104 @@
+"""Persisted contracts for offline benchmark experiments."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from pydantic import Field
+
+from prml_vslam.utils import BaseData
+
+
+class ExperimentRunSpec(BaseData):
+    """Resolved plan metadata for one experiment item."""
+
+    experiment_id: str
+    item_id: str
+    run_id: str
+    artifact_root: Path
+    config_hash: str
+    dataset_id: str | None = None
+    sequence_id: str | None = None
+    method_id: str | None = None
+    preset_id: str | None = None
+    run_config: dict[str, Any]
+
+
+class ExperimentValidationResult(BaseData):
+    """One deterministic validation check result for a concrete run."""
+
+    experiment_id: str
+    run_id: str
+    item_id: str
+    check_name: str
+    passed: bool
+    status: str
+    message: str = ""
+    artifact_path: Path | None = None
+
+
+class ExperimentMetricRecord(BaseData):
+    """One tidy metric observation collected from persisted run artifacts."""
+
+    experiment_id: str
+    run_id: str
+    item_id: str
+    dataset_id: str | None = None
+    sequence_id: str | None = None
+    method_id: str | None = None
+    stage: str
+    metric_name: str
+    metric_value: float | int | str | bool | None
+    unit: str | None = None
+    artifact_path: Path | None = None
+    status: str = "available"
+
+
+class ExperimentArtifactRecord(BaseData):
+    """One tidy artifact observation collected from persisted manifests."""
+
+    experiment_id: str
+    run_id: str
+    item_id: str
+    dataset_id: str | None = None
+    sequence_id: str | None = None
+    method_id: str | None = None
+    stage: str
+    artifact_key: str
+    artifact_path: Path
+    status: str
+
+
+class ExperimentRunResult(BaseData):
+    """Terminal result for one concrete experiment item."""
+
+    spec: ExperimentRunSpec
+    terminal_state: str
+    success: bool
+    error_message: str = ""
+    validations: list[ExperimentValidationResult] = Field(default_factory=list)
+    metrics: list[ExperimentMetricRecord] = Field(default_factory=list)
+    artifacts: list[ExperimentArtifactRecord] = Field(default_factory=list)
+
+
+class ExperimentReport(BaseData):
+    """Machine-readable report for one offline experiment execution."""
+
+    experiment_id: str
+    started_at: datetime
+    completed_at: datetime | None = None
+    results: list[ExperimentRunResult] = Field(default_factory=list)
+    report_json_path: Path | None = None
+    metrics_csv_path: Path | None = None
+    metrics_parquet_path: Path | None = None
+    validation_csv_path: Path | None = None
+    validation_parquet_path: Path | None = None
+    artifacts_csv_path: Path | None = None
+    artifacts_parquet_path: Path | None = None
+
+    @property
+    def success(self) -> bool:
+        """Return true when every run succeeded or was explicitly allowed to fail."""
+        return all(result.success for result in self.results)

--- a/src/prml_vslam/experiments/execution.py
+++ b/src/prml_vslam/experiments/execution.py
@@ -1,0 +1,188 @@
+"""Offline experiment expansion and sequential execution."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import time
+from collections.abc import Callable
+from datetime import datetime
+from typing import Any, Protocol
+
+from prml_vslam.experiments.config import ExperimentConfig, ExperimentItem, deep_merge_config_snapshot
+from prml_vslam.experiments.contracts import ExperimentReport, ExperimentRunResult, ExperimentRunSpec
+from prml_vslam.experiments.reporting import collect_artifact_records, collect_metric_records, write_experiment_report
+from prml_vslam.experiments.validation import validate_run_artifacts
+from prml_vslam.experiments.wandb_logging import log_run_to_wandb
+from prml_vslam.pipeline.backend import PipelineRuntimeSource
+from prml_vslam.pipeline.config import RunConfig
+from prml_vslam.pipeline.contracts.mode import PipelineMode
+from prml_vslam.pipeline.contracts.runtime import RunSnapshot, RunState
+from prml_vslam.pipeline.demo import build_runtime_source_from_run_config
+from prml_vslam.pipeline.run_service import RunService
+from prml_vslam.utils import BaseConfig, PathConfig
+
+
+class ExperimentRunService(Protocol):
+    """Subset of :class:`RunService` needed by experiment execution."""
+
+    def start_run(self, *, run_config: RunConfig, runtime_source: PipelineRuntimeSource = None) -> None:
+        """Start one pipeline run."""
+
+    def snapshot(self) -> RunSnapshot:
+        """Return the latest run snapshot."""
+
+    def stop_run(self) -> None:
+        """Stop the active run."""
+
+    def shutdown(self, *, preserve_local_head: bool = False) -> None:
+        """Release runtime resources."""
+
+
+RunServiceFactory = Callable[[PathConfig], ExperimentRunService]
+
+
+def expand_experiment_items(
+    config: ExperimentConfig,
+    *,
+    path_config: PathConfig | None = None,
+) -> list[ExperimentRunSpec]:
+    """Expand experiment items into concrete offline run specs."""
+    paths = PathConfig() if path_config is None else path_config
+    return [_build_run_spec(config, item, _build_run_config_for_item(item), path_config=paths) for item in config.items]
+
+
+def run_experiment(
+    config: ExperimentConfig,
+    *,
+    path_config: PathConfig | None = None,
+    run_service_factory: RunServiceFactory | None = None,
+) -> ExperimentReport:
+    """Execute an experiment sequentially through the existing pipeline service."""
+    paths = PathConfig() if path_config is None else path_config
+    service_factory = _default_run_service_factory if run_service_factory is None else run_service_factory
+    report_dir = paths.resolve_output_dir(config.output_dir) / paths.slugify_experiment_name(config.name)
+    report = ExperimentReport(experiment_id=config.name, started_at=datetime.now().astimezone())
+    for item in config.items:
+        run_config = _build_run_config_for_item(item)
+        spec = _build_run_spec(config, item, run_config, path_config=paths)
+        result = _run_one_item(
+            spec=spec,
+            item=item,
+            run_config=run_config,
+            path_config=paths,
+            run_service_factory=service_factory,
+        )
+        report.results.append(result)
+        report = write_experiment_report(report, output_dir=report_dir)
+        log_run_to_wandb(config=config, result=result)
+        if config.fail_fast and not result.success:
+            break
+    return write_experiment_report(report, output_dir=report_dir)
+
+
+def _build_run_config_for_item(item: ExperimentItem) -> RunConfig:
+    if item.run_config_path is not None:
+        run_config = RunConfig.from_toml(item.run_config_path)
+    elif item.run_config is not None:
+        run_config = item.run_config
+    else:
+        raise ValueError("Experiment item has no run config source.")
+    if item.overrides:
+        snapshot = run_config.model_dump_jsonable()
+        run_config = RunConfig.model_validate(deep_merge_config_snapshot(snapshot, item.overrides))
+    if run_config.mode is not PipelineMode.OFFLINE:
+        raise ValueError(f"Experiment item `{item.id}` must use offline mode, got `{run_config.mode.value}`.")
+    return run_config
+
+
+def _build_run_spec(
+    config: ExperimentConfig,
+    item: ExperimentItem,
+    run_config: RunConfig,
+    *,
+    path_config: PathConfig,
+) -> ExperimentRunSpec:
+    plan = run_config.compile_plan(path_config)
+    config_snapshot = run_config.model_dump_jsonable()
+    return ExperimentRunSpec(
+        experiment_id=config.name,
+        item_id=item.id,
+        run_id=plan.run_id,
+        artifact_root=plan.artifact_root,
+        config_hash=_stable_hash(config_snapshot),
+        dataset_id=item.dataset_id or _dataset_id_from_plan(plan.source.metadata),
+        sequence_id=item.sequence_id or plan.source.sequence_id,
+        method_id=item.method_id or run_config.stages.slam.backend.method_id.value,
+        preset_id=item.preset_id,
+        run_config=config_snapshot,
+    )
+
+
+def _run_one_item(
+    *,
+    spec: ExperimentRunSpec,
+    item: ExperimentItem,
+    run_config: RunConfig,
+    path_config: PathConfig,
+    run_service_factory: RunServiceFactory,
+) -> ExperimentRunResult:
+    service = run_service_factory(path_config)
+    snapshot = RunSnapshot(state=RunState.IDLE)
+    try:
+        runtime_source = build_runtime_source_from_run_config(run_config=run_config, path_config=path_config)
+        service.start_run(run_config=run_config, runtime_source=runtime_source)
+        snapshot = _wait_for_terminal_snapshot(service)
+    except Exception as exc:
+        snapshot = RunSnapshot(run_id=spec.run_id, state=RunState.FAILED, error_message=str(exc))
+    finally:
+        service.shutdown(
+            preserve_local_head=snapshot.state is RunState.COMPLETED
+            and run_config.ray_local_head_lifecycle == "reusable"
+        )
+    validations = validate_run_artifacts(
+        spec=spec,
+        run_config=run_config,
+        snapshot=snapshot,
+        allow_failure=item.allow_failure,
+    )
+    metrics = collect_metric_records(spec)
+    artifacts = collect_artifact_records(spec)
+    success = all(validation.passed for validation in validations) or (
+        item.allow_failure and snapshot.state is not RunState.IDLE
+    )
+    return ExperimentRunResult(
+        spec=spec,
+        terminal_state=snapshot.state.value,
+        success=success,
+        error_message=snapshot.error_message,
+        validations=validations,
+        metrics=metrics,
+        artifacts=artifacts,
+    )
+
+
+def _wait_for_terminal_snapshot(
+    service: ExperimentRunService,
+    *,
+    poll_interval_seconds: float = 0.2,
+) -> RunSnapshot:
+    while True:
+        snapshot = service.snapshot()
+        if snapshot.state in {RunState.COMPLETED, RunState.FAILED, RunState.STOPPED}:
+            return snapshot
+        time.sleep(poll_interval_seconds)
+
+
+def _stable_hash(payload: dict[str, Any]) -> str:
+    encoded = json.dumps(BaseConfig.to_jsonable(payload), sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _dataset_id_from_plan(metadata: dict[str, str | int | float | bool | None]) -> str | None:
+    value = metadata.get("dataset_id")
+    return None if value is None else str(value)
+
+
+def _default_run_service_factory(path_config: PathConfig) -> RunService:
+    return RunService(path_config=path_config)

--- a/src/prml_vslam/experiments/reporting.py
+++ b/src/prml_vslam/experiments/reporting.py
@@ -1,0 +1,192 @@
+"""Tidy dataframe and persisted report helpers for experiments."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from prml_vslam.experiments.contracts import (
+    ExperimentArtifactRecord,
+    ExperimentMetricRecord,
+    ExperimentReport,
+    ExperimentRunSpec,
+)
+from prml_vslam.utils import BaseConfig, RunArtifactPaths
+
+_TRAJECTORY_STAT_UNITS = {
+    "rmse": "m",
+    "mean": "m",
+    "median": "m",
+    "std": "m",
+    "min": "m",
+    "max": "m",
+    "sse": "m2",
+}
+
+
+def collect_metric_records(spec: ExperimentRunSpec) -> list[ExperimentMetricRecord]:
+    """Collect existing persisted trajectory/cloud metrics into tidy rows."""
+    paths = RunArtifactPaths.build(spec.artifact_root)
+    records: list[ExperimentMetricRecord] = []
+    records.extend(_trajectory_metric_records(spec, paths.trajectory_metrics_path))
+    records.extend(
+        _trajectory_alignment_records(spec, paths.artifact_root / "evaluation" / "trajectory_alignment.json")
+    )
+    records.extend(_cloud_alignment_records(spec, paths.artifact_root / "evaluation" / "cloud_alignment.json"))
+    return records
+
+
+def collect_artifact_records(spec: ExperimentRunSpec) -> list[ExperimentArtifactRecord]:
+    """Collect existing stage manifest outputs into tidy artifact rows."""
+    manifest_path = RunArtifactPaths.build(spec.artifact_root).stage_manifests_path
+    if not manifest_path.is_file():
+        return []
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    records: list[ExperimentArtifactRecord] = []
+    for manifest in payload:
+        output_paths = manifest.get("output_paths", {})
+        for artifact_key, artifact_path in output_paths.items():
+            records.append(
+                ExperimentArtifactRecord(
+                    experiment_id=spec.experiment_id,
+                    run_id=spec.run_id,
+                    item_id=spec.item_id,
+                    dataset_id=spec.dataset_id,
+                    sequence_id=spec.sequence_id,
+                    method_id=spec.method_id,
+                    stage=str(manifest.get("stage_id", "")),
+                    artifact_key=str(artifact_key),
+                    artifact_path=Path(str(artifact_path)),
+                    status=str(manifest.get("status", "")),
+                )
+            )
+    return records
+
+
+def collect_run_dataframes(report: ExperimentReport) -> dict[str, pd.DataFrame]:
+    """Return tidy pandas tables for metrics, validation checks, and artifacts."""
+    metric_rows: list[dict[str, Any]] = []
+    validation_rows: list[dict[str, Any]] = []
+    artifact_rows: list[dict[str, Any]] = []
+    for result in report.results:
+        metric_rows.extend(record.model_dump(mode="json") for record in result.metrics)
+        validation_rows.extend(record.model_dump(mode="json") for record in result.validations)
+        artifact_rows.extend(record.model_dump(mode="json") for record in result.artifacts)
+    return {
+        "metrics": pd.DataFrame(metric_rows),
+        "validation": pd.DataFrame(validation_rows),
+        "artifacts": pd.DataFrame(artifact_rows),
+    }
+
+
+def write_experiment_report(report: ExperimentReport, *, output_dir: Path) -> ExperimentReport:
+    """Persist a report JSON file plus long-form CSV/Parquet tables."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    completed = report.completed_at if report.completed_at is not None else datetime.now().astimezone()
+    updated = report.model_copy(update={"completed_at": completed})
+    report_json_path = output_dir / "experiment_report.json"
+    dataframes = collect_run_dataframes(updated)
+    path_updates: dict[str, Path] = {"report_json_path": report_json_path}
+    for name, dataframe in dataframes.items():
+        csv_path = output_dir / f"{name}_long.csv"
+        parquet_path = output_dir / f"{name}_long.parquet"
+        dataframe.to_csv(csv_path, index=False)
+        dataframe.to_parquet(parquet_path, index=False)
+        path_updates[f"{name}_csv_path"] = csv_path
+        path_updates[f"{name}_parquet_path"] = parquet_path
+    updated = updated.model_copy(update=path_updates)
+    report_json_path.write_text(updated.model_dump_json(indent=2), encoding="utf-8")
+    return updated
+
+
+def _trajectory_metric_records(spec: ExperimentRunSpec, path: Path) -> list[ExperimentMetricRecord]:
+    payload = _read_json_if_present(path)
+    if payload is None:
+        return []
+    records: list[ExperimentMetricRecord] = []
+    stats = payload.get("stats", {})
+    if isinstance(stats, dict):
+        records.extend(
+            _metric(
+                spec,
+                stage="evaluate.trajectory",
+                name=f"ape_translation_{name}",
+                value=value,
+                unit=_TRAJECTORY_STAT_UNITS.get(str(name)),
+                path=path,
+            )
+            for name, value in stats.items()
+        )
+    if "matched_pairs" in payload:
+        records.append(
+            _metric(
+                spec,
+                stage="evaluate.trajectory",
+                name="matched_pairs",
+                value=payload["matched_pairs"],
+                unit="pairs",
+                path=path,
+            )
+        )
+    return records
+
+
+def _trajectory_alignment_records(spec: ExperimentRunSpec, path: Path) -> list[ExperimentMetricRecord]:
+    payload = _read_json_if_present(path)
+    if payload is None:
+        return []
+    records: list[ExperimentMetricRecord] = []
+    for name, unit in (("rms_error_m", "m"), ("scale", None), ("matched_pairs", "pairs")):
+        if name in payload:
+            records.append(
+                _metric(spec, stage="align.trajectory", name=name, value=payload[name], unit=unit, path=path)
+            )
+    return records
+
+
+def _cloud_alignment_records(spec: ExperimentRunSpec, path: Path) -> list[ExperimentMetricRecord]:
+    payload = _read_json_if_present(path)
+    if payload is None:
+        return []
+    records: list[ExperimentMetricRecord] = []
+    for name, unit in (("fitness", None), ("inlier_rmse_m", "m"), ("max_correspondence_distance_m", "m")):
+        if name in payload:
+            records.append(_metric(spec, stage="align.cloud", name=name, value=payload[name], unit=unit, path=path))
+    return records
+
+
+def _metric(
+    spec: ExperimentRunSpec,
+    *,
+    stage: str,
+    name: str,
+    value: Any,
+    unit: str | None,
+    path: Path,
+) -> ExperimentMetricRecord:
+    return ExperimentMetricRecord(
+        experiment_id=spec.experiment_id,
+        run_id=spec.run_id,
+        item_id=spec.item_id,
+        dataset_id=spec.dataset_id,
+        sequence_id=spec.sequence_id,
+        method_id=spec.method_id,
+        stage=stage,
+        metric_name=name,
+        metric_value=BaseConfig.to_jsonable(value),
+        unit=unit,
+        artifact_path=path,
+    )
+
+
+def _read_json_if_present(path: Path) -> dict[str, Any] | None:
+    if not path.is_file() or path.stat().st_size == 0:
+        return None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        return None
+    return payload

--- a/src/prml_vslam/experiments/validation.py
+++ b/src/prml_vslam/experiments/validation.py
@@ -1,0 +1,145 @@
+"""Deterministic artifact validation for offline experiment runs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from prml_vslam.experiments.contracts import ExperimentRunSpec, ExperimentValidationResult
+from prml_vslam.pipeline.config import RunConfig
+from prml_vslam.pipeline.contracts.runtime import RunSnapshot, RunState
+from prml_vslam.utils import RunArtifactPaths
+
+
+def validate_run_artifacts(
+    *,
+    spec: ExperimentRunSpec,
+    run_config: RunConfig,
+    snapshot: RunSnapshot,
+    allow_failure: bool,
+) -> list[ExperimentValidationResult]:
+    """Validate terminal state and configured artifact expectations for one run."""
+    paths = RunArtifactPaths.build(spec.artifact_root)
+    checks = [
+        _check(
+            spec,
+            "terminal_state",
+            snapshot.state in {RunState.COMPLETED, RunState.FAILED, RunState.STOPPED},
+            snapshot.state.value,
+            f"terminal state is {snapshot.state.value}",
+        ),
+        _check(
+            spec,
+            "run_completed",
+            snapshot.state is RunState.COMPLETED or allow_failure,
+            snapshot.state.value,
+            snapshot.error_message,
+        ),
+        _path_check(spec, "artifact_root_exists", paths.artifact_root, require_non_empty=False),
+    ]
+    if run_config.stages.slam.enabled:
+        checks.append(_path_check(spec, "slam_trajectory_exists", paths.trajectory_path))
+        if run_config.stages.slam.outputs.emit_dense_points:
+            checks.append(_path_check(spec, "slam_point_cloud_exists", paths.point_cloud_path))
+    if run_config.visualization.export_viewer_rrd:
+        checks.append(_path_check(spec, "rerun_recording_exists", paths.viewer_rrd_path))
+    if run_config.stages.align_trajectory.enabled:
+        checks.append(
+            _path_check(
+                spec,
+                "trajectory_alignment_exists",
+                paths.artifact_root / "evaluation" / "trajectory_alignment.json",
+            )
+        )
+        checks.append(
+            _path_check(
+                spec,
+                "aligned_trajectory_exists",
+                paths.artifact_root / "evaluation" / "trajectory_sim3_aligned.tum",
+            )
+        )
+    if run_config.stages.evaluate_trajectory.enabled:
+        checks.append(_json_check(spec, "trajectory_metrics_parseable", paths.trajectory_metrics_path))
+    if run_config.stages.align_cloud.enabled:
+        checks.append(
+            _json_check(spec, "cloud_alignment_parseable", paths.artifact_root / "evaluation" / "cloud_alignment.json")
+        )
+        checks.extend(
+            _json_field_checks(
+                spec,
+                path=paths.artifact_root / "evaluation" / "cloud_alignment.json",
+                fields=("fitness", "inlier_rmse_m"),
+            )
+        )
+    return checks
+
+
+def _check(
+    spec: ExperimentRunSpec,
+    check_name: str,
+    passed: bool,
+    status: str,
+    message: str = "",
+    artifact_path: Path | None = None,
+) -> ExperimentValidationResult:
+    return ExperimentValidationResult(
+        experiment_id=spec.experiment_id,
+        run_id=spec.run_id,
+        item_id=spec.item_id,
+        check_name=check_name,
+        passed=passed,
+        status=status,
+        message=message,
+        artifact_path=artifact_path,
+    )
+
+
+def _path_check(
+    spec: ExperimentRunSpec,
+    check_name: str,
+    path: Path,
+    *,
+    require_non_empty: bool = True,
+) -> ExperimentValidationResult:
+    exists = path.exists()
+    non_empty = path.is_dir() or (path.is_file() and path.stat().st_size > 0)
+    passed = exists and (not require_non_empty or non_empty)
+    status = "present" if passed else "missing"
+    if exists and require_non_empty and not non_empty:
+        status = "empty"
+    return _check(spec, check_name, passed, status, artifact_path=path)
+
+
+def _json_check(spec: ExperimentRunSpec, check_name: str, path: Path) -> ExperimentValidationResult:
+    if not path.is_file() or path.stat().st_size == 0:
+        return _check(spec, check_name, False, "missing", artifact_path=path)
+    try:
+        json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return _check(spec, check_name, False, "invalid_json", str(exc), artifact_path=path)
+    return _check(spec, check_name, True, "parseable", artifact_path=path)
+
+
+def _json_field_checks(
+    spec: ExperimentRunSpec,
+    *,
+    path: Path,
+    fields: tuple[str, ...],
+) -> list[ExperimentValidationResult]:
+    try:
+        payload: dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return [
+            _check(spec, f"cloud_alignment_{field}_present", False, "missing", artifact_path=path) for field in fields
+        ]
+    return [
+        _check(
+            spec,
+            f"cloud_alignment_{field}_present",
+            field in payload,
+            "present" if field in payload else "missing",
+            artifact_path=path,
+        )
+        for field in fields
+    ]

--- a/src/prml_vslam/experiments/wandb_logging.py
+++ b/src/prml_vslam/experiments/wandb_logging.py
@@ -1,0 +1,74 @@
+"""Optional Weights & Biases logging for experiment runs."""
+
+from __future__ import annotations
+
+from types import ModuleType
+
+from prml_vslam.experiments.config import ExperimentConfig
+from prml_vslam.experiments.contracts import ExperimentRunResult
+
+
+def log_run_to_wandb(
+    *,
+    config: ExperimentConfig,
+    result: ExperimentRunResult,
+    wandb_module: ModuleType | None = None,
+) -> None:
+    """Log one concrete run to W&B when enabled by config."""
+    if not config.wandb.enabled:
+        return
+    wandb = _resolve_wandb_module(wandb_module)
+    init_kwargs = {
+        "project": config.wandb.project,
+        "group": config.wandb.group or config.name,
+        "name": result.spec.run_id,
+        "job_type": "pipeline-run",
+        "tags": config.wandb.tags,
+        "config": {
+            "experiment_id": result.spec.experiment_id,
+            "item_id": result.spec.item_id,
+            "run_id": result.spec.run_id,
+            "artifact_root": result.spec.artifact_root.as_posix(),
+            "config_hash": result.spec.config_hash,
+            "dataset_id": result.spec.dataset_id,
+            "sequence_id": result.spec.sequence_id,
+            "method_id": result.spec.method_id,
+            "preset_id": result.spec.preset_id,
+            "run_config": result.spec.run_config,
+        },
+    }
+    if config.wandb.entity is not None:
+        init_kwargs["entity"] = config.wandb.entity
+    if config.wandb.mode is not None:
+        init_kwargs["mode"] = config.wandb.mode
+    run = wandb.init(**init_kwargs)
+    try:
+        run.summary["terminal_state"] = result.terminal_state
+        run.summary["success"] = result.success
+        run.summary["validation_passed"] = sum(validation.passed for validation in result.validations)
+        run.summary["validation_total"] = len(result.validations)
+        metrics: dict[str, float | int | bool] = {}
+        for record in result.metrics:
+            if isinstance(record.metric_value, bool | int | float):
+                metrics[f"{record.stage}/{record.metric_name}"] = record.metric_value
+        if metrics:
+            run.log(metrics)
+        if config.wandb.log_artifacts:
+            artifact = wandb.Artifact(f"{result.spec.run_id}-paths", type="prml-vslam-run")
+            artifact.add_reference(result.spec.artifact_root.as_uri())
+            run.log_artifact(artifact)
+    finally:
+        run.finish()
+
+
+def _resolve_wandb_module(wandb_module: ModuleType | None) -> ModuleType:
+    if wandb_module is not None:
+        return wandb_module
+    try:
+        import wandb
+    except ImportError as exc:
+        raise RuntimeError(
+            "W&B logging is enabled, but the `wandb` package is not installed. "
+            "Install it or set `[wandb].enabled = false`."
+        ) from exc
+    return wandb

--- a/src/prml_vslam/main.py
+++ b/src/prml_vslam/main.py
@@ -25,6 +25,8 @@ from rich.panel import Panel
 from rich.table import Table
 from typer.core import TyperCommand
 
+from prml_vslam.experiments.config import load_experiment_config
+from prml_vslam.experiments.execution import expand_experiment_items, run_experiment
 from prml_vslam.methods.stage.backend_config import MethodId
 from prml_vslam.pipeline import PipelineMode
 from prml_vslam.pipeline.config import RunConfig, build_run_config
@@ -689,6 +691,44 @@ def _run_config_loaded(*, run_cfg: RunConfig, path_config: PathConfig) -> None:
     _wait_for_rerun_viewer_close(viewer)
     _shutdown_rerun_viewer(viewer)
     if snapshot.state is RunState.FAILED:
+        raise typer.Exit(code=1)
+
+
+@app.command("plan-experiment-config")
+def plan_experiment_config(
+    config_path: Annotated[
+        Path,
+        typer.Argument(help="Path to an experiment config TOML file."),
+    ],
+) -> None:
+    """Plan every offline run referenced by an experiment config."""
+    path_config = get_path_config()
+    try:
+        experiment_config = load_experiment_config(config_path, path_config=path_config)
+        specs = expand_experiment_items(experiment_config, path_config=path_config)
+    except Exception as exc:
+        console.error(str(exc))
+        raise typer.Exit(code=1) from exc
+    console.plog([spec.model_dump(mode="json") for spec in specs])
+
+
+@app.command("run-experiment-config")
+def run_experiment_config(
+    config_path: Annotated[
+        Path,
+        typer.Argument(help="Path to an experiment config TOML file."),
+    ],
+) -> None:
+    """Run a group of offline pipeline configs and write tidy experiment reports."""
+    path_config = get_path_config()
+    try:
+        experiment_config = load_experiment_config(config_path, path_config=path_config)
+        report = run_experiment(experiment_config, path_config=path_config)
+    except Exception as exc:
+        console.error(str(exc))
+        raise typer.Exit(code=1) from exc
+    console.plog(report.model_dump(mode="json"))
+    if not report.success:
         raise typer.Exit(code=1)
 
 

--- a/tests/test_experiments.py
+++ b/tests/test_experiments.py
@@ -1,0 +1,382 @@
+"""Experiment scaffold tests."""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from typer.testing import CliRunner
+
+from prml_vslam.experiments.config import ExperimentConfig, ExperimentItem, load_experiment_config
+from prml_vslam.experiments.contracts import ExperimentReport
+from prml_vslam.experiments.execution import expand_experiment_items, run_experiment
+from prml_vslam.experiments.reporting import collect_run_dataframes, write_experiment_report
+from prml_vslam.experiments.validation import validate_run_artifacts
+from prml_vslam.experiments.wandb_logging import log_run_to_wandb
+from prml_vslam.methods.stage.backend_config import MethodId
+from prml_vslam.pipeline.config import RunConfig, build_run_config
+from prml_vslam.pipeline.contracts.runtime import RunSnapshot, RunState
+from prml_vslam.pipeline.contracts.stages import StageKey
+from prml_vslam.sources.config import VideoSourceConfig
+from prml_vslam.utils import PathConfig, RunArtifactPaths
+
+runner = CliRunner()
+
+
+def test_experiment_config_loads_relative_run_config_paths(tmp_path: Path) -> None:
+    run_config_path = tmp_path / "run.toml"
+    _run_config(tmp_path).save_toml(run_config_path)
+    experiment_path = tmp_path / "experiment.toml"
+    experiment_path.write_text(
+        """
+name = "offline-smoke"
+output_dir = "experiment-artifacts"
+
+[[items]]
+id = "vista-demo"
+run_config_path = "run.toml"
+dataset_id = "video"
+sequence_id = "demo"
+method_id = "vista"
+""",
+        encoding="utf-8",
+    )
+
+    config = load_experiment_config(experiment_path, path_config=PathConfig(root=tmp_path))
+
+    assert config.items[0].run_config_path == run_config_path.resolve()
+
+
+def test_experiment_config_rejects_empty_and_duplicate_items(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="at least one item"):
+        ExperimentConfig(name="empty")
+
+    item = ExperimentItem(id="same", run_config=_run_config(tmp_path))
+    with pytest.raises(ValueError, match="Duplicate"):
+        ExperimentConfig(name="dupes", items=[item, item])
+
+
+def test_expand_experiment_items_applies_overrides_and_enforces_offline(tmp_path: Path) -> None:
+    config = ExperimentConfig(
+        name="expansion",
+        items=[
+            ExperimentItem(
+                id="vista",
+                run_config=_run_config(tmp_path),
+                overrides={"stages": {"slam": {"backend": {"max_frames": 3}}}},
+            )
+        ],
+    )
+
+    specs = expand_experiment_items(config, path_config=PathConfig(root=tmp_path))
+
+    assert specs[0].method_id == "vista"
+    assert specs[0].run_config["stages"]["slam"]["backend"]["max_frames"] == 3
+
+    streaming_payload = _run_config(tmp_path).model_dump_jsonable()
+    streaming_payload["mode"] = "streaming"
+    streaming = RunConfig.model_validate(streaming_payload)
+    with pytest.raises(ValueError, match="offline mode"):
+        expand_experiment_items(
+            ExperimentConfig(name="streaming", items=[ExperimentItem(id="bad", run_config=streaming)]),
+            path_config=PathConfig(root=tmp_path),
+        )
+
+
+def test_validate_run_artifacts_passes_on_expected_fake_tree(tmp_path: Path) -> None:
+    run_config = _run_config(tmp_path, trajectory_eval=True, trajectory_alignment=True, cloud_alignment=True)
+    spec = expand_experiment_items(
+        ExperimentConfig(name="validation", items=[ExperimentItem(id="vista", run_config=run_config)]),
+        path_config=PathConfig(root=tmp_path),
+    )[0]
+    _write_artifacts(spec.artifact_root, run_config=run_config)
+
+    results = validate_run_artifacts(
+        spec=spec,
+        run_config=run_config,
+        snapshot=RunSnapshot(run_id=spec.run_id, state=RunState.COMPLETED),
+        allow_failure=False,
+    )
+
+    assert results
+    assert all(result.passed for result in results)
+
+
+def test_validate_run_artifacts_fails_on_missing_trajectory(tmp_path: Path) -> None:
+    run_config = _run_config(tmp_path)
+    spec = expand_experiment_items(
+        ExperimentConfig(name="validation", items=[ExperimentItem(id="vista", run_config=run_config)]),
+        path_config=PathConfig(root=tmp_path),
+    )[0]
+    spec.artifact_root.mkdir(parents=True)
+
+    results = validate_run_artifacts(
+        spec=spec,
+        run_config=run_config,
+        snapshot=RunSnapshot(run_id=spec.run_id, state=RunState.COMPLETED),
+        allow_failure=False,
+    )
+
+    assert any(result.check_name == "slam_trajectory_exists" and not result.passed for result in results)
+
+
+def test_validate_run_artifacts_fails_on_missing_requested_metrics(tmp_path: Path) -> None:
+    run_config = _run_config(tmp_path, trajectory_eval=True)
+    spec = expand_experiment_items(
+        ExperimentConfig(name="validation", items=[ExperimentItem(id="vista", run_config=run_config)]),
+        path_config=PathConfig(root=tmp_path),
+    )[0]
+    _write_artifacts(spec.artifact_root, run_config=_run_config(tmp_path))
+
+    results = validate_run_artifacts(
+        spec=spec,
+        run_config=run_config,
+        snapshot=RunSnapshot(run_id=spec.run_id, state=RunState.COMPLETED),
+        allow_failure=False,
+    )
+
+    assert any(result.check_name == "trajectory_metrics_parseable" and not result.passed for result in results)
+
+
+def test_run_experiment_writes_report_and_tidy_tables(tmp_path: Path) -> None:
+    config = ExperimentConfig(
+        name="experiment",
+        output_dir=Path("experiment-output"),
+        items=[
+            ExperimentItem(
+                id="vista",
+                run_config=_run_config(tmp_path, trajectory_eval=True, trajectory_alignment=True, cloud_alignment=True),
+            )
+        ],
+    )
+
+    report = run_experiment(
+        config,
+        path_config=PathConfig(root=tmp_path),
+        run_service_factory=lambda path_config: _FakeRunService(path_config),
+    )
+    frames = collect_run_dataframes(report)
+
+    assert report.success
+    assert report.report_json_path is not None and report.report_json_path.is_file()
+    assert report.metrics_parquet_path is not None and report.metrics_parquet_path.is_file()
+    assert {"metrics", "validation", "artifacts"} == set(frames)
+    assert "ape_translation_rmse" in set(frames["metrics"]["metric_name"])
+    assert "slam_trajectory_exists" in set(frames["validation"]["check_name"])
+
+
+def test_plan_experiment_config_command_prints_specs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from prml_vslam.main import app
+
+    experiment_path = _write_experiment_config(tmp_path)
+    monkeypatch.setattr("prml_vslam.main.get_path_config", lambda: PathConfig(root=tmp_path))
+
+    result = runner.invoke(app, ["plan-experiment-config", str(experiment_path)])
+
+    assert result.exit_code == 0
+    assert "vista-demo" in result.stdout
+    assert "artifact_root" in result.stdout
+
+
+def test_run_experiment_config_command_prints_report(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    from prml_vslam.main import app
+
+    experiment_path = _write_experiment_config(tmp_path)
+    monkeypatch.setattr("prml_vslam.main.get_path_config", lambda: PathConfig(root=tmp_path))
+    monkeypatch.setattr(
+        "prml_vslam.main.run_experiment",
+        lambda experiment_config, path_config: ExperimentReport(
+            experiment_id=experiment_config.name,
+            started_at=datetime.now().astimezone(),
+            completed_at=datetime.now().astimezone(),
+        ),
+    )
+
+    result = runner.invoke(app, ["run-experiment-config", str(experiment_path)])
+
+    assert result.exit_code == 0
+    assert "offline-smoke" in result.stdout
+
+
+def test_report_serialization_handles_empty_tables(tmp_path: Path) -> None:
+    config = ExperimentConfig(name="empty-report", items=[ExperimentItem(id="vista", run_config=_run_config(tmp_path))])
+    report = run_experiment(
+        config,
+        path_config=PathConfig(root=tmp_path),
+        run_service_factory=lambda path_config: _FakeRunService(path_config),
+    )
+
+    updated = write_experiment_report(report, output_dir=tmp_path / "manual-report")
+
+    assert updated.report_json_path is not None and updated.report_json_path.is_file()
+    assert updated.metrics_csv_path is not None and updated.metrics_csv_path.is_file()
+
+
+def test_wandb_disabled_mode_is_noop(tmp_path: Path) -> None:
+    config = ExperimentConfig(name="wandb-off", items=[ExperimentItem(id="vista", run_config=_run_config(tmp_path))])
+    report = run_experiment(
+        config,
+        path_config=PathConfig(root=tmp_path),
+        run_service_factory=lambda path_config: _FakeRunService(path_config),
+    )
+
+    log_run_to_wandb(config=config, result=report.results[0])
+
+
+def test_wandb_mocked_mode_logs_metrics(tmp_path: Path) -> None:
+    config = ExperimentConfig(
+        name="wandb-on",
+        wandb={"enabled": True, "project": "prml-vslam-test", "mode": "offline"},
+        items=[ExperimentItem(id="vista", run_config=_run_config(tmp_path, trajectory_eval=True))],
+    )
+    disabled_config = config.model_copy(update={"wandb": config.wandb.model_copy(update={"enabled": False})})
+    report = run_experiment(
+        disabled_config,
+        path_config=PathConfig(root=tmp_path),
+        run_service_factory=lambda path_config: _FakeRunService(path_config),
+    )
+    wandb = _FakeWandbModule("wandb")
+
+    log_run_to_wandb(config=config, result=report.results[0], wandb_module=wandb)
+
+    assert wandb.runs[0].logged
+    assert wandb.runs[0].summary["terminal_state"] == "completed"
+
+
+class _FakeRunService:
+    def __init__(self, path_config: PathConfig) -> None:
+        self.path_config = path_config
+        self._snapshot = RunSnapshot()
+
+    def start_run(self, *, run_config: RunConfig, runtime_source=None) -> None:
+        plan = run_config.compile_plan(self.path_config)
+        _write_artifacts(plan.artifact_root, run_config=run_config)
+        self._snapshot = RunSnapshot(run_id=plan.run_id, state=RunState.COMPLETED, plan=plan)
+
+    def snapshot(self) -> RunSnapshot:
+        return self._snapshot
+
+    def stop_run(self) -> None:
+        self._snapshot = self._snapshot.model_copy(update={"state": RunState.STOPPED})
+
+    def shutdown(self, *, preserve_local_head: bool = False) -> None:
+        return None
+
+
+class _FakeWandbRun:
+    def __init__(self) -> None:
+        self.summary = {}
+        self.logged: list[dict[str, float | int | bool]] = []
+
+    def log(self, payload: dict[str, float | int | bool]) -> None:
+        self.logged.append(payload)
+
+    def finish(self) -> None:
+        return None
+
+
+class _FakeWandbModule(ModuleType):
+    def __init__(self, name: str) -> None:
+        super().__init__(name)
+        self.runs: list[_FakeWandbRun] = []
+
+    def init(self, **kwargs) -> _FakeWandbRun:
+        run = _FakeWandbRun()
+        run.summary["init_kwargs"] = kwargs
+        self.runs.append(run)
+        return run
+
+
+def _run_config(
+    tmp_path: Path,
+    *,
+    trajectory_eval: bool = False,
+    trajectory_alignment: bool = False,
+    cloud_alignment: bool = False,
+) -> RunConfig:
+    return build_run_config(
+        experiment_name="vista experiment",
+        output_dir=Path("artifacts"),
+        source_backend=VideoSourceConfig(video_path=Path("captures/demo.mp4")),
+        method=MethodId.VISTA,
+        trajectory_eval_enabled=trajectory_eval,
+        trajectory_alignment_enabled=trajectory_alignment,
+        cloud_alignment_enabled=cloud_alignment,
+        export_viewer_rrd=True,
+        ray_log_to_driver=False,
+    )
+
+
+def _write_experiment_config(tmp_path: Path) -> Path:
+    run_config_path = tmp_path / "run.toml"
+    _run_config(tmp_path).save_toml(run_config_path)
+    experiment_path = tmp_path / "experiment.toml"
+    experiment_path.write_text(
+        """
+name = "offline-smoke"
+output_dir = "experiment-artifacts"
+
+[[items]]
+id = "vista-demo"
+run_config_path = "run.toml"
+dataset_id = "video"
+sequence_id = "demo"
+method_id = "vista"
+""",
+        encoding="utf-8",
+    )
+    return experiment_path
+
+
+def _write_artifacts(artifact_root: Path, *, run_config: RunConfig) -> None:
+    paths = RunArtifactPaths.build(artifact_root)
+    _write_text(paths.trajectory_path, "0 0 0 0 0 0 0 1\n")
+    _write_text(paths.point_cloud_path, "ply\nformat ascii 1.0\nend_header\n")
+    _write_text(paths.viewer_rrd_path, "rrd")
+    if run_config.stages.align_trajectory.enabled:
+        _write_json(
+            paths.artifact_root / "evaluation" / "trajectory_alignment.json",
+            {"rms_error_m": 0.1, "scale": 1.0, "matched_pairs": 10},
+        )
+        _write_text(paths.artifact_root / "evaluation" / "trajectory_sim3_aligned.tum", "0 0 0 0 0 0 0 1\n")
+    if run_config.stages.evaluate_trajectory.enabled:
+        _write_json(
+            paths.trajectory_metrics_path,
+            {
+                "matched_pairs": 10,
+                "stats": {"rmse": 0.1, "mean": 0.1, "median": 0.1, "std": 0.0, "min": 0.1, "max": 0.1, "sse": 0.1},
+            },
+        )
+    if run_config.stages.align_cloud.enabled:
+        _write_json(
+            paths.artifact_root / "evaluation" / "cloud_alignment.json",
+            {"fitness": 0.9, "inlier_rmse_m": 0.02, "max_correspondence_distance_m": 0.1},
+        )
+    _write_json(
+        paths.stage_manifests_path,
+        [
+            {
+                "stage_id": StageKey.SLAM.value,
+                "config_hash": "slam-hash",
+                "input_fingerprint": "slam-input",
+                "output_paths": {
+                    "trajectory_tum": paths.trajectory_path.as_posix(),
+                    "dense_points_ply": paths.point_cloud_path.as_posix(),
+                },
+                "status": "completed",
+            }
+        ],
+    )
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_json(path: Path, payload) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")


### PR DESCRIPTION
## Summary
This PR adds a narrow offline benchmark experiment scaffold that groups existing pipeline `RunConfig`s into typed `ExperimentConfig`s, expands them through the existing planner, executes them sequentially through `RunService`, validates canonical artifacts, writes tidy JSON/CSV/Parquet reports, and optionally logs run metadata and scalar metrics to W&B without making W&B the scheduling or config authority.

Focused verification completed:
- `prml-vslam-worktree-env run pytest tests/test_experiments.py -q`
- `prml-vslam-worktree-env run ruff check src/prml_vslam/experiments src/prml_vslam/main.py tests/test_experiments.py`
- `prml-vslam-worktree-env run pytest tests/test_experiments.py tests/test_cli.py -q`
- `prml-vslam-worktree-env run make lint`
- `prml-vslam-worktree-env run make graphify-rebuild`
- `prml-vslam-worktree-env run make ci` (520 passed, 2 skipped, 1 warning)

## Work Packages
| WP | Scope | Primary surfaces | Status |
| --- | --- | --- | --- |
| WP1 | Experiment contracts | `src/prml_vslam/experiments/config.py`, `contracts.py` | new scope, scaffold resolved |
| WP2 | Offline execution and validation | `execution.py`, `validation.py` | new scope, scaffold resolved |
| WP3 | Tidy reports and W&B logging | `reporting.py`, `wandb_logging.py` | new scope, scaffold resolved |
| WP4 | CLI and tests | `src/prml_vslam/main.py`, `tests/test_experiments.py` | resolved |

## WP1 — Experiment Contracts
### Scope
- Added typed `ExperimentConfig`, `ExperimentItem`, W&B logging config, and persisted result DTOs for specs, validations, metrics, artifacts, per-run results, and experiment reports.
- Config loading keeps run config paths declarative and resolves relative item paths against the experiment TOML location.

### Key files
- `src/prml_vslam/experiments/config.py`
- `src/prml_vslam/experiments/contracts.py`
- `src/prml_vslam/experiments/__init__.py`

### Initial success criteria resolution
- `group multiple offline RunConfigs`: `new scope, scaffold resolved`
- `reuse typed RunConfig/factory-config patterns`: `resolved`
- `avoid runtime instance serialization`: `resolved`

## WP2 — Offline Execution And Validation
### Scope
- Added explicit item expansion via `RunConfig.compile_plan()` and sequential execution via the existing `RunService` façade.
- Enforced offline mode at expansion/execution boundaries.
- Added deterministic per-run validations for terminal state, artifact root, SLAM trajectory, dense point cloud, Rerun recording, trajectory alignment, trajectory metrics, and cloud alignment fields when those stages are configured.

### Key files
- `src/prml_vslam/experiments/execution.py`
- `src/prml_vslam/experiments/validation.py`

### Initial success criteria resolution
- `offline run execution through existing pipeline path`: `resolved`
- `artifact validation gates`: `resolved`
- `no optimizer or tuning framework`: `resolved`

## WP3 — Tidy Reports And W&B Logging
### Scope
- Added long-form metric, validation, and artifact table collection with JSON/CSV/Parquet persistence under the experiment output directory.
- Collected existing trajectory and cloud metric artifacts into tidy rows without adding new metric implementations.
- Added optional lazy W&B logging: disabled mode imports no W&B package; enabled mode logs config metadata, terminal status, validation counts, and scalar metrics.

### Key files
- `src/prml_vslam/experiments/reporting.py`
- `src/prml_vslam/experiments/wandb_logging.py`

### Initial success criteria resolution
- `machine-readable summary`: `resolved`
- `long-form pandas result exports`: `resolved`
- `W&B experiment logging as tracker, not scheduler`: `resolved`

## WP4 — CLI And Tests
### Scope
- Added `plan-experiment-config` and `run-experiment-config` commands beside the existing run-config commands.
- Added focused tests for config parsing, item expansion, offline enforcement, validation pass/fail behavior, report serialization, W&B disabled/mocked modes, and command surfaces.
- Refreshed Graphify artifacts after adding the new package.

### Key files
- `src/prml_vslam/main.py`
- `tests/test_experiments.py`
- `graphify-out/GRAPH_REPORT.md`
- `graphify-out/graph.json`
- `graphify-out/graph.html`

### Initial success criteria resolution
- `config parsing and expansion tests`: `resolved`
- `run construction without heavy SLAM`: `resolved`
- `W&B disabled and mocked coverage`: `resolved`
- `CLI planning/running surfaces`: `resolved`
