### PR TITLE
Repair repo-local memory and graph tooling

### DIFF
--- a/.agents/SETUP.md
+++ b/.agents/SETUP.md
@@ -21,8 +21,56 @@ docker mcp profile pull docker.io/janduchscherer104/codex:latest
 Then open this repository in Codex. The repo-local config wires:
 
 - `docker mcp gateway run --profile codex`
-- `uvx code-index-mcp`
+- `uvx code-index-mcp --project-path .`
+- `python3 .agents/scripts/graphify_repo.py mcp`
+- `python3 .agents/skills/mempalace-repo/scripts/mempalace_repo.py mcp`
 - the repo-local skills under `.agents/skills/`
 
 If a server needs credentials, configure them locally and do not commit them to
 the repository.
+
+## MCP Surfaces
+
+- Docker MCP Toolkit exposes shared external tools such as Context7. Use
+  `.agents/references/agent_reference.md` for the repo's known Context7 library
+  IDs before falling back to broad web search.
+- Code Index is the fast local symbol and file discovery surface. The checked-in
+  config uses `--project-path .` so linked worktrees point at their own source
+  tree.
+- Graphify serves `graphify-out/graph.json` through the repo wrapper. Because
+  `graphify-out/graph.json` and `graphify-out/graph.html` are Git LFS artifacts,
+  the wrapper materializes `graph.json` before MCP startup when the checkout
+  only has a pointer file.
+- MemPalace serves the repo-local palace through the repo wrapper. The wrapper
+  uses the installed `mempalace` and `mempalace-mcp` executables and pins
+  `.artifacts/mempalace/palace` instead of the global `~/.mempalace` palace.
+
+## MemPalace Mining Scope
+
+The refresh helper stages two wings:
+
+- `prml-vslam-docs`: root docs, `docs/` markdown/Typst/bibliography/text files,
+  package README/REQUIREMENTS/AGENTS files, repo-local agent skills, agent
+  references, agents-db TOML state, and checked-in Codex config/hooks.
+- `prml-vslam-chats`: raw repo-scoped Codex session JSONL files copied from the
+  configured Codex home, plus compact JSONL exports for inspection.
+
+Do not mine `.artifacts/`, `.omx/`, `graphify-out/`, caches, generated binary
+outputs, or full source files by default. Those surfaces are derived, runtime
+local, or too noisy for durable recall. If a future task needs more memory
+coverage, prefer adding compact owner surfaces under `.agents/references/`,
+`.agents/skills/`, or the agents DB instead of mining large generated output.
+
+MemPalace init is heuristic-only by default. To use local Ollama refinement
+during init, run with:
+
+```bash
+MEMPALACE_INIT_LLM=1 \
+MEMPALACE_INIT_LLM_PROVIDER=ollama \
+MEMPALACE_INIT_LLM_MODEL=gemma4:e4b \
+python3 .agents/skills/mempalace-repo/scripts/mempalace_repo.py refresh
+```
+
+External subscription or OpenAI-compatible providers are opt-in only. Set
+`MEMPALACE_ACCEPT_EXTERNAL_LLM=1` only after deciding that the staged repo docs
+and agent scaffold may be sent to that provider.

--- a/.agents/references/agent_reference.md
+++ b/.agents/references/agent_reference.md
@@ -18,6 +18,8 @@
 - `/isl-org/open3d` - 3D data processing and evaluation
 - `/michaelgrupp/evo` - Trajectory evaluation for odometry and SLAM
 - `/rerun-io/rerun` - Rerun visualization stack for robotics and spatial data
+- `/safishamsi/graphify` - Graphify codebase knowledge graph, MCP server, and hook usage
+- `/mempalace/mempalace` - MemPalace local memory CLI, mining, wake-up, and MCP usage
 
 ## Primary Sources
 
@@ -33,6 +35,8 @@
 - evo plot helpers (`traj_colormap`, trajectory plotting internals): <https://github.com/MichaelGrupp/evo/blob/master/evo/tools/plot.py>
 - Rerun docs.rs crate docs: <https://docs.rs/rerun/latest/rerun/>
 - Rerun repo: <https://github.com/rerun-io/rerun>
+- Graphify repo: <https://github.com/safishamsi/graphify>
+- MemPalace repo: <https://github.com/mempalace/mempalace>
 - Nerfstudio docs: <https://docs.nerf.studio/>
 - Nerfstudio data conventions: <https://docs.nerf.studio/quickstart/data_conventions.html>
 - ViSTA-SLAM GH pages: <https://ganlinzhang.xyz/vista-slam/>

--- a/.agents/scripts/graphify_repo.py
+++ b/.agents/scripts/graphify_repo.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Repo-local Graphify helper for status, reports, and MCP startup."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+GRAPHIFY_DIR = Path("graphify-out")
+GRAPHIFY_REPORT = GRAPHIFY_DIR / "GRAPH_REPORT.md"
+GRAPHIFY_GRAPH = GRAPHIFY_DIR / "graph.json"
+GRAPHIFY_HTML = GRAPHIFY_DIR / "graph.html"
+LFS_POINTER_PREFIX = "version https://git-lfs.github.com/spec/v1"
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def is_lfs_pointer(path: Path) -> bool:
+    if not path.exists() or not path.is_file():
+        return False
+    try:
+        return _read_text(path).startswith(LFS_POINTER_PREFIX)
+    except UnicodeDecodeError:
+        return False
+
+
+def graphify_version() -> str:
+    try:
+        return version("graphifyy")
+    except PackageNotFoundError:
+        return "missing"
+
+
+def _report_summary() -> dict[str, str]:
+    report_path = repo_root() / GRAPHIFY_REPORT
+    if not report_path.exists():
+        return {}
+    report = _read_text(report_path)
+    date = re.search(r"^# Graph Report - .*\(([^)]*)\)", report, re.M)
+    summary = re.search(r"^- (\d+) nodes .+? (\d+) edges .+? (\d+) communities detected", report, re.M)
+    return {
+        "date": date.group(1) if date else "unknown",
+        "nodes": summary.group(1) if summary else "unknown",
+        "links": summary.group(2) if summary else "unknown",
+        "communities": summary.group(3) if summary else "unknown",
+    }
+
+
+def _materialized_graph_summary() -> dict[str, str]:
+    graph = json.loads(_read_text(repo_root() / GRAPHIFY_GRAPH))
+    nodes = graph.get("nodes", [])
+    links = graph.get("links", graph.get("edges", []))
+    return {"nodes": str(len(nodes)), "links": str(len(links))}
+
+
+def _git_status(paths: list[Path]) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "status", "--short", "--", *[str(path) for path in paths]],
+            cwd=repo_root(),
+            text=True,
+            check=True,
+            capture_output=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return "unknown"
+    return "modified" if result.stdout.strip() else "clean"
+
+
+def status() -> None:
+    for path, label in (
+        (GRAPHIFY_DIR, "graphify directory"),
+        (GRAPHIFY_REPORT, "graphify report"),
+        (GRAPHIFY_GRAPH, "graphify graph data"),
+    ):
+        if not (repo_root() / path).exists():
+            raise SystemExit(f"Missing {label}: {path}")
+
+    print(f"graphify artifacts: {GRAPHIFY_DIR}")
+    print(f"report: {GRAPHIFY_REPORT}")
+    print(f"graph data: {GRAPHIFY_GRAPH}")
+    if (repo_root() / GRAPHIFY_HTML).exists():
+        print(f"viewer: {GRAPHIFY_HTML}")
+    print(
+        f"runtime: {'available (graphifyy ' + graphify_version() + ')' if graphify_version() != 'missing' else 'missing'}"
+    )
+
+    summary = _report_summary()
+    if is_lfs_pointer(repo_root() / GRAPHIFY_GRAPH):
+        print("graph data state: git-lfs pointer")
+        print(
+            "graph data hydration: run `git lfs pull --include=graphify-out/graph.json` or `make graphify-rebuild` before MCP startup"
+        )
+    else:
+        summary.update(_materialized_graph_summary())
+        print("graph data state: materialized")
+    if summary:
+        print(f"graph date: {summary.get('date', 'unknown')}")
+        print(f"nodes: {summary.get('nodes', 'unknown')}")
+        print(f"links: {summary.get('links', 'unknown')}")
+        print(f"communities: {summary.get('communities', 'unknown')}")
+    print(f"artifact dirty state: {_git_status([GRAPHIFY_REPORT, GRAPHIFY_GRAPH, GRAPHIFY_HTML])}")
+    print("next: make graphify-report | make graphify-rebuild | make graphify-hook-install")
+
+
+def report() -> None:
+    if not (repo_root() / GRAPHIFY_REPORT).exists():
+        raise SystemExit(f"Missing graphify report: {GRAPHIFY_REPORT}")
+    text = _read_text(repo_root() / GRAPHIFY_REPORT)
+    print(text.splitlines()[0])
+    for name in ("Corpus Check", "Summary", "Suggested Questions"):
+        match = re.search(r"^## " + re.escape(name) + r"\n(.*?)(?=^## |\Z)", text, re.M | re.S)
+        if match:
+            print(f"\n## {name}\n{match.group(1).strip()}")
+
+
+def materialize_graph_for_mcp() -> None:
+    graph_path = repo_root() / GRAPHIFY_GRAPH
+    if not graph_path.exists():
+        raise SystemExit(f"Missing graphify graph data: {GRAPHIFY_GRAPH}")
+    if not is_lfs_pointer(graph_path):
+        json.loads(_read_text(graph_path))
+        return
+
+    pull = subprocess.run(
+        ["git", "lfs", "pull", "--include=graphify-out/graph.json", "--exclude="],
+        cwd=repo_root(),
+        text=True,
+        capture_output=True,
+    )
+    if pull.returncode != 0:
+        raise SystemExit(
+            "Graphify graph data is a Git LFS pointer and `git lfs pull` failed.\n"
+            f"stdout:\n{pull.stdout}\nstderr:\n{pull.stderr}"
+        )
+    if is_lfs_pointer(graph_path):
+        raise SystemExit(
+            "Graphify graph data is still a Git LFS pointer after `git lfs pull`; "
+            "run `git lfs pull --include=graphify-out/graph.json` or `make graphify-rebuild`."
+        )
+    json.loads(_read_text(graph_path))
+
+
+def mcp() -> None:
+    materialize_graph_for_mcp()
+    uv = os.environ.get("UV_BIN", "uv")
+    os.execvp(
+        uv,
+        [
+            uv,
+            "run",
+            "--preview-features",
+            "extra-build-dependencies",
+            "--group",
+            "dev",
+            "python",
+            "-m",
+            "graphify.serve",
+            str(GRAPHIFY_GRAPH),
+        ],
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("status", help="Show graphify artifact and runtime status.")
+    subparsers.add_parser("report", help="Print the top of the graphify report.")
+    subparsers.add_parser("mcp", help="Start the graphify MCP server after LFS preflight.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.command == "status":
+        status()
+    elif args.command == "report":
+        report()
+    elif args.command == "mcp":
+        mcp()
+    else:
+        raise RuntimeError(f"Unhandled command: {args.command}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/mempalace_startup_context.sh
+++ b/.agents/scripts/mempalace_startup_context.sh
@@ -8,6 +8,7 @@ helper=".agents/skills/mempalace-repo/scripts/mempalace_repo.py"
 log_dir=".artifacts/mempalace/logs"
 lock_dir=".artifacts/mempalace/startup-refresh.lock"
 log_file="$log_dir/startup-refresh.log"
+pid_file="$lock_dir/pid"
 
 echo "PRML VSLAM MemPalace startup context"
 
@@ -18,20 +19,59 @@ fi
 
 mkdir -p "$log_dir"
 
+start_refresh() {
+  if command -v setsid >/dev/null 2>&1; then
+    setsid bash -c '
+      lock_dir="$1"
+      pid_file="$2"
+      log_file="$3"
+      helper="$4"
+      trap "rm -f \"$pid_file\"; rmdir \"$lock_dir\" 2>/dev/null || true" EXIT
+      printf "%s\n" "$$" >"$pid_file"
+      {
+        printf "\n[%s] startup refresh begin\n" "$(date -Is)"
+        python3 "$helper" refresh
+        printf "[%s] startup refresh end\n" "$(date -Is)"
+      } >>"$log_file" 2>&1
+    ' bash "$lock_dir" "$pid_file" "$log_file" "$helper" >/dev/null 2>&1 &
+  else
+    nohup bash -c '
+      lock_dir="$1"
+      pid_file="$2"
+      log_file="$3"
+      helper="$4"
+      trap "rm -f \"$pid_file\"; rmdir \"$lock_dir\" 2>/dev/null || true" EXIT
+      printf "%s\n" "$$" >"$pid_file"
+      {
+        printf "\n[%s] startup refresh begin\n" "$(date -Is)"
+        python3 "$helper" refresh
+        printf "[%s] startup refresh end\n" "$(date -Is)"
+      } >>"$log_file" 2>&1
+    ' bash "$lock_dir" "$pid_file" "$log_file" "$helper" >/dev/null 2>&1 &
+  fi
+}
+
 if [ "${MEMPALACE_SKIP_STARTUP_REFRESH:-}" = "1" ]; then
   echo "- Startup refresh skipped by MEMPALACE_SKIP_STARTUP_REFRESH=1."
 elif mkdir "$lock_dir" 2>/dev/null; then
-  (
-    trap 'rmdir "$lock_dir" 2>/dev/null || true' EXIT
-    {
-      printf '\n[%s] startup refresh begin\n' "$(date -Is)"
-      python3 "$helper" refresh
-      printf '[%s] startup refresh end\n' "$(date -Is)"
-    } >>"$log_file" 2>&1
-  ) &
-  echo "- Refreshing docs and Codex chat histories in the background."
+  start_refresh
+  echo "- Refreshing docs, agent scaffold, and Codex chat histories in the background."
 else
-  echo "- A MemPalace startup refresh is already running."
+  existing_pid=""
+  if [ -f "$pid_file" ]; then
+    existing_pid="$(cat "$pid_file" 2>/dev/null || true)"
+  fi
+  if [ -n "$existing_pid" ] && kill -0 "$existing_pid" 2>/dev/null; then
+    echo "- A MemPalace startup refresh is already running."
+  else
+    rm -rf "$lock_dir"
+    if mkdir "$lock_dir" 2>/dev/null; then
+      start_refresh
+      echo "- Removed stale MemPalace startup lock and restarted refresh."
+    else
+      echo "- A MemPalace startup refresh is already running."
+    fi
+  fi
 fi
 
 echo "- Refresh log: \`$log_file\`"

--- a/.agents/skills/graphify/SKILL.md
+++ b/.agents/skills/graphify/SKILL.md
@@ -13,13 +13,19 @@ Use this skill in repositories that carry a `graphify-out/` knowledge graph.
 2. If `graphify-out/wiki/index.md` exists, use it as the first navigation surface before reading raw files directly.
 3. Use `make graphify` for a concise artifact, runtime, hook, and freshness dashboard.
 4. Use `make graphify-report` when you only need the report summary.
-5. Use `make graphify-view` to locate the generated HTML graph viewer.
-6. Use `make graphify-hook-status` to check local post-commit/post-checkout hooks without failing the workflow.
-7. Use `make graphify-hook-install` once per clone to install the local graph refresh hooks.
-8. After modifying code files in a graphify-enabled repository, run `make graphify-rebuild`.
+5. Use `python3 .agents/scripts/graphify_repo.py mcp` as the repo-local MCP
+   startup wrapper; it materializes `graphify-out/graph.json` if the checkout
+   only has a Git LFS pointer.
+6. Use `make graphify-view` to locate the generated HTML graph viewer.
+7. Use `make graphify-hook-status` to check local post-commit/post-checkout hooks without failing the workflow.
+8. Use `make graphify-hook-install` once per clone to install the local graph refresh hooks.
+9. After modifying code files in a graphify-enabled repository, run `make graphify-rebuild`.
 
 ## Notes
 
 - Keep graphify commands repo-relative.
 - Do not hardcode local machine paths in graphify instructions or config.
+- `graphify-out/graph.json` and `graphify-out/graph.html` are Git LFS-managed
+  artifacts in this repo. Treat pointer files as a normal checkout state for
+  status/report commands, but materialize `graph.json` before MCP startup.
 - If `make graphify-status` reports that the runtime is missing, the existing artifacts can still guide codebase navigation, but rebuilds require the official `graphifyy` package and `graphify` CLI.

--- a/.agents/skills/mempalace-repo/SKILL.md
+++ b/.agents/skills/mempalace-repo/SKILL.md
@@ -14,6 +14,7 @@ repository.
 - the staged docs source tree under `.artifacts/mempalace/sources/docs`
 - the staged Codex raw session copies under `.artifacts/mempalace/sources/chats`
 - refresh/search workflows through the wrapper script
+- repo-local MCP startup through the installed `mempalace-mcp` executable
 
 ## Workflow
 
@@ -50,6 +51,11 @@ python3 .agents/skills/mempalace-repo/scripts/mempalace_repo.py wake-up
    but complete enough for later mining: decisions, files changed, validation,
    blockers, and follow-up facts.
 
+The docs wing intentionally includes repo guidance, `.agents/skills/`,
+`.agents/references/`, agents-db TOML state, and checked-in Codex config/hooks
+in addition to public docs. Do not add generated artifacts, `.omx/` runtime
+state, caches, or full source trees to the default mining scope.
+
 ## Guardrails
 
 - Treat the repo-local palace as derived state. Refresh it instead of editing
@@ -61,5 +67,8 @@ python3 .agents/skills/mempalace-repo/scripts/mempalace_repo.py wake-up
   needed.
 - Do not assume the global `~/.mempalace` palace is the one this repo uses; the
   wrapper script pins a repo-local palace path.
+- Do not assume MemPalace is importable from the repo virtualenv. The wrapper
+  locates `mempalace` and `mempalace-mcp` on PATH, with `MEMPALACE_BIN` and
+  `MEMPALACE_MCP_BIN` overrides for unusual installs.
 - Treat `.artifacts/mempalace/` as derived state. Do not hand-edit staged
   sources, logs, or palace index files.

--- a/.agents/skills/mempalace-repo/scripts/mempalace_repo.py
+++ b/.agents/skills/mempalace-repo/scripts/mempalace_repo.py
@@ -14,6 +14,15 @@ from pathlib import Path
 DOC_SUFFIXES = {".md", ".typ", ".bib", ".txt"}
 ROOT_DOC_FILES = ("README.md", "SETUP.md", "AGENTS.md")
 PACKAGE_DOC_NAMES = {"README.md", "REQUIREMENTS.md", "AGENTS.md"}
+AGENT_MEMORY_FILES = (
+    ".agents/AGENTS_INTERNAL_DB.md",
+    ".agents/issues.toml",
+    ".agents/todos.toml",
+    ".agents/refactors.toml",
+    ".agents/resolved.toml",
+    ".codex/config.toml",
+    ".codex/hooks.json",
+)
 DOCS_WING = "prml-vslam-docs"
 CHATS_WING = "prml-vslam-chats"
 AGENT_NAME = "prml-vslam-codex"
@@ -24,16 +33,37 @@ def repo_root() -> Path:
     return Path(__file__).resolve().parents[4]
 
 
-def venv_python() -> Path:
-    return repo_root() / ".venv" / "bin" / "python"
+def shared_repo_root() -> Path:
+    try:
+        common_dir = subprocess.check_output(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            cwd=repo_root(),
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return repo_root()
+    if not common_dir:
+        return repo_root()
+    return Path(common_dir).resolve().parent
+
+
+def mempalace_root() -> Path:
+    local_root = repo_root() / ".artifacts" / "mempalace"
+    if (local_root / "palace").exists():
+        return local_root
+    shared_root = shared_repo_root() / ".artifacts" / "mempalace"
+    if (shared_root / "palace").exists():
+        return shared_root
+    return local_root
 
 
 def palace_path() -> Path:
-    return repo_root() / ".artifacts" / "mempalace" / "palace"
+    return mempalace_root() / "palace"
 
 
 def sources_root() -> Path:
-    return repo_root() / ".artifacts" / "mempalace" / "sources"
+    return mempalace_root() / "sources"
 
 
 def docs_source_root() -> Path:
@@ -46,10 +76,6 @@ def chats_source_root() -> Path:
 
 def exports_source_root() -> Path:
     return sources_root() / "exports"
-
-
-def windows_codex_home() -> Path:
-    return Path("/mnt/c/Users/jandu/.codex")
 
 
 def _load_codex_history_module():
@@ -65,9 +91,6 @@ def _load_codex_history_module():
 
 def _candidate_codex_homes(history) -> list[Path]:
     candidates = list(history._candidate_codex_homes())
-    windows_home = windows_codex_home()
-    if windows_home.exists():
-        candidates.append(windows_home)
     unique: list[Path] = []
     seen: set[Path] = set()
     for candidate in candidates:
@@ -119,8 +142,26 @@ def _mempalace_env() -> dict[str, str]:
     return env
 
 
-def run_python_module(module: str, *args: str, capture_output: bool = False) -> subprocess.CompletedProcess[str]:
-    command = [str(venv_python()), "-m", module, *args]
+def _require_executable(env_name: str, default_name: str) -> str:
+    configured = os.environ.get(env_name)
+    if configured:
+        return configured
+    executable = shutil.which(default_name)
+    if executable is None:
+        raise RuntimeError(f"Missing `{default_name}` executable on PATH; install it or set {env_name}.")
+    return executable
+
+
+def mempalace_executable() -> str:
+    return _require_executable("MEMPALACE_BIN", "mempalace")
+
+
+def mempalace_mcp_executable() -> str:
+    return _require_executable("MEMPALACE_MCP_BIN", "mempalace-mcp")
+
+
+def run_mempalace(*args: str, capture_output: bool = False) -> subprocess.CompletedProcess[str]:
+    command = [mempalace_executable(), "--palace", str(palace_path()), *args]
     return subprocess.run(
         command,
         cwd=repo_root(),
@@ -131,11 +172,37 @@ def run_python_module(module: str, *args: str, capture_output: bool = False) -> 
     )
 
 
+def _init_llm_args() -> list[str]:
+    if os.environ.get("MEMPALACE_INIT_LLM") != "1":
+        return ["--no-llm"]
+
+    args: list[str] = []
+    provider = os.environ.get("MEMPALACE_INIT_LLM_PROVIDER")
+    model = os.environ.get("MEMPALACE_INIT_LLM_MODEL")
+    endpoint = os.environ.get("MEMPALACE_INIT_LLM_ENDPOINT")
+    api_key = os.environ.get("MEMPALACE_INIT_LLM_API_KEY")
+    if provider:
+        args.extend(["--llm-provider", provider])
+    if model:
+        args.extend(["--llm-model", model])
+    if endpoint:
+        args.extend(["--llm-endpoint", endpoint])
+    if api_key:
+        args.extend(["--llm-api-key", api_key])
+    if os.environ.get("MEMPALACE_ACCEPT_EXTERNAL_LLM") == "1":
+        args.append("--accept-external-llm")
+    return args
+
+
 def ensure_runtime() -> None:
-    if not venv_python().exists():
-        raise RuntimeError(f"Missing repo venv python at {venv_python()}")
-    command = [str(venv_python()), "-c", "import mempalace"]
-    subprocess.run(command, cwd=repo_root(), env=_mempalace_env(), text=True, check=True)
+    subprocess.run(
+        [mempalace_executable(), "--version"],
+        cwd=repo_root(),
+        env=_mempalace_env(),
+        text=True,
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
 
 
 def _clear_directory(path: Path) -> None:
@@ -166,6 +233,15 @@ def _iter_docs_files() -> list[Path]:
         for path in package_dir.rglob("*"):
             if path.is_file() and path.name in PACKAGE_DOC_NAMES:
                 docs_files.add(path)
+    agents_dir = repo_root() / ".agents"
+    if agents_dir.exists():
+        for path in agents_dir.rglob("*"):
+            if path.is_file() and (path.name == "SKILL.md" or path.suffix in DOC_SUFFIXES):
+                docs_files.add(path)
+    for name in AGENT_MEMORY_FILES:
+        path = repo_root() / name
+        if path.exists():
+            docs_files.add(path)
     return sorted(docs_files)
 
 
@@ -224,12 +300,11 @@ def initialize_docs_source() -> None:
     docs_root = docs_source_root()
     if (docs_root / "mempalace.yaml").exists():
         return
-    run_python_module("mempalace", "init", str(docs_root), "--yes")
+    run_mempalace("init", str(docs_root), "--yes", *_init_llm_args())
 
 
 def mine_docs() -> None:
-    run_python_module(
-        "mempalace",
+    run_mempalace(
         "mine",
         str(docs_source_root()),
         "--wing",
@@ -240,8 +315,7 @@ def mine_docs() -> None:
 
 
 def mine_chats() -> None:
-    run_python_module(
-        "mempalace",
+    run_mempalace(
         "mine",
         str(chats_source_root()),
         "--mode",
@@ -268,22 +342,24 @@ def refresh() -> None:
 
 def status() -> None:
     ensure_runtime()
-    run_python_module("mempalace", "status")
+    run_mempalace("status")
 
 
 def search(query: str) -> None:
     ensure_runtime()
-    run_python_module("mempalace", "search", query)
+    run_mempalace("search", query)
 
 
 def wake_up() -> None:
     ensure_runtime()
-    run_python_module("mempalace", "wake-up")
+    run_mempalace("wake-up")
 
 
 def mcp() -> None:
     ensure_runtime()
-    run_python_module("mempalace", "--palace", str(palace_path()), "mcp")
+    env = _mempalace_env()
+    executable = mempalace_mcp_executable()
+    os.execve(executable, [executable, "--palace", str(palace_path())], env)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/.agents/skills/scientific-writing/SKILL.md
+++ b/.agents/skills/scientific-writing/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: scientific-writing
+description: Use when drafting, revising, or reviewing PRML VSLAM scientific prose for the report, slides, papers, abstracts, or literature-backed technical narrative.
+metadata:
+  mode: "writing"
+  not_when:
+    - "implementation-only code edits with no scientific prose"
+    - "generic biomedical manuscript formatting unrelated to this project"
+  handoff_to:
+    - "typst-authoring for Typst layout, compilation, or figure placement"
+    - "mempalace-repo for prior-session rationale and durable decisions"
+    - "graphify for architecture navigation before writing about code structure"
+  evidence_required:
+    - "repo artifact, experiment output, source code, or primary paper for each technical claim"
+    - "docs/Questions.md when prose touches project scope or evaluation intent"
+  applies_to:
+    - "docs/**"
+    - "README.md"
+    - "SETUP.md"
+  triggers:
+    - "scientific writing"
+    - "paper"
+    - "report prose"
+    - "abstract"
+    - "related work"
+    - "discussion"
+  must_read:
+    - "AGENTS.md"
+    - "docs/AGENTS.md when editing docs/"
+    - "docs/Questions.md when scope, requirements, or evaluation intent is discussed"
+  verification:
+    - "render or compile the touched Typst/docs surface when non-trivial"
+    - "run citation/source checks when claims or bibliography entries change"
+---
+
+# Scientific Writing
+
+Use this skill for PRML VSLAM scientific prose. The audience is a computer
+vision and spatial computing project, not a generic biomedical journal.
+
+## Use When
+
+- Writing or revising report, slides, abstract, introduction, method, results,
+  discussion, limitations, or related-work text.
+- Turning implementation or experiment facts into source-backed prose.
+- Reviewing scientific claims for scope, evidence, and wording.
+- Explaining architecture or evaluation choices in public-facing docs.
+
+## Do Not Use When
+
+- The task is only code, config, or command execution.
+- A generic manuscript rule conflicts with this repo's scope, artifacts, or
+  report format.
+- The request needs layout mechanics first; use `typst-authoring` for Typst
+  structure, rendering, and figure placement.
+
+## Rules
+
+- Draft with bullet outlines if useful, but final scientific prose must be
+  connected paragraphs unless the target template explicitly requires a list.
+- Ground every technical claim in one of: repo code, generated artifacts,
+  experiment output, docs/Questions.md, or a primary source.
+- Prefer primary papers and official docs for method, dataset, metric, and API
+  claims. Use surveys only for broad field context.
+- State scope and limits directly: dataset, method version, run configuration,
+  metric, artifact path, or section boundary.
+- Keep interpretation separate from measured results. Results state what was
+  observed; discussion explains plausible reasons and limitations.
+- Do not import generic defaults such as mandatory AI-generated figures, fixed
+  figure quotas, CONSORT/STROBE/PRISMA checklists, or `research-lookup`
+  requirements unless the concrete section genuinely needs them.
+- Avoid inflated prose. Replace "novel", "robust", "seamless", "holistic",
+  and "pivotal" with the mechanism, metric, comparison, or limitation.
+- Use Context7 or official docs when prose depends on current library behavior;
+  use `.agents/references/agent_reference.md` for known library IDs.
+
+## Workflow
+
+1. Identify the target surface and audience.
+2. Read the owning docs guidance and the specific artifacts or sources behind
+   the claims.
+3. Build a short outline with claim, scope, evidence, limitation, and citation
+   or repo path for each paragraph.
+4. Convert the outline into prose with one job per paragraph.
+5. Check that citations, terms, metrics, and limitations match the source
+   artifacts.
+6. Run the smallest render, compile, or source check that proves the touched
+   surface still works.
+
+## Paragraph Check
+
+For each paragraph, answer:
+
+1. What is the paragraph's single job?
+2. What claim does it make?
+3. What evidence supports it?
+4. What scope or limitation prevents overclaiming?
+5. Does the final sentence set up the next paragraph or close the section?
+
+If any answer is unclear, fix structure and evidence before polishing style.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -11,21 +11,11 @@ project_doc_fallback_filenames = ["AGENTS.md"]
 
     [mcp_servers.code-index]
     command = "uvx"
-    args    = ["code-index-mcp", "--project-path", "/home/jd/repos/prml-vslam"]
+    args    = ["code-index-mcp", "--project-path", "."]
 
     [mcp_servers.graphify]
-    command = "uv"
-    args = [
-        "run",
-        "--preview-features",
-        "extra-build-dependencies",
-        "--group",
-        "dev",
-        "python",
-        "-m",
-        "graphify.serve",
-        "graphify-out/graph.json",
-    ]
+    command = "python3"
+    args    = [".agents/scripts/graphify_repo.py", "mcp"]
 
     [mcp_servers.mempalace]
     command = "python3"
@@ -55,4 +45,8 @@ enabled = true
 
 [[skills.config]]
 path    = "../.agents/skills/rerun-slam-integration"
+enabled = true
+
+[[skills.config]]
+path    = "../.agents/skills/scientific-writing"
 enabled = true

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -17,24 +17,17 @@
       ]
     },
     "graphify": {
-      "command": "uv",
+      "command": "python3",
       "args": [
-        "run",
-        "--preview-features",
-        "extra-build-dependencies",
-        "--group",
-        "dev",
-        "python",
-        "-m",
-        "graphify.serve",
-        "graphify-out/graph.json"
+        ".agents/scripts/graphify_repo.py",
+        "mcp"
       ]
     },
     "mempalace": {
-      "command": "bash",
+      "command": "python3",
       "args": [
-        "-lc",
-        "cd \"$(git rev-parse --show-toplevel)\" && exec .venv/bin/python -m mempalace.mcp_server --palace .artifacts/mempalace/palace"
+        ".agents/skills/mempalace-repo/scripts/mempalace_repo.py",
+        "mcp"
       ]
     }
   },

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ GRAPHIFY_GRAPH ?= $(GRAPHIFY_DIR)/graph.json
 GRAPHIFY_HTML ?= $(GRAPHIFY_DIR)/graph.html
 GRAPHIFY_PYTHON ?= $(UV_RUN) --preview-features extra-build-dependencies --group dev python
 GRAPHIFY_CLI ?= $(UV_RUN) --preview-features extra-build-dependencies --group dev graphify
+GRAPHIFY_HELPER ?= .agents/scripts/graphify_repo.py
 
 BIB_FILE ?= docs/references.bib
 BIB_CACHE_DIR ?= .cache/bib
@@ -99,21 +100,10 @@ open3d-stubs: ## Regenerate repo-local Open3D .pyi files
 graphify: graphify-status ## Show a concise graphify dashboard
 
 graphify-status: ## Check graphify artifacts and Python runtime availability
-	@test -d "$(GRAPHIFY_DIR)" || { echo "Missing graphify directory: $(GRAPHIFY_DIR)"; exit 1; }
-	@test -f "$(GRAPHIFY_REPORT)" || { echo "Missing graphify report: $(GRAPHIFY_REPORT)"; exit 1; }
-	@test -f "$(GRAPHIFY_GRAPH)" || { echo "Missing graphify graph data: $(GRAPHIFY_GRAPH)"; exit 1; }
-	@printf "graphify artifacts: %s\n" "$(GRAPHIFY_DIR)"
-	@printf "report: %s\n" "$(GRAPHIFY_REPORT)"
-	@printf "graph data: %s\n" "$(GRAPHIFY_GRAPH)"
-	@test ! -f "$(GRAPHIFY_HTML)" || printf "viewer: %s\n" "$(GRAPHIFY_HTML)"
-	@$(GRAPHIFY_PYTHON) -c 'from importlib.metadata import version; print("runtime: available (graphifyy " + version("graphifyy") + ")")'
-	@$(GRAPHIFY_PYTHON) -c 'import json, re; from pathlib import Path; report = Path("$(GRAPHIFY_REPORT)").read_text(encoding="utf-8"); graph = json.loads(Path("$(GRAPHIFY_GRAPH)").read_text(encoding="utf-8")); date = re.search(r"^# Graph Report - .*\(([^)]*)\)", report, re.M); summary = re.search(r"^- (\d+) nodes .+? (\d+) edges .+? (\d+) communities detected", report, re.M); nodes = graph.get("nodes", []); links = graph.get("links", graph.get("edges", [])); print("graph date: " + (date.group(1) if date else "unknown")); print("nodes: " + (summary.group(1) if summary else str(len(nodes)))); print("links: " + (summary.group(2) if summary else str(len(links)))); print("communities: " + (summary.group(3) if summary else "unknown"))'
-	@if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then dirty=$$(git status --short -- "$(GRAPHIFY_REPORT)" "$(GRAPHIFY_GRAPH)" "$(GRAPHIFY_HTML)"); if [ -n "$$dirty" ]; then echo "artifact dirty state: modified"; else echo "artifact dirty state: clean"; fi; fi
-	@printf "next: make graphify-report | make graphify-rebuild | make graphify-hook-install\n"
+	@$(GRAPHIFY_PYTHON) $(GRAPHIFY_HELPER) status
 
 graphify-report: ## Print the top of the graphify report
-	@test -f "$(GRAPHIFY_REPORT)" || { echo "Missing graphify report: $(GRAPHIFY_REPORT)"; exit 1; }
-	@$(GRAPHIFY_PYTHON) -c 'import re; from pathlib import Path; report = Path("$(GRAPHIFY_REPORT)").read_text(encoding="utf-8"); print(report.splitlines()[0]); wanted = ("Corpus Check", "Summary", "Suggested Questions"); [print("\n## " + name + "\n" + match.group(1).strip()) for name in wanted for match in [re.search(r"^## " + re.escape(name) + r"\n(.*?)(?=^## |\Z)", report, re.M | re.S)] if match]'
+	@$(GRAPHIFY_PYTHON) $(GRAPHIFY_HELPER) report
 
 graphify-rebuild: ## Rebuild graphify code artifacts for this repository
 	$(GRAPHIFY_CLI) update .

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,12 +1,12 @@
-# Graph Report - pr91-lingbot-simplify  (2026-06-11)
+# Graph Report - agent-tooling-mempalace-graphify  (2026-06-12)
 
 ## Corpus Check
-- 277 files · ~1,071,768 words
+- 279 files · ~1,072,418 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 4202 nodes · 19090 edges · 31 communities detected
-- Extraction: 32% EXTRACTED · 68% INFERRED · 0% AMBIGUOUS · INFERRED: 12979 edges (avg confidence: 0.59)
+- 4214 nodes · 19112 edges · 33 communities detected
+- Extraction: 32% EXTRACTED · 68% INFERRED · 0% AMBIGUOUS · INFERRED: 12991 edges (avg confidence: 0.59)
 - Token cost: 0 input · 0 output
 
 ## Community Hubs (Navigation)
@@ -41,6 +41,8 @@
 - [[_COMMUNITY_Community 28|Community 28]]
 - [[_COMMUNITY_Community 29|Community 29]]
 - [[_COMMUNITY_Community 30|Community 30]]
+- [[_COMMUNITY_Community 31|Community 31]]
+- [[_COMMUNITY_Community 32|Community 32]]
 
 ## God Nodes (most connected - your core abstractions)
 1. `StageKey` - 434 edges
@@ -55,184 +57,194 @@
 10. `FrameTransform` - 183 edges
 
 ## Surprising Connections (you probably didn't know these)
-- `test_plan_run_defaults_to_live_viewer()` --calls--> `plan_run()`  [INFERRED]
-  tests/test_main.py → src/prml_vslam/main.py
-- `Focused tests for derived ground-plane alignment.` --uses--> `GroundAlignmentMetadata`  [INFERRED]
-  tests/test_ground_alignment.py → src/prml_vslam/interfaces/alignment.py
-- `Small runtime sources used by focused pipeline smoke tests.` --uses--> `SequenceManifest`  [INFERRED]
-  tests/pipeline_testing_support.py → src/prml_vslam/sources/contracts.py
-- `Minimal offline source for pipeline smoke tests.` --uses--> `SequenceManifest`  [INFERRED]
-  tests/pipeline_testing_support.py → src/prml_vslam/sources/contracts.py
-- `Finite in-memory packet stream for streaming smoke tests.` --uses--> `SequenceManifest`  [INFERRED]
-  tests/pipeline_testing_support.py → src/prml_vslam/sources/contracts.py
+- `plan_run()` --calls--> `test_plan_run_defaults_to_live_viewer()`  [INFERRED]
+  src/prml_vslam/main.py → tests/test_main.py
+- `GroundAlignmentMetadata` --uses--> `Focused tests for derived ground-plane alignment.`  [INFERRED]
+  src/prml_vslam/interfaces/alignment.py → tests/test_ground_alignment.py
+- `SequenceManifest` --uses--> `Small runtime sources used by focused pipeline smoke tests.`  [INFERRED]
+  src/prml_vslam/sources/contracts.py → tests/pipeline_testing_support.py
+- `SequenceManifest` --uses--> `Minimal offline source for pipeline smoke tests.`  [INFERRED]
+  src/prml_vslam/sources/contracts.py → tests/pipeline_testing_support.py
+- `SequenceManifest` --uses--> `Finite in-memory packet stream for streaming smoke tests.`  [INFERRED]
+  src/prml_vslam/sources/contracts.py → tests/pipeline_testing_support.py
 
 ## Communities
 
 ### Community 0 - "Community 0"
-Cohesion: 0.01
-Nodes (315): AdvioDownloadManager, _ensure_directory_parent(), Return the cache directory used for downloaded scene archives., Return one catalog scene by id., Return local availability status for every catalog scene., Download selected ADVIO scenes and extract the requested modalities., advio_basis_metadata(), advio_basis_provenance() (+307 more)
+Cohesion: 0.02
+Nodes (424): GroundAlignmentMetadata, InputArtifactDiagnostics, Inspection helpers for persisted pipeline run artifact roots., One submitted run attempt found in a persisted event log., Structured inspection result for one persisted pipeline run., Discover method-level run roots under the configured artifact directory., Load typed metadata and path inventory for one persisted run root., One selectable persisted method-level run artifact root. (+416 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.02
-Nodes (309): _adapt_checkpoint_state_dict(), _as_numpy(), _build_artifacts(), _build_lingbot_artifacts(), _cast_aggregator_for_inference(), _decode_pose_predictions(), _DensePredictionArtifacts, _ensure_uint8_rgb_from_uimg() (+301 more)
+Cohesion: 0.01
+Nodes (324): AdvioDownloadManager, _ensure_directory_parent(), Return the cache directory used for downloaded scene archives., Return one catalog scene by id., Return local availability status for every catalog scene., Download selected ADVIO scenes and extract the requested modalities., advio_basis_metadata(), advio_basis_provenance() (+316 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.02
-Nodes (278): GroundAlignmentMetadata, Result of one derived ground-plane alignment attempt.      When :attr:`applied`, _apply_snapshot_fallbacks(), _candidate_from_root(), _canonical_path_rows(), _derive_slam_artifacts(), discover_run_artifact_roots(), _file_inventory() (+270 more)
+Cohesion: 0.03
+Nodes (332): _DensePredictionArtifacts, _ensure_uint8_rgb_from_uimg(), _estimate_camera_intrinsics_from_frame(), _InProcessManager, _InProcessValue, _LingbotRuntime, Mast3rSlamSession, Canonical MASt3R-SLAM backend adapter (offline + streaming).  This adapter wraps (+324 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.03
-Nodes (319): Controller helpers for the ADVIO Streamlit page., Persist the current ADVIO download-form state., Persist the current explorer selection and load its offline sample., Keep persisted preview state aligned with the runtime snapshot., Apply one preview-form action and return an error message when it fails., MethodId, BaseConfig, AppContext (+311 more)
+Cohesion: 0.01
+Nodes (292): build_advio_comparison_trajectories(), build_crowd_density_figure(), build_local_readiness_figure(), build_scene_attribute_figure(), build_scene_mix_figure(), build_advio_page_data(), handle_advio_preview_action(), load_advio_explorer_sample() (+284 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.02
-Nodes (233): _entity_token(), observation_sequence_artifact_key(), Project source output contracts into durable stage artifact refs., Return the source-stage artifact key for one prepared trajectory., Return the source-stage artifact key for one prepared static cloud., Return the source-stage artifact key for one static cloud metadata file., Return the source-stage artifact key for one observation sequence index., reference_cloud_artifact_key() (+225 more)
+Cohesion: 0.01
+Nodes (285): GroundPlaneModel, GroundPlaneVisualizationHint, Alignment result DTOs shared outside the alignment package.  These datamodels de, Dominant ground-plane hypothesis expressed in native ``world`` coordinates., Finite plane-patch geometry ready for visualization consumers., Result of one derived ground-plane alignment attempt.      When :attr:`applied`, CameraIntrinsics, CameraIntrinsicsSample (+277 more)
 
 ### Community 5 - "Community 5"
 Cohesion: 0.01
-Nodes (289): GroundPlaneModel, GroundPlaneVisualizationHint, Alignment result DTOs shared outside the alignment package.  These datamodels de, Dominant ground-plane hypothesis expressed in native ``world`` coordinates., Finite plane-patch geometry ready for visualization consumers., BaseData, CameraIntrinsics, CameraIntrinsicsSample (+281 more)
+Nodes (235): _build_artifacts(), resolve(), _apply_snapshot_fallbacks(), _candidate_from_root(), _canonical_path_rows(), _derive_slam_artifacts(), discover_run_artifact_roots(), _file_inventory() (+227 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.01
-Nodes (220): load_vista_intrinsics_matrices(), Load native ViSTA per-keyframe 3x3 intrinsics matrices., _build_estimated_intrinsics_series(), _build_unfiltered_cloud_export(), build_vista_artifacts(), _frame_transform_from_vista_pose(), _load_native_point_cloud(), _load_unfiltered_cloud_colors() (+212 more)
+Cohesion: 0.02
+Nodes (171): _is_cuda_oom(), PipelineBackend, _coordinator_actor_options(), Ray-backed backend for plan execution and run attachment.  This module owns subs, Forward a stop request to the named coordinator actor., Fetch the latest projected snapshot from the coordinator actor., Fetch trailing events from the coordinator actor., Resolve one coordinator-owned target transient payload ref. (+163 more)
 
 ### Community 7 - "Community 7"
-Cohesion: 0.02
-Nodes (295): resolve(), Trajectory-alignment contracts shared by evaluation and visualization.  Trajecto, Describe how trajectories are aligned before metric computation., State whether an alignment may publish a downstream dense cloud., Persist an explicit trajectory alignment used for diagnostics or metrics., TrajectoryAlignmentArtifact, TrajectoryAlignmentCloudUseStatus, TrajectoryAlignmentMode (+287 more)
+Cohesion: 0.03
+Nodes (233): BaseConfig, AppContext, AdvioSourceConfig, build_run_config(), CloudAlignmentStageConfig, CloudEvaluationStageConfig, CloudMetricId, _compile_run_plan() (+225 more)
 
 ### Community 8 - "Community 8"
 Cohesion: 0.02
-Nodes (253): build_advio_page_data(), handle_advio_preview_action(), load_advio_explorer_sample(), _scene_rows(), sync_advio_download_state(), sync_advio_preview_state(), validate_dataset_root(), validate_modalities() (+245 more)
+Nodes (228): Controller helpers for the ADVIO Streamlit page., Persist the current ADVIO download-form state., Persist the current explorer selection and load its offline sample., Keep persisted preview state aligned with the runtime snapshot., Apply one preview-form action and return an error message when it fails., _coerce_view_graph(), _coerce_view_graph_node(), load_vista_confidences() (+220 more)
 
 ### Community 9 - "Community 9"
 Cohesion: 0.02
-Nodes (160): build_advio_comparison_trajectories(), build_crowd_density_figure(), build_local_readiness_figure(), build_scene_attribute_figure(), build_scene_mix_figure(), Plotly figure builders for the ADVIO dataset page., Build a crowd-density composition chart., Build a scene-attribute prevalence chart. (+152 more)
+Nodes (192): _adapt_checkpoint_state_dict(), _as_numpy(), _build_lingbot_artifacts(), _cast_aggregator_for_inference(), _decode_pose_predictions(), _expect_lingbot_config(), _extract_checkpoint_state_dict(), _extract_dense_prediction_artifacts() (+184 more)
 
 ### Community 10 - "Community 10"
-Cohesion: 0.03
-Nodes (112): _coordinator_actor_options(), RayPipelineBackend, _enter_page(), ArxivSourceSpec, download_file(), fetch_pdf(), fetch_tex_source(), from_json() (+104 more)
+Cohesion: 0.05
+Nodes (115): build_coverage_matrix(), build_heatmap_data(), build_leaderboard(), build_per_sequence_table(), CoverageCell, CoverageMatrix, HeatmapData, LeaderboardRow (+107 more)
 
 ### Community 11 - "Community 11"
-Cohesion: 0.02
-Nodes (123): BaseConfig, _ConfigFactory, FactoryConfig, from_toml(), _normalize_value(), Shared config and config-as-factory helpers for the repository.  This module own, Render the config as a Rich tree for quick human inspection., Mixin for configs that construct one runtime owner or adapter.      This pattern (+115 more)
+Cohesion: 0.03
+Nodes (88): ArxivSourceSpec, download_file(), fetch_pdf(), fetch_tex_source(), from_json(), load_manifest(), main(), normalize_member_path() (+80 more)
 
 ### Community 12 - "Community 12"
 Cohesion: 0.03
-Nodes (94): analyze_file(), analyze_source(), code_lines_for_source(), collect_dirty_diff_stats(), count_code_line_delta(), count_grouped_stats(), count_module_stats(), count_source_code_delta() (+86 more)
+Nodes (60): IntEnum, build_record3d_frame_details(), _camera_pose_from_binding(), _device_from_binding(), _import_record3d_module(), _intrinsics_from_binding(), list_record3d_usb_devices(), open_record3d_usb_packet_stream() (+52 more)
 
 ### Community 13 - "Community 13"
 Cohesion: 0.07
 Nodes (34): Replay clock used by dataset and video source streams., Select whether replay follows source timing or returns observations immediately., Apply source-timestamp pacing for real-time replay., Reset the clock baseline for a new replay loop or connection., Sleep until the replay timestamp should be emitted., ReplayClock, ReplayMode, ImageSequenceObservationSource (+26 more)
 
 ### Community 14 - "Community 14"
-Cohesion: 0.1
-Nodes (29): Return the user-facing reconstruction label., Configure the minimal Open3D TSDF reconstruction backend.      The repo targets, Return the concrete reconstruction backend type., Instantiate the Open3D TSDF backend while ignoring unrelated kwargs., Describe normalized durable outputs from one reconstruction run.      The minima, ReconstructionArtifacts, ReconstructionMethodId, _import_open3d() (+21 more)
+Cohesion: 0.08
+Nodes (40): validate_modalities(), build_backend_spec(), iter_sequence_manifest_observations(), _load_manifest_rgb_inputs(), _load_rgb(), _load_timestamps_ns(), _manifest_provenance(), Source-owned readers for normalized offline observations. (+32 more)
 
 ### Community 15 - "Community 15"
 Cohesion: 0.12
-Nodes (37): test_load_recording_summary_reports_live_keyed_and_tracking_surfaces(), test_write_validation_bundle_emits_report_and_projection_images(), test_write_validation_bundle_respects_explicit_keyed_cloud_limit(), _write_synthetic_recording(), _ancestor_entity_paths(), _component_columns(), _keyed_point_cloud_snapshots(), _latest_live_model_snapshot() (+29 more)
+Nodes (36): test_load_recording_summary_reports_live_keyed_and_tracking_surfaces(), test_write_validation_bundle_emits_report_and_projection_images(), test_write_validation_bundle_respects_explicit_keyed_cloud_limit(), _ancestor_entity_paths(), _component_columns(), _keyed_point_cloud_snapshots(), _latest_live_model_snapshot(), _latest_transform_matrix_before_or_at_log_tick() (+28 more)
 
 ### Community 16 - "Community 16"
-Cohesion: 0.11
-Nodes (36): build_pipeline_snapshot_render_model(), _coerce_int_metric(), _format_latency(), _format_optional_rate(), _format_queue(), _format_resources(), _format_tasks(), _format_throughput() (+28 more)
+Cohesion: 0.12
+Nodes (33): build_pipeline_snapshot_render_model(), _coerce_int_metric(), _format_latency(), _format_optional_rate(), _format_queue(), _format_resources(), _format_tasks(), _format_throughput() (+25 more)
 
 ### Community 17 - "Community 17"
-Cohesion: 1.0
-Nodes (1): Thin Streamlit entrypoint for the PRML VSLAM workbench scaffold.  The file stays
+Cohesion: 0.13
+Nodes (18): Return the user-facing reconstruction label., Configure the minimal Open3D TSDF reconstruction backend.      The repo targets, Return the concrete reconstruction backend type., Instantiate the Open3D TSDF backend while ignoring unrelated kwargs., Describe normalized durable outputs from one reconstruction run.      The minima, ReconstructionArtifacts, ReconstructionMethodId, _import_open3d() (+10 more)
 
 ### Community 18 - "Community 18"
-Cohesion: 1.0
-Nodes (1): Ray-specific helpers for future stage runtime deployment.  This module intention
+Cohesion: 0.18
+Nodes (2): finish_streaming(), start_streaming()
 
 ### Community 19 - "Community 19"
 Cohesion: 1.0
-Nodes (1): Build the shared transform DTO from XYZW quaternion and XYZ translation arrays.
+Nodes (1): Thin Streamlit entrypoint for the PRML VSLAM workbench scaffold.  The file stays
 
 ### Community 20 - "Community 20"
 Cohesion: 1.0
-Nodes (1): Build the shared transform DTO from a 4x4 homogeneous matrix.
+Nodes (1): Ray-specific helpers for future stage runtime deployment.  This module intention
 
 ### Community 21 - "Community 21"
 Cohesion: 1.0
-Nodes (1): Return the compact source label used in logs and diagnostics.
+Nodes (1): Build the shared transform DTO from XYZW quaternion and XYZ translation arrays.
 
 ### Community 22 - "Community 22"
 Cohesion: 1.0
-Nodes (1): Connect to the source and prepare subsequent blocking observation reads.
+Nodes (1): Build the shared transform DTO from a 4x4 homogeneous matrix.
 
 ### Community 23 - "Community 23"
 Cohesion: 1.0
-Nodes (1): Disconnect or release the source and any owned runtime resources.
+Nodes (1): Return the compact source label used in logs and diagnostics.
 
 ### Community 24 - "Community 24"
 Cohesion: 1.0
-Nodes (1): Return the short user-facing dataset label.
+Nodes (1): Connect to the source and prepare subsequent blocking observation reads.
 
 ### Community 25 - "Community 25"
 Cohesion: 1.0
-Nodes (1): Deserialize one IPC payload back into the target validated model type.
+Nodes (1): Disconnect or release the source and any owned runtime resources.
 
 ### Community 26 - "Community 26"
 Cohesion: 1.0
-Nodes (1): Return the human-readable label shown in plan previews.
+Nodes (1): Return the short user-facing dataset label.
 
 ### Community 27 - "Community 27"
 Cohesion: 1.0
-Nodes (1): Return whether ``exc`` looks like a transient local Ray connection failure.
+Nodes (1): Deserialize one IPC payload back into the target validated model type.
 
 ### Community 28 - "Community 28"
 Cohesion: 1.0
-Nodes (1): Build one spec from one JSON object.
+Nodes (1): Return the human-readable label shown in plan previews.
 
 ### Community 29 - "Community 29"
 Cohesion: 1.0
-Nodes (1): Return the net code-line delta.
+Nodes (1): Return whether ``exc`` looks like a transient local Ray connection failure.
 
 ### Community 30 - "Community 30"
+Cohesion: 1.0
+Nodes (1): Build one spec from one JSON object.
+
+### Community 31 - "Community 31"
+Cohesion: 1.0
+Nodes (1): Return the net code-line delta.
+
+### Community 32 - "Community 32"
 Cohesion: 1.0
 Nodes (1): Return the path that should own this change in reports.
 
 ## Knowledge Gaps
 - **255 isolated node(s):** `Thin Streamlit entrypoint for the PRML VSLAM workbench scaffold.  The file stays`, `Frame preprocessing helpers for ViSTA-SLAM.`, `One RGB frame prepared for upstream ViSTA ingestion.`, `Use the exact upstream ViSTA crop-and-resize helper path.`, `Convert one upstream ViSTA array-like payload into a numpy array.` (+250 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **Thin community `Community 17`** (2 nodes): `streamlit_app.py`, `Thin Streamlit entrypoint for the PRML VSLAM workbench scaffold.  The file stays`
+- **Thin community `Community 18`** (12 nodes): `protocols.py`, `protocols.py`, `drain_runtime_updates()`, `drain_streaming_updates()`, `finish_streaming()`, `run_observations()`, `run_offline()`, `start_streaming()`, `status()`, `step_streaming()`, `stop()`, `submit_stream_item()`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 18`** (2 nodes): `ray.py`, `Ray-specific helpers for future stage runtime deployment.  This module intention`
+- **Thin community `Community 19`** (2 nodes): `streamlit_app.py`, `Thin Streamlit entrypoint for the PRML VSLAM workbench scaffold.  The file stays`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 19`** (1 nodes): `Build the shared transform DTO from XYZW quaternion and XYZ translation arrays.`
+- **Thin community `Community 20`** (2 nodes): `ray.py`, `Ray-specific helpers for future stage runtime deployment.  This module intention`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 20`** (1 nodes): `Build the shared transform DTO from a 4x4 homogeneous matrix.`
+- **Thin community `Community 21`** (1 nodes): `Build the shared transform DTO from XYZW quaternion and XYZ translation arrays.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 21`** (1 nodes): `Return the compact source label used in logs and diagnostics.`
+- **Thin community `Community 22`** (1 nodes): `Build the shared transform DTO from a 4x4 homogeneous matrix.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 22`** (1 nodes): `Connect to the source and prepare subsequent blocking observation reads.`
+- **Thin community `Community 23`** (1 nodes): `Return the compact source label used in logs and diagnostics.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 23`** (1 nodes): `Disconnect or release the source and any owned runtime resources.`
+- **Thin community `Community 24`** (1 nodes): `Connect to the source and prepare subsequent blocking observation reads.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 24`** (1 nodes): `Return the short user-facing dataset label.`
+- **Thin community `Community 25`** (1 nodes): `Disconnect or release the source and any owned runtime resources.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 25`** (1 nodes): `Deserialize one IPC payload back into the target validated model type.`
+- **Thin community `Community 26`** (1 nodes): `Return the short user-facing dataset label.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 26`** (1 nodes): `Return the human-readable label shown in plan previews.`
+- **Thin community `Community 27`** (1 nodes): `Deserialize one IPC payload back into the target validated model type.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 27`** (1 nodes): `Return whether ``exc`` looks like a transient local Ray connection failure.`
+- **Thin community `Community 28`** (1 nodes): `Return the human-readable label shown in plan previews.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 28`** (1 nodes): `Build one spec from one JSON object.`
+- **Thin community `Community 29`** (1 nodes): `Return whether ``exc`` looks like a transient local Ray connection failure.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 29`** (1 nodes): `Return the net code-line delta.`
+- **Thin community `Community 30`** (1 nodes): `Build one spec from one JSON object.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
-- **Thin community `Community 30`** (1 nodes): `Return the path that should own this change in reports.`
+- **Thin community `Community 31`** (1 nodes): `Return the net code-line delta.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 32`** (1 nodes): `Return the path that should own this change in reports.`
   Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `Test package helpers and suites for PRML VSLAM.` connect `Community 0` to `Community 1`, `Community 2`, `Community 3`, `Community 4`, `Community 5`, `Community 6`, `Community 7`, `Community 8`, `Community 9`, `Community 10`, `Community 11`, `Community 13`, `Community 14`?**
-  _High betweenness centrality (0.137) - this node is a cross-community bridge._
-- **Why does `StageKey` connect `Community 3` to `Community 0`, `Community 1`, `Community 2`, `Community 4`, `Community 5`, `Community 6`, `Community 7`, `Community 10`, `Community 11`?**
-  _High betweenness centrality (0.075) - this node is a cross-community bridge._
-- **Why does `SequenceManifest` connect `Community 1` to `Community 0`, `Community 2`, `Community 3`, `Community 4`, `Community 5`, `Community 6`, `Community 7`, `Community 8`, `Community 10`?**
-  _High betweenness centrality (0.068) - this node is a cross-community bridge._
+- **Why does `Test package helpers and suites for PRML VSLAM.` connect `Community 1` to `Community 0`, `Community 2`, `Community 3`, `Community 4`, `Community 5`, `Community 7`, `Community 8`, `Community 9`, `Community 12`, `Community 13`, `Community 17`?**
+  _High betweenness centrality (0.114) - this node is a cross-community bridge._
+- **Why does `StageKey` connect `Community 7` to `Community 0`, `Community 1`, `Community 2`, `Community 5`, `Community 6`, `Community 8`?**
+  _High betweenness centrality (0.084) - this node is a cross-community bridge._
+- **Why does `SequenceManifest` connect `Community 2` to `Community 0`, `Community 1`, `Community 4`, `Community 5`, `Community 6`, `Community 7`, `Community 8`, `Community 9`, `Community 10`, `Community 12`, `Community 14`?**
+  _High betweenness centrality (0.069) - this node is a cross-community bridge._
 - **Are the 431 inferred relationships involving `StageKey` (e.g. with `RunConfigOverrideCommand` and `_RerunViewerProcess`) actually correct?**
   _`StageKey` has 431 INFERRED edges - model-reasoned connections that need verification._
 - **Are the 344 inferred relationships involving `SequenceManifest` (e.g. with `OfflineSlamBackend` and `StreamingSlamBackend`) actually correct?**

--- a/graphify-out/graph.html
+++ b/graphify-out/graph.html
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a6b81e748e5369e10359314ed11dcf21fb02927535aaa8a449db7693f36dddb8
-size 6359084
+oid sha256:55bd42b467f8f5ed7c6c74f8fb67f0c4ae3598217ff410b2e70af15fc4a3ce0e
+size 6403238

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:5976b242c80e9c8bf9917509a5a1db12c6775c6e4fe98e6e7158784eb648a099
-size 9859594
+oid sha256:05b2007b2f6bcb9f13707464accb92131fae50e8e4bcce010c0e7a98fef6ff61
+size 9936654

--- a/tests/test_graphify_repo.py
+++ b/tests/test_graphify_repo.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_graphify_module() -> Any:
+    module_path = Path(__file__).resolve().parents[1] / ".agents" / "scripts" / "graphify_repo.py"
+    spec = importlib.util.spec_from_file_location("graphify_repo", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load module from {module_path}.")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+GRAPHIFY = _load_graphify_module()
+
+
+def test_lfs_pointer_detection(tmp_path: Path) -> None:
+    pointer = tmp_path / "graph.json"
+    pointer.write_text(
+        "version https://git-lfs.github.com/spec/v1\n"
+        "oid sha256:5976b242c80e9c8bf9917509a5a1db12c6775c6e4fe98e6e7158784eb648a099\n"
+        "size 9859594\n",
+        encoding="utf-8",
+    )
+    materialized = tmp_path / "materialized.json"
+    materialized.write_text('{"nodes": [], "links": []}\n', encoding="utf-8")
+
+    assert GRAPHIFY.is_lfs_pointer(pointer)
+    assert not GRAPHIFY.is_lfs_pointer(materialized)
+
+
+def test_status_reports_pointer_without_json_traceback(tmp_path: Path, monkeypatch: Any, capsys: Any) -> None:
+    repo = tmp_path / "repo"
+    graphify_out = repo / "graphify-out"
+    graphify_out.mkdir(parents=True)
+    (graphify_out / "GRAPH_REPORT.md").write_text(
+        "# Graph Report - demo (2026-06-12)\n\n## Summary\n- 2 nodes · 3 edges · 1 communities detected\n",
+        encoding="utf-8",
+    )
+    (graphify_out / "graph.json").write_text(
+        "version https://git-lfs.github.com/spec/v1\n"
+        "oid sha256:5976b242c80e9c8bf9917509a5a1db12c6775c6e4fe98e6e7158784eb648a099\n"
+        "size 9859594\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(GRAPHIFY, "repo_root", lambda: repo)
+    monkeypatch.setattr(GRAPHIFY, "graphify_version", lambda: "0.4.26")
+    monkeypatch.setattr(GRAPHIFY, "_git_status", lambda _paths: "clean")
+
+    GRAPHIFY.status()
+
+    output = capsys.readouterr().out
+    assert "graph data state: git-lfs pointer" in output
+    assert "nodes: 2" in output
+    assert "artifact dirty state: clean" in output
+
+
+def test_mcp_materializes_pointer_then_execs_graphify_server(tmp_path: Path, monkeypatch: Any) -> None:
+    repo = tmp_path / "repo"
+    graphify_out = repo / "graphify-out"
+    graphify_out.mkdir(parents=True)
+    graph_path = graphify_out / "graph.json"
+    graph_path.write_text(
+        "version https://git-lfs.github.com/spec/v1\n"
+        "oid sha256:5976b242c80e9c8bf9917509a5a1db12c6775c6e4fe98e6e7158784eb648a099\n"
+        "size 9859594\n",
+        encoding="utf-8",
+    )
+    captured: dict[str, Any] = {}
+
+    class PullResult:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(command: list[str], **kwargs: Any) -> PullResult:
+        captured["pull"] = command
+        graph_path.write_text('{"nodes": [], "links": []}\n', encoding="utf-8")
+        return PullResult()
+
+    def fake_execvp(executable: str, argv: list[str]) -> None:
+        captured["exec"] = (executable, argv)
+        raise RuntimeError("stop")
+
+    monkeypatch.setenv("UV_BIN", "/tools/uv")
+    monkeypatch.setattr(GRAPHIFY, "repo_root", lambda: repo)
+    monkeypatch.setattr(GRAPHIFY.subprocess, "run", fake_run)
+    monkeypatch.setattr(GRAPHIFY.os, "execvp", fake_execvp)
+
+    with pytest.raises(RuntimeError, match="stop"):
+        GRAPHIFY.mcp()
+
+    assert captured["pull"] == ["git", "lfs", "pull", "--include=graphify-out/graph.json", "--exclude="]
+    executable, argv = captured["exec"]
+    assert executable == "/tools/uv"
+    assert argv[-3:] == ["-m", "graphify.serve", "graphify-out/graph.json"]

--- a/tests/test_mempalace_repo.py
+++ b/tests/test_mempalace_repo.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+from typing import Any
+
+
+def _load_mempalace_module() -> Any:
+    module_path = (
+        Path(__file__).resolve().parents[1] / ".agents" / "skills" / "mempalace-repo" / "scripts" / "mempalace_repo.py"
+    )
+    spec = importlib.util.spec_from_file_location("mempalace_repo", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load module from {module_path}.")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MEMPALACE = _load_mempalace_module()
+
+
+def test_run_mempalace_uses_cli_and_explicit_repo_palace(monkeypatch: Any) -> None:
+    calls: list[dict[str, Any]] = []
+    palace = Path("/repo/.artifacts/mempalace/palace")
+
+    def fake_run(command: list[str], **kwargs: Any) -> object:
+        calls.append({"command": command, **kwargs})
+
+        class Result:
+            returncode = 0
+
+        return Result()
+
+    monkeypatch.setenv("MEMPALACE_BIN", "/tools/mempalace")
+    monkeypatch.setattr(MEMPALACE, "repo_root", lambda: Path("/repo"))
+    monkeypatch.setattr(MEMPALACE, "palace_path", lambda: palace)
+    monkeypatch.setattr(MEMPALACE.subprocess, "run", fake_run)
+
+    MEMPALACE.run_mempalace("search", "pipeline")
+
+    assert calls[0]["command"] == ["/tools/mempalace", "--palace", str(palace), "search", "pipeline"]
+    assert calls[0]["cwd"] == Path("/repo")
+    assert calls[0]["env"]["MEMPALACE_PALACE_PATH"] == str(palace)
+
+
+def test_mcp_execs_mempalace_mcp_with_repo_palace(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+    palace = Path("/repo/.artifacts/mempalace/palace")
+
+    monkeypatch.setenv("MEMPALACE_MCP_BIN", "/tools/mempalace-mcp")
+    monkeypatch.setattr(MEMPALACE, "ensure_runtime", lambda: None)
+    monkeypatch.setattr(MEMPALACE, "palace_path", lambda: palace)
+
+    def fake_execve(executable: str, argv: list[str], env: dict[str, str]) -> None:
+        captured.update({"executable": executable, "argv": argv, "env": env})
+        raise RuntimeError("stop")
+
+    monkeypatch.setattr(MEMPALACE.os, "execve", fake_execve)
+
+    try:
+        MEMPALACE.mcp()
+    except RuntimeError as exc:
+        assert str(exc) == "stop"
+
+    assert captured["executable"] == "/tools/mempalace-mcp"
+    assert captured["argv"] == ["/tools/mempalace-mcp", "--palace", str(palace)]
+    assert captured["env"]["MEMPALACE_PALACE_PATH"] == str(palace)
+
+
+def test_linked_worktree_uses_shared_palace_when_local_palace_missing(tmp_path: Path, monkeypatch: Any) -> None:
+    worktree = tmp_path / "repo.worktrees" / "branch"
+    shared = tmp_path / "repo"
+    (worktree / ".agents" / "skills" / "mempalace-repo" / "scripts").mkdir(parents=True)
+    (shared / ".artifacts" / "mempalace" / "palace").mkdir(parents=True)
+
+    monkeypatch.setattr(MEMPALACE, "repo_root", lambda: worktree)
+    monkeypatch.setattr(MEMPALACE, "shared_repo_root", lambda: shared)
+
+    assert MEMPALACE.palace_path() == shared / ".artifacts" / "mempalace" / "palace"
+    assert MEMPALACE.sources_root() == shared / ".artifacts" / "mempalace" / "sources"
+
+
+def test_docs_mining_includes_agent_scaffold(tmp_path: Path, monkeypatch: Any) -> None:
+    repo = tmp_path / "repo"
+    skill = repo / ".agents" / "skills" / "scientific-writing" / "SKILL.md"
+    reference = repo / ".agents" / "references" / "agent_reference.md"
+    backlog = repo / ".agents" / "issues.toml"
+    codex_config = repo / ".codex" / "config.toml"
+    for path in (skill, reference, backlog, codex_config, repo / "README.md"):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("content", encoding="utf-8")
+
+    monkeypatch.setattr(MEMPALACE, "repo_root", lambda: repo)
+
+    docs = {path.relative_to(repo) for path in MEMPALACE._iter_docs_files()}
+
+    assert Path(".agents/skills/scientific-writing/SKILL.md") in docs
+    assert Path(".agents/references/agent_reference.md") in docs
+    assert Path(".agents/issues.toml") in docs
+    assert Path(".codex/config.toml") in docs
+
+
+def test_init_llm_args_default_local_and_explicit_external_opt_in(monkeypatch: Any) -> None:
+    assert MEMPALACE._init_llm_args() == ["--no-llm"]
+
+    monkeypatch.setenv("MEMPALACE_INIT_LLM", "1")
+    monkeypatch.setenv("MEMPALACE_INIT_LLM_PROVIDER", "openai-compat")
+    monkeypatch.setenv("MEMPALACE_INIT_LLM_MODEL", "gpt-4.1-mini")
+    monkeypatch.setenv("MEMPALACE_INIT_LLM_ENDPOINT", "https://api.example.test/v1")
+    monkeypatch.setenv("MEMPALACE_INIT_LLM_API_KEY", "test-key")
+    monkeypatch.setenv("MEMPALACE_ACCEPT_EXTERNAL_LLM", "1")
+
+    assert MEMPALACE._init_llm_args() == [
+        "--llm-provider",
+        "openai-compat",
+        "--llm-model",
+        "gpt-4.1-mini",
+        "--llm-endpoint",
+        "https://api.example.test/v1",
+        "--llm-api-key",
+        "test-key",
+        "--accept-external-llm",
+    ]
+
+
+def test_mempalace_executable_uses_env_override(monkeypatch: Any) -> None:
+    monkeypatch.setenv("MEMPALACE_BIN", "/custom/mempalace")
+
+    assert MEMPALACE.mempalace_executable() == "/custom/mempalace"
+    assert os.environ["MEMPALACE_BIN"] == "/custom/mempalace"


### PR DESCRIPTION
## Summary
This branch repairs the repo-local agent tooling layer against `origin/main`: MemPalace now uses the installed upstream CLI/MCP executables instead of assuming an importable repo-venv module, Graphify status/MCP startup now handles Git LFS pointer checkout state explicitly, checked-in MCP config is worktree-relative, and the agent scaffold gains a project-specific scientific-writing skill plus documented Context7/MCP usage.

Focused verification completed:
- `python3 -m py_compile .agents/skills/mempalace-repo/scripts/mempalace_repo.py .agents/scripts/graphify_repo.py tests/test_mempalace_repo.py tests/test_graphify_repo.py`
- `bash -n .agents/scripts/mempalace_startup_context.sh`
- `prml-vslam-worktree-env uv run --extra dev pytest tests/test_mempalace_repo.py tests/test_graphify_repo.py -q`
- `prml-vslam-worktree-env uv run --extra dev ruff check .agents/skills/mempalace-repo/scripts/mempalace_repo.py .agents/scripts/graphify_repo.py tests/test_mempalace_repo.py tests/test_graphify_repo.py`
- `prml-vslam-worktree-env uv run --extra dev ruff format --check .agents/skills/mempalace-repo/scripts/mempalace_repo.py .agents/scripts/graphify_repo.py tests/test_mempalace_repo.py tests/test_graphify_repo.py`
- `python3 .agents/skills/mempalace-repo/scripts/mempalace_repo.py status`
- `python3 .agents/skills/mempalace-repo/scripts/mempalace_repo.py refresh`
- `timeout 3s python3 .agents/skills/mempalace-repo/scripts/mempalace_repo.py mcp`
- `timeout 8s python3 .agents/scripts/graphify_repo.py mcp`
- `MEMPALACE_SKIP_STARTUP_REFRESH=1 bash .agents/scripts/mempalace_startup_context.sh`
- `bash .agents/scripts/mempalace_startup_context.sh`
- `prml-vslam-worktree-env run make graphify`
- `prml-vslam-worktree-env run make graphify-rebuild`
- `git lfs pointer --check --file=graphify-out/graph.json && git lfs pointer --check --file=graphify-out/graph.html`
- `git diff --check`
- `prml-vslam-worktree-env run make ci`

## Work Packages
| WP | Scope | Primary surfaces | Status |
| --- | --- | --- | --- |
| WP1 | MemPalace wrapper and mining contract | `.agents/skills/mempalace-repo`, `.agents/scripts/mempalace_startup_context.sh`, tests | resolved |
| WP2 | Graphify MCP and LFS preflight | `.agents/scripts/graphify_repo.py`, `Makefile`, graphify skill, tests | resolved |
| WP3 | Agent scaffold guidance | `.agents/SETUP.md`, `.agents/references/agent_reference.md`, scientific-writing skill | resolved |
| WP4 | Worktree-relative MCP config and graph refresh | `.codex/config.toml`, `.gemini/settings.json`, `graphify-out/` | resolved |

## WP1 — MemPalace Wrapper And Mining Contract
### Scope
- Switched repo-local MemPalace commands from `.venv/bin/python -m mempalace` and import probes to installed `mempalace` / `mempalace-mcp` executables with `--palace` pinned to the repo-local palace.
- Preserved linked-worktree behavior by falling back to the shared repo `.artifacts/mempalace` palace when a worktree has no local palace.
- Expanded the docs wing to include `.agents/skills`, `.agents/references`, agents-db TOML state, and checked-in Codex config/hooks while keeping derived/runtime artifacts out of the default mining scope.
- Added explicit optional init LLM controls for local Ollama or external providers; default init remains `--no-llm`.

### Key files
- `.agents/skills/mempalace-repo/scripts/mempalace_repo.py`
- `.agents/skills/mempalace-repo/SKILL.md`
- `.agents/scripts/mempalace_startup_context.sh`
- `tests/test_mempalace_repo.py`

### API/path mapping
- `MEMPALACE_BIN` overrides the `mempalace` executable.
- `MEMPALACE_MCP_BIN` overrides the `mempalace-mcp` executable.
- `MEMPALACE_INIT_LLM=1` enables LLM-assisted init; `MEMPALACE_ACCEPT_EXTERNAL_LLM=1` is required before bypassing external-provider consent.

### Initial success criteria resolution
- `MemPalace works without repo-venv importability`: `resolved`
- `MCP server starts through upstream executable usage`: `resolved`
- `agent scaffold and backlog are mined deliberately`: `resolved`
- `cloud/subscription LLM mining is explicit opt-in`: `resolved`

## WP2 — Graphify MCP And LFS Preflight
### Scope
- Added a repo-local Graphify helper for status, report, and MCP startup.
- Made `make graphify` report LFS pointer state without JSON traceback.
- Made Graphify MCP startup materialize `graphify-out/graph.json` through Git LFS before executing `python -m graphify.serve graphify-out/graph.json`.

### Key files
- `.agents/scripts/graphify_repo.py`
- `Makefile`
- `.agents/skills/graphify/SKILL.md`
- `tests/test_graphify_repo.py`

### API/path mapping
- `make graphify` and `make graphify-report` now route through `.agents/scripts/graphify_repo.py`.
- Graphify MCP startup is now `python3 .agents/scripts/graphify_repo.py mcp`.

### Initial success criteria resolution
- `pointer-form graph.json does not break status`: `resolved`
- `MCP startup uses upstream graphify.serve after preflight`: `resolved`
- `graph.json and graph.html remain LFS-managed`: `resolved`

## WP3 — Agent Scaffold Guidance
### Scope
- Documented the important MCP surfaces and the intended MemPalace mining scope in `.agents/SETUP.md`.
- Added Graphify and MemPalace Context7 IDs plus primary upstream source URLs to the existing agent reference.
- Added a PRML VSLAM-specific scientific-writing skill that keeps useful outline-to-prose and claim-evidence discipline while rejecting unsuitable generic defaults such as mandatory generated figures or biomedical checklists.

### Key files
- `.agents/SETUP.md`
- `.agents/references/agent_reference.md`
- `.agents/skills/scientific-writing/SKILL.md`

### Initial success criteria resolution
- `Context7 should be easier to use`: `resolved`
- `scientific-writing guidance should be project-specific`: `resolved`
- `MCP and mining best practices are documented in repo-owned setup guidance`: `resolved`

## WP4 — Worktree-Relative MCP Config And Graph Refresh
### Scope
- Changed checked-in Codex/Gemini MCP wiring to route MemPalace and Graphify through repo wrappers.
- Changed Code Index from a hard-coded primary checkout path to `--project-path .`.
- Rebuilt Graphify artifacts after tooling edits and restored large graph outputs to LFS pointer form.

### Key files
- `.codex/config.toml`
- `.gemini/settings.json`
- `graphify-out/GRAPH_REPORT.md`
- `graphify-out/graph.json`
- `graphify-out/graph.html`

### Initial success criteria resolution
- `config is worktree-relative`: `resolved`
- `Graphify artifacts reflect this branch`: `resolved`
- `large generated graph files stay LFS pointers`: `resolved`
