### PR TITLE
Repair repo-local agent scaffold tooling

### DIFF
--- a/.agents/SETUP.md
+++ b/.agents/SETUP.md
@@ -21,8 +21,56 @@ docker mcp profile pull docker.io/janduchscherer104/codex:latest
 Then open this repository in Codex. The repo-local config wires:
 
 - `docker mcp gateway run --profile codex`
-- `uvx code-index-mcp`
+- `uvx code-index-mcp --project-path .`
+- `python3 .agents/scripts/graphify_repo.py mcp`
+- `python3 .agents/skills/mempalace-repo/scripts/mempalace_repo.py mcp`
 - the repo-local skills under `.agents/skills/`
 
 If a server needs credentials, configure them locally and do not commit them to
 the repository.
+
+## MCP Surfaces
+
+- Docker MCP Toolkit exposes shared external tools such as Context7. Use
+  `.agents/references/agent_reference.md` for the repo's known Context7 library
+  IDs before falling back to broad web search.
+- Code Index is the fast local symbol and file discovery surface. The checked-in
+  config uses `--project-path .` so linked worktrees point at their own source
+  tree.
+- Graphify serves `graphify-out/graph.json` through the repo wrapper. Because
+  `graphify-out/graph.json` and `graphify-out/graph.html` are Git LFS artifacts,
+  the wrapper materializes `graph.json` before MCP startup when the checkout
+  only has a pointer file.
+- MemPalace serves the repo-local palace through the repo wrapper. The wrapper
+  uses the installed `mempalace` and `mempalace-mcp` executables and pins
+  `.artifacts/mempalace/palace` instead of the global `~/.mempalace` palace.
+
+## MemPalace Mining Scope
+
+The refresh helper stages two wings:
+
+- `prml-vslam-docs`: root docs, `docs/` markdown/Typst/bibliography/text files,
+  package README/REQUIREMENTS/AGENTS files, repo-local agent skills, agent
+  references, agents-db TOML state, and checked-in Codex config/hooks.
+- `prml-vslam-chats`: raw repo-scoped Codex session JSONL files copied from the
+  configured Codex home, plus compact JSONL exports for inspection.
+
+Do not mine `.artifacts/`, `.omx/`, `graphify-out/`, caches, generated binary
+outputs, or full source files by default. Those surfaces are derived, runtime
+local, or too noisy for durable recall. If a future task needs more memory
+coverage, prefer adding compact owner surfaces under `.agents/references/`,
+`.agents/skills/`, or the agents DB instead of mining large generated output.
+
+MemPalace init is heuristic-only by default. To use local Ollama refinement
+during init, run with:
+
+```bash
+MEMPALACE_INIT_LLM=1 \
+MEMPALACE_INIT_LLM_PROVIDER=ollama \
+MEMPALACE_INIT_LLM_MODEL=gemma4:e4b \
+python3 .agents/skills/mempalace-repo/scripts/mempalace_repo.py refresh
+```
+
+External subscription or OpenAI-compatible providers are opt-in only. Set
+`MEMPALACE_ACCEPT_EXTERNAL_LLM=1` only after deciding that the staged repo docs
+and agent scaffold may be sent to that provider.

--- a/.agents/references/agent_reference.md
+++ b/.agents/references/agent_reference.md
@@ -18,6 +18,8 @@
 - `/isl-org/open3d` - 3D data processing and evaluation
 - `/michaelgrupp/evo` - Trajectory evaluation for odometry and SLAM
 - `/rerun-io/rerun` - Rerun visualization stack for robotics and spatial data
+- `/safishamsi/graphify` - Graphify codebase knowledge graph, MCP server, and hook usage
+- `/mempalace/mempalace` - MemPalace local memory CLI, mining, wake-up, and MCP usage
 
 ## Primary Sources
 
@@ -33,6 +35,8 @@
 - evo plot helpers (`traj_colormap`, trajectory plotting internals): <https://github.com/MichaelGrupp/evo/blob/master/evo/tools/plot.py>
 - Rerun docs.rs crate docs: <https://docs.rs/rerun/latest/rerun/>
 - Rerun repo: <https://github.com/rerun-io/rerun>
+- Graphify repo: <https://github.com/safishamsi/graphify>
+- MemPalace repo: <https://github.com/mempalace/mempalace>
 - Nerfstudio docs: <https://docs.nerf.studio/>
 - Nerfstudio data conventions: <https://docs.nerf.studio/quickstart/data_conventions.html>
 - ViSTA-SLAM GH pages: <https://ganlinzhang.xyz/vista-slam/>

--- a/.agents/references/agent_reference.md
+++ b/.agents/references/agent_reference.md
@@ -1,7 +1,19 @@
 # Agent Reference
 
+## Agent Scaffold
+
+- Scaffold contract: [agent_scaffold.md](agent_scaffold.md)
+- OpenAI Codex best practices: <https://developers.openai.com/codex/learn/best-practices>
+- AGENTS.md format guide: <https://agents.md/>
+- Claude Code memory guide: <https://code.claude.com/docs/en/memory>
+- GitHub Copilot repository instructions: <https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions>
+- NVIDIA NeMo Agent Toolkit cursor-rules guide: <https://docs.nvidia.com/nemo/agent-toolkit/1.2/extend/cursor-rules-developer-guide.html>
+- GitHub awesome-copilot scaffold collection: <https://github.com/github/awesome-copilot>
+- MCP specification: <https://modelcontextprotocol.io/specification/2025-06-18/>
+
 ## Context7 Library IDs
 
+- `/websites/modelcontextprotocol_io_specification_2025-06-18` - Model Context Protocol specification
 - `/websites/astral_sh_uv` - UV package manager
 - `/pydantic/pydantic` - Data validation and settings management
 - `/pydantic/pydantic-settings` - Environment-backed application settings
@@ -37,6 +49,7 @@
 - Rerun repo: <https://github.com/rerun-io/rerun>
 - Graphify repo: <https://github.com/safishamsi/graphify>
 - MemPalace repo: <https://github.com/mempalace/mempalace>
+- MCP specification: <https://modelcontextprotocol.io/specification/2025-06-18/>
 - Nerfstudio docs: <https://docs.nerf.studio/>
 - Nerfstudio data conventions: <https://docs.nerf.studio/quickstart/data_conventions.html>
 - ViSTA-SLAM GH pages: <https://ganlinzhang.xyz/vista-slam/>

--- a/.agents/references/agent_scaffold.md
+++ b/.agents/references/agent_scaffold.md
@@ -1,0 +1,105 @@
+# Agent Scaffold Contract
+
+Use this guide when changing repo-local agent instructions, skills, references,
+MCP wiring, or generated assistant-support artifacts. Keep it compact: this is
+a routing contract, not another policy layer.
+
+## Source Order
+
+1. User request and current task context.
+2. Nearest `AGENTS.md` for repo or subtree policy.
+3. Human-maintained repo truth such as `README.md`, `SETUP.md`,
+   `docs/Questions.md`, package `README.md`, and package `REQUIREMENTS.md`.
+4. Task-specific skills under `.agents/skills/`.
+5. Lookup references under `.agents/references/`.
+6. Derived or advisory systems such as Graphify, MemPalace, code-index, Context7,
+   MCP servers, prior chat memory, and generated work notes.
+
+When sources disagree, update the owner surface instead of duplicating a second
+definition in a helper file.
+
+## What Belongs Where
+
+- `AGENTS.md`: durable repo policy, source order, safety boundaries, and
+  verification expectations.
+- Nested `AGENTS.md`: subtree-specific deltas only.
+- `.agents/skills/*/SKILL.md`: compact repeatable workflows with activation
+  cues, required reads, rules, and verification.
+- `.agents/references/*.md`: lookup tables, source maps, upstream contracts,
+  and longer distilled guidance that would bloat a skill.
+- `.codex/config.toml`: repo-local Codex and MCP wiring that can be portable
+  across linked worktrees. Keep machine-local trust and secrets outside the repo.
+- `.omx/`: runtime or planning artifacts. Promote only stable decisions back to
+  the owning source above.
+- `.artifacts/`, `graphify-out/`, MemPalace palaces, and code indexes: derived
+  evidence. Refresh or rebuild them; do not treat them as policy.
+
+## Skill Header Pattern
+
+New skills should include a small `metadata:` block when it improves routing:
+
+```yaml
+---
+name: skill-name
+description: One sentence saying when to use the skill.
+metadata:
+  mode: "implementation | research | review | maintenance | router"
+  applies_to:
+    - "path/or/glob/**"
+  evidence_required:
+    - "file, command, artifact, or source required before acting"
+  handoff_to:
+    - "adjacent-skill-name"
+---
+```
+
+Do not mass-normalize old skill headers unless a validator or routing failure
+shows the change will pay for its review cost.
+
+## Tool And MCP Boundaries
+
+- Use Graphify for architecture orientation and graph freshness checks.
+- Use MemPalace for prior-session, durable-decision, and previous-attempt
+  lookup.
+- Use code-index for broad symbol/file lookup when `rg` is too shallow.
+- Use Context7 for current dependency documentation before version-sensitive
+  implementation or advice.
+- Use MCP tools as discovery and execution channels. Durable decisions still
+  land in `AGENTS.md`, skills, references, docs, code, tests, or backlog files.
+
+Repo-local MCP config should prefer repo-relative roots, for example `cwd = "."`
+and `--project-path "."`, so linked worktrees do not silently index the primary
+checkout.
+
+## External Scaffold Examples
+
+- OpenAI Codex best practices: testing, checks, behavior confirmation, and
+  review expectations can live in `AGENTS.md`.
+  <https://developers.openai.com/codex/learn/best-practices>
+- AGENTS.md format guide: common sections include project overview, build/test
+  commands, style, testing, security, and nested instructions.
+  <https://agents.md/>
+- Claude Code memory: project memory should hold stable facts and route longer
+  procedures into task-specific instructions.
+  <https://code.claude.com/docs/en/memory>
+- GitHub Copilot custom instructions: repository and path-specific instructions
+  should describe how to understand, build, test, and validate changes.
+  <https://docs.github.com/en/copilot/how-tos/copilot-on-github/customize-copilot/add-custom-instructions/add-repository-instructions>
+- Cursor/NVIDIA NeMo rule practice: hierarchical, generated, and scoped rules
+  reduce drift when the source documentation remains the owner.
+  <https://docs.nvidia.com/nemo/agent-toolkit/1.2/extend/cursor-rules-developer-guide.html>
+- Public scaffold inventory: `github/awesome-copilot` curates agents,
+  instructions, skills, hooks, workflows, plugins, and MCP examples.
+  <https://github.com/github/awesome-copilot>
+- MCP specification: tools, resources, prompts, and roots are discoverable
+  protocol capabilities, not project policy by themselves.
+  <https://modelcontextprotocol.io/specification/2025-06-18/>
+
+## Maintenance Checklist
+
+- Keep root and nested `AGENTS.md` concise.
+- Link to references instead of copying long lists into skills.
+- Prefer one owner for each durable rule.
+- Add verification commands to the surface that owns the workflow.
+- After scaffold changes, parse TOML/YAML/frontmatter and run a cheap repo
+  orientation smoke check such as `make graphify-report`.

--- a/.agents/scripts/graphify_repo.py
+++ b/.agents/scripts/graphify_repo.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Repo-local Graphify helper for status, reports, and MCP startup."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+from importlib.metadata import PackageNotFoundError, version
+from pathlib import Path
+
+GRAPHIFY_DIR = Path("graphify-out")
+GRAPHIFY_REPORT = GRAPHIFY_DIR / "GRAPH_REPORT.md"
+GRAPHIFY_GRAPH = GRAPHIFY_DIR / "graph.json"
+GRAPHIFY_HTML = GRAPHIFY_DIR / "graph.html"
+LFS_POINTER_PREFIX = "version https://git-lfs.github.com/spec/v1"
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def is_lfs_pointer(path: Path) -> bool:
+    if not path.exists() or not path.is_file():
+        return False
+    try:
+        return _read_text(path).startswith(LFS_POINTER_PREFIX)
+    except UnicodeDecodeError:
+        return False
+
+
+def graphify_version() -> str:
+    try:
+        return version("graphifyy")
+    except PackageNotFoundError:
+        return "missing"
+
+
+def _report_summary() -> dict[str, str]:
+    report_path = repo_root() / GRAPHIFY_REPORT
+    if not report_path.exists():
+        return {}
+    report = _read_text(report_path)
+    date = re.search(r"^# Graph Report - .*\(([^)]*)\)", report, re.M)
+    summary = re.search(r"^- (\d+) nodes .+? (\d+) edges .+? (\d+) communities detected", report, re.M)
+    return {
+        "date": date.group(1) if date else "unknown",
+        "nodes": summary.group(1) if summary else "unknown",
+        "links": summary.group(2) if summary else "unknown",
+        "communities": summary.group(3) if summary else "unknown",
+    }
+
+
+def _materialized_graph_summary() -> dict[str, str]:
+    graph = json.loads(_read_text(repo_root() / GRAPHIFY_GRAPH))
+    nodes = graph.get("nodes", [])
+    links = graph.get("links", graph.get("edges", []))
+    return {"nodes": str(len(nodes)), "links": str(len(links))}
+
+
+def _git_status(paths: list[Path]) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "status", "--short", "--", *[str(path) for path in paths]],
+            cwd=repo_root(),
+            text=True,
+            check=True,
+            capture_output=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return "unknown"
+    return "modified" if result.stdout.strip() else "clean"
+
+
+def status() -> None:
+    for path, label in (
+        (GRAPHIFY_DIR, "graphify directory"),
+        (GRAPHIFY_REPORT, "graphify report"),
+        (GRAPHIFY_GRAPH, "graphify graph data"),
+    ):
+        if not (repo_root() / path).exists():
+            raise SystemExit(f"Missing {label}: {path}")
+
+    print(f"graphify artifacts: {GRAPHIFY_DIR}")
+    print(f"report: {GRAPHIFY_REPORT}")
+    print(f"graph data: {GRAPHIFY_GRAPH}")
+    if (repo_root() / GRAPHIFY_HTML).exists():
+        print(f"viewer: {GRAPHIFY_HTML}")
+    print(
+        f"runtime: {'available (graphifyy ' + graphify_version() + ')' if graphify_version() != 'missing' else 'missing'}"
+    )
+
+    summary = _report_summary()
+    if is_lfs_pointer(repo_root() / GRAPHIFY_GRAPH):
+        print("graph data state: git-lfs pointer")
+        print(
+            "graph data hydration: run `git lfs pull --include=graphify-out/graph.json` or `make graphify-rebuild` before MCP startup"
+        )
+    else:
+        summary.update(_materialized_graph_summary())
+        print("graph data state: materialized")
+    if summary:
+        print(f"graph date: {summary.get('date', 'unknown')}")
+        print(f"nodes: {summary.get('nodes', 'unknown')}")
+        print(f"links: {summary.get('links', 'unknown')}")
+        print(f"communities: {summary.get('communities', 'unknown')}")
+    print(f"artifact dirty state: {_git_status([GRAPHIFY_REPORT, GRAPHIFY_GRAPH, GRAPHIFY_HTML])}")
+    print("next: make graphify-report | make graphify-rebuild | make graphify-hook-install")
+
+
+def report() -> None:
+    if not (repo_root() / GRAPHIFY_REPORT).exists():
+        raise SystemExit(f"Missing graphify report: {GRAPHIFY_REPORT}")
+    text = _read_text(repo_root() / GRAPHIFY_REPORT)
+    print(text.splitlines()[0])
+    for name in ("Corpus Check", "Summary", "Suggested Questions"):
+        match = re.search(r"^## " + re.escape(name) + r"\n(.*?)(?=^## |\Z)", text, re.M | re.S)
+        if match:
+            print(f"\n## {name}\n{match.group(1).strip()}")
+
+
+def materialize_graph_for_mcp() -> None:
+    graph_path = repo_root() / GRAPHIFY_GRAPH
+    if not graph_path.exists():
+        raise SystemExit(f"Missing graphify graph data: {GRAPHIFY_GRAPH}")
+    if not is_lfs_pointer(graph_path):
+        json.loads(_read_text(graph_path))
+        return
+
+    pull = subprocess.run(
+        ["git", "lfs", "pull", "--include=graphify-out/graph.json", "--exclude="],
+        cwd=repo_root(),
+        text=True,
+        capture_output=True,
+    )
+    if pull.returncode != 0:
+        raise SystemExit(
+            "Graphify graph data is a Git LFS pointer and `git lfs pull` failed.\n"
+            f"stdout:\n{pull.stdout}\nstderr:\n{pull.stderr}"
+        )
+    if is_lfs_pointer(graph_path):
+        raise SystemExit(
+            "Graphify graph data is still a Git LFS pointer after `git lfs pull`; "
+            "run `git lfs pull --include=graphify-out/graph.json` or `make graphify-rebuild`."
+        )
+    json.loads(_read_text(graph_path))
+
+
+def mcp() -> None:
+    materialize_graph_for_mcp()
+    uv = os.environ.get("UV_BIN", "uv")
+    os.execvp(
+        uv,
+        [
+            uv,
+            "run",
+            "--preview-features",
+            "extra-build-dependencies",
+            "--group",
+            "dev",
+            "python",
+            "-m",
+            "graphify.serve",
+            str(GRAPHIFY_GRAPH),
+        ],
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("status", help="Show graphify artifact and runtime status.")
+    subparsers.add_parser("report", help="Print the top of the graphify report.")
+    subparsers.add_parser("mcp", help="Start the graphify MCP server after LFS preflight.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.command == "status":
+        status()
+    elif args.command == "report":
+        report()
+    elif args.command == "mcp":
+        mcp()
+    else:
+        raise RuntimeError(f"Unhandled command: {args.command}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.agents/scripts/mempalace_startup_context.sh
+++ b/.agents/scripts/mempalace_startup_context.sh
@@ -8,6 +8,7 @@ helper=".agents/skills/mempalace-repo/scripts/mempalace_repo.py"
 log_dir=".artifacts/mempalace/logs"
 lock_dir=".artifacts/mempalace/startup-refresh.lock"
 log_file="$log_dir/startup-refresh.log"
+pid_file="$lock_dir/pid"
 
 echo "PRML VSLAM MemPalace startup context"
 
@@ -18,20 +19,59 @@ fi
 
 mkdir -p "$log_dir"
 
+start_refresh() {
+  if command -v setsid >/dev/null 2>&1; then
+    setsid bash -c '
+      lock_dir="$1"
+      pid_file="$2"
+      log_file="$3"
+      helper="$4"
+      trap "rm -f \"$pid_file\"; rmdir \"$lock_dir\" 2>/dev/null || true" EXIT
+      printf "%s\n" "$$" >"$pid_file"
+      {
+        printf "\n[%s] startup refresh begin\n" "$(date -Is)"
+        python3 "$helper" refresh
+        printf "[%s] startup refresh end\n" "$(date -Is)"
+      } >>"$log_file" 2>&1
+    ' bash "$lock_dir" "$pid_file" "$log_file" "$helper" >/dev/null 2>&1 &
+  else
+    nohup bash -c '
+      lock_dir="$1"
+      pid_file="$2"
+      log_file="$3"
+      helper="$4"
+      trap "rm -f \"$pid_file\"; rmdir \"$lock_dir\" 2>/dev/null || true" EXIT
+      printf "%s\n" "$$" >"$pid_file"
+      {
+        printf "\n[%s] startup refresh begin\n" "$(date -Is)"
+        python3 "$helper" refresh
+        printf "[%s] startup refresh end\n" "$(date -Is)"
+      } >>"$log_file" 2>&1
+    ' bash "$lock_dir" "$pid_file" "$log_file" "$helper" >/dev/null 2>&1 &
+  fi
+}
+
 if [ "${MEMPALACE_SKIP_STARTUP_REFRESH:-}" = "1" ]; then
   echo "- Startup refresh skipped by MEMPALACE_SKIP_STARTUP_REFRESH=1."
 elif mkdir "$lock_dir" 2>/dev/null; then
-  (
-    trap 'rmdir "$lock_dir" 2>/dev/null || true' EXIT
-    {
-      printf '\n[%s] startup refresh begin\n' "$(date -Is)"
-      python3 "$helper" refresh
-      printf '[%s] startup refresh end\n' "$(date -Is)"
-    } >>"$log_file" 2>&1
-  ) &
-  echo "- Refreshing docs and Codex chat histories in the background."
+  start_refresh
+  echo "- Refreshing docs, agent scaffold, and Codex chat histories in the background."
 else
-  echo "- A MemPalace startup refresh is already running."
+  existing_pid=""
+  if [ -f "$pid_file" ]; then
+    existing_pid="$(cat "$pid_file" 2>/dev/null || true)"
+  fi
+  if [ -n "$existing_pid" ] && kill -0 "$existing_pid" 2>/dev/null; then
+    echo "- A MemPalace startup refresh is already running."
+  else
+    rm -rf "$lock_dir"
+    if mkdir "$lock_dir" 2>/dev/null; then
+      start_refresh
+      echo "- Removed stale MemPalace startup lock and restarted refresh."
+    else
+      echo "- A MemPalace startup refresh is already running."
+    fi
+  fi
 fi
 
 echo "- Refresh log: \`$log_file\`"

--- a/.agents/skills/graphify/SKILL.md
+++ b/.agents/skills/graphify/SKILL.md
@@ -13,13 +13,19 @@ Use this skill in repositories that carry a `graphify-out/` knowledge graph.
 2. If `graphify-out/wiki/index.md` exists, use it as the first navigation surface before reading raw files directly.
 3. Use `make graphify` for a concise artifact, runtime, hook, and freshness dashboard.
 4. Use `make graphify-report` when you only need the report summary.
-5. Use `make graphify-view` to locate the generated HTML graph viewer.
-6. Use `make graphify-hook-status` to check local post-commit/post-checkout hooks without failing the workflow.
-7. Use `make graphify-hook-install` once per clone to install the local graph refresh hooks.
-8. After modifying code files in a graphify-enabled repository, run `make graphify-rebuild`.
+5. Use `python3 .agents/scripts/graphify_repo.py mcp` as the repo-local MCP
+   startup wrapper; it materializes `graphify-out/graph.json` if the checkout
+   only has a Git LFS pointer.
+6. Use `make graphify-view` to locate the generated HTML graph viewer.
+7. Use `make graphify-hook-status` to check local post-commit/post-checkout hooks without failing the workflow.
+8. Use `make graphify-hook-install` once per clone to install the local graph refresh hooks.
+9. After modifying code files in a graphify-enabled repository, run `make graphify-rebuild`.
 
 ## Notes
 
 - Keep graphify commands repo-relative.
 - Do not hardcode local machine paths in graphify instructions or config.
+- `graphify-out/graph.json` and `graphify-out/graph.html` are Git LFS-managed
+  artifacts in this repo. Treat pointer files as a normal checkout state for
+  status/report commands, but materialize `graph.json` before MCP startup.
 - If `make graphify-status` reports that the runtime is missing, the existing artifacts can still guide codebase navigation, but rebuilds require the official `graphifyy` package and `graphify` CLI.

--- a/.agents/skills/mempalace-repo/SKILL.md
+++ b/.agents/skills/mempalace-repo/SKILL.md
@@ -14,6 +14,7 @@ repository.
 - the staged docs source tree under `.artifacts/mempalace/sources/docs`
 - the staged Codex raw session copies under `.artifacts/mempalace/sources/chats`
 - refresh/search workflows through the wrapper script
+- repo-local MCP startup through the installed `mempalace-mcp` executable
 
 ## Workflow
 
@@ -50,6 +51,11 @@ python3 .agents/skills/mempalace-repo/scripts/mempalace_repo.py wake-up
    but complete enough for later mining: decisions, files changed, validation,
    blockers, and follow-up facts.
 
+The docs wing intentionally includes repo guidance, `.agents/skills/`,
+`.agents/references/`, agents-db TOML state, and checked-in Codex config/hooks
+in addition to public docs. Do not add generated artifacts, `.omx/` runtime
+state, caches, or full source trees to the default mining scope.
+
 ## Guardrails
 
 - Treat the repo-local palace as derived state. Refresh it instead of editing
@@ -61,5 +67,8 @@ python3 .agents/skills/mempalace-repo/scripts/mempalace_repo.py wake-up
   needed.
 - Do not assume the global `~/.mempalace` palace is the one this repo uses; the
   wrapper script pins a repo-local palace path.
+- Do not assume MemPalace is importable from the repo virtualenv. The wrapper
+  locates `mempalace` and `mempalace-mcp` on PATH, with `MEMPALACE_BIN` and
+  `MEMPALACE_MCP_BIN` overrides for unusual installs.
 - Treat `.artifacts/mempalace/` as derived state. Do not hand-edit staged
   sources, logs, or palace index files.

--- a/.agents/skills/mempalace-repo/scripts/mempalace_repo.py
+++ b/.agents/skills/mempalace-repo/scripts/mempalace_repo.py
@@ -14,6 +14,15 @@ from pathlib import Path
 DOC_SUFFIXES = {".md", ".typ", ".bib", ".txt"}
 ROOT_DOC_FILES = ("README.md", "SETUP.md", "AGENTS.md")
 PACKAGE_DOC_NAMES = {"README.md", "REQUIREMENTS.md", "AGENTS.md"}
+AGENT_MEMORY_FILES = (
+    ".agents/AGENTS_INTERNAL_DB.md",
+    ".agents/issues.toml",
+    ".agents/todos.toml",
+    ".agents/refactors.toml",
+    ".agents/resolved.toml",
+    ".codex/config.toml",
+    ".codex/hooks.json",
+)
 DOCS_WING = "prml-vslam-docs"
 CHATS_WING = "prml-vslam-chats"
 AGENT_NAME = "prml-vslam-codex"
@@ -24,16 +33,37 @@ def repo_root() -> Path:
     return Path(__file__).resolve().parents[4]
 
 
-def venv_python() -> Path:
-    return repo_root() / ".venv" / "bin" / "python"
+def shared_repo_root() -> Path:
+    try:
+        common_dir = subprocess.check_output(
+            ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+            cwd=repo_root(),
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return repo_root()
+    if not common_dir:
+        return repo_root()
+    return Path(common_dir).resolve().parent
+
+
+def mempalace_root() -> Path:
+    local_root = repo_root() / ".artifacts" / "mempalace"
+    if (local_root / "palace").exists():
+        return local_root
+    shared_root = shared_repo_root() / ".artifacts" / "mempalace"
+    if (shared_root / "palace").exists():
+        return shared_root
+    return local_root
 
 
 def palace_path() -> Path:
-    return repo_root() / ".artifacts" / "mempalace" / "palace"
+    return mempalace_root() / "palace"
 
 
 def sources_root() -> Path:
-    return repo_root() / ".artifacts" / "mempalace" / "sources"
+    return mempalace_root() / "sources"
 
 
 def docs_source_root() -> Path:
@@ -46,10 +76,6 @@ def chats_source_root() -> Path:
 
 def exports_source_root() -> Path:
     return sources_root() / "exports"
-
-
-def windows_codex_home() -> Path:
-    return Path("/mnt/c/Users/jandu/.codex")
 
 
 def _load_codex_history_module():
@@ -65,9 +91,6 @@ def _load_codex_history_module():
 
 def _candidate_codex_homes(history) -> list[Path]:
     candidates = list(history._candidate_codex_homes())
-    windows_home = windows_codex_home()
-    if windows_home.exists():
-        candidates.append(windows_home)
     unique: list[Path] = []
     seen: set[Path] = set()
     for candidate in candidates:
@@ -119,8 +142,26 @@ def _mempalace_env() -> dict[str, str]:
     return env
 
 
-def run_python_module(module: str, *args: str, capture_output: bool = False) -> subprocess.CompletedProcess[str]:
-    command = [str(venv_python()), "-m", module, *args]
+def _require_executable(env_name: str, default_name: str) -> str:
+    configured = os.environ.get(env_name)
+    if configured:
+        return configured
+    executable = shutil.which(default_name)
+    if executable is None:
+        raise RuntimeError(f"Missing `{default_name}` executable on PATH; install it or set {env_name}.")
+    return executable
+
+
+def mempalace_executable() -> str:
+    return _require_executable("MEMPALACE_BIN", "mempalace")
+
+
+def mempalace_mcp_executable() -> str:
+    return _require_executable("MEMPALACE_MCP_BIN", "mempalace-mcp")
+
+
+def run_mempalace(*args: str, capture_output: bool = False) -> subprocess.CompletedProcess[str]:
+    command = [mempalace_executable(), "--palace", str(palace_path()), *args]
     return subprocess.run(
         command,
         cwd=repo_root(),
@@ -131,11 +172,37 @@ def run_python_module(module: str, *args: str, capture_output: bool = False) -> 
     )
 
 
+def _init_llm_args() -> list[str]:
+    if os.environ.get("MEMPALACE_INIT_LLM") != "1":
+        return ["--no-llm"]
+
+    args: list[str] = []
+    provider = os.environ.get("MEMPALACE_INIT_LLM_PROVIDER")
+    model = os.environ.get("MEMPALACE_INIT_LLM_MODEL")
+    endpoint = os.environ.get("MEMPALACE_INIT_LLM_ENDPOINT")
+    api_key = os.environ.get("MEMPALACE_INIT_LLM_API_KEY")
+    if provider:
+        args.extend(["--llm-provider", provider])
+    if model:
+        args.extend(["--llm-model", model])
+    if endpoint:
+        args.extend(["--llm-endpoint", endpoint])
+    if api_key:
+        args.extend(["--llm-api-key", api_key])
+    if os.environ.get("MEMPALACE_ACCEPT_EXTERNAL_LLM") == "1":
+        args.append("--accept-external-llm")
+    return args
+
+
 def ensure_runtime() -> None:
-    if not venv_python().exists():
-        raise RuntimeError(f"Missing repo venv python at {venv_python()}")
-    command = [str(venv_python()), "-c", "import mempalace"]
-    subprocess.run(command, cwd=repo_root(), env=_mempalace_env(), text=True, check=True)
+    subprocess.run(
+        [mempalace_executable(), "--version"],
+        cwd=repo_root(),
+        env=_mempalace_env(),
+        text=True,
+        check=True,
+        stdout=subprocess.DEVNULL,
+    )
 
 
 def _clear_directory(path: Path) -> None:
@@ -166,6 +233,15 @@ def _iter_docs_files() -> list[Path]:
         for path in package_dir.rglob("*"):
             if path.is_file() and path.name in PACKAGE_DOC_NAMES:
                 docs_files.add(path)
+    agents_dir = repo_root() / ".agents"
+    if agents_dir.exists():
+        for path in agents_dir.rglob("*"):
+            if path.is_file() and (path.name == "SKILL.md" or path.suffix in DOC_SUFFIXES):
+                docs_files.add(path)
+    for name in AGENT_MEMORY_FILES:
+        path = repo_root() / name
+        if path.exists():
+            docs_files.add(path)
     return sorted(docs_files)
 
 
@@ -224,12 +300,11 @@ def initialize_docs_source() -> None:
     docs_root = docs_source_root()
     if (docs_root / "mempalace.yaml").exists():
         return
-    run_python_module("mempalace", "init", str(docs_root), "--yes")
+    run_mempalace("init", str(docs_root), "--yes", *_init_llm_args())
 
 
 def mine_docs() -> None:
-    run_python_module(
-        "mempalace",
+    run_mempalace(
         "mine",
         str(docs_source_root()),
         "--wing",
@@ -240,8 +315,7 @@ def mine_docs() -> None:
 
 
 def mine_chats() -> None:
-    run_python_module(
-        "mempalace",
+    run_mempalace(
         "mine",
         str(chats_source_root()),
         "--mode",
@@ -268,22 +342,24 @@ def refresh() -> None:
 
 def status() -> None:
     ensure_runtime()
-    run_python_module("mempalace", "status")
+    run_mempalace("status")
 
 
 def search(query: str) -> None:
     ensure_runtime()
-    run_python_module("mempalace", "search", query)
+    run_mempalace("search", query)
 
 
 def wake_up() -> None:
     ensure_runtime()
-    run_python_module("mempalace", "wake-up")
+    run_mempalace("wake-up")
 
 
 def mcp() -> None:
     ensure_runtime()
-    run_python_module("mempalace", "--palace", str(palace_path()), "mcp")
+    env = _mempalace_env()
+    executable = mempalace_mcp_executable()
+    os.execve(executable, [executable, "--palace", str(palace_path())], env)
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/.agents/skills/scientific-writing/SKILL.md
+++ b/.agents/skills/scientific-writing/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: scientific-writing
+description: Use when drafting, revising, or reviewing PRML VSLAM scientific prose for the report, slides, papers, abstracts, or literature-backed technical narrative.
+metadata:
+  mode: "writing"
+  not_when:
+    - "implementation-only code edits with no scientific prose"
+    - "generic biomedical manuscript formatting unrelated to this project"
+  handoff_to:
+    - "typst-authoring for Typst layout, compilation, or figure placement"
+    - "mempalace-repo for prior-session rationale and durable decisions"
+    - "graphify for architecture navigation before writing about code structure"
+  evidence_required:
+    - "repo artifact, experiment output, source code, or primary paper for each technical claim"
+    - "docs/Questions.md when prose touches project scope or evaluation intent"
+  applies_to:
+    - "docs/**"
+    - "README.md"
+    - "SETUP.md"
+  triggers:
+    - "scientific writing"
+    - "paper"
+    - "report prose"
+    - "abstract"
+    - "related work"
+    - "discussion"
+  must_read:
+    - "AGENTS.md"
+    - "docs/AGENTS.md when editing docs/"
+    - "docs/Questions.md when scope, requirements, or evaluation intent is discussed"
+  verification:
+    - "render or compile the touched Typst/docs surface when non-trivial"
+    - "run citation/source checks when claims or bibliography entries change"
+---
+
+# Scientific Writing
+
+Use this skill for PRML VSLAM scientific prose. The audience is a computer
+vision and spatial computing project, not a generic biomedical journal.
+
+## Use When
+
+- Writing or revising report, slides, abstract, introduction, method, results,
+  discussion, limitations, or related-work text.
+- Turning implementation or experiment facts into source-backed prose.
+- Reviewing scientific claims for scope, evidence, and wording.
+- Explaining architecture or evaluation choices in public-facing docs.
+
+## Do Not Use When
+
+- The task is only code, config, or command execution.
+- A generic manuscript rule conflicts with this repo's scope, artifacts, or
+  report format.
+- The request needs layout mechanics first; use `typst-authoring` for Typst
+  structure, rendering, and figure placement.
+
+## Rules
+
+- Draft with bullet outlines if useful, but final scientific prose must be
+  connected paragraphs unless the target template explicitly requires a list.
+- Ground every technical claim in one of: repo code, generated artifacts,
+  experiment output, docs/Questions.md, or a primary source.
+- Prefer primary papers and official docs for method, dataset, metric, and API
+  claims. Use surveys only for broad field context.
+- State scope and limits directly: dataset, method version, run configuration,
+  metric, artifact path, or section boundary.
+- Keep interpretation separate from measured results. Results state what was
+  observed; discussion explains plausible reasons and limitations.
+- Do not import generic defaults such as mandatory AI-generated figures, fixed
+  figure quotas, CONSORT/STROBE/PRISMA checklists, or `research-lookup`
+  requirements unless the concrete section genuinely needs them.
+- Avoid inflated prose. Replace "novel", "robust", "seamless", "holistic",
+  and "pivotal" with the mechanism, metric, comparison, or limitation.
+- Use Context7 or official docs when prose depends on current library behavior;
+  use `.agents/references/agent_reference.md` for known library IDs.
+
+## Workflow
+
+1. Identify the target surface and audience.
+2. Read the owning docs guidance and the specific artifacts or sources behind
+   the claims.
+3. Build a short outline with claim, scope, evidence, limitation, and citation
+   or repo path for each paragraph.
+4. Convert the outline into prose with one job per paragraph.
+5. Check that citations, terms, metrics, and limitations match the source
+   artifacts.
+6. Run the smallest render, compile, or source check that proves the touched
+   surface still works.
+
+## Paragraph Check
+
+For each paragraph, answer:
+
+1. What is the paragraph's single job?
+2. What claim does it make?
+3. What evidence supports it?
+4. What scope or limitation prevents overclaiming?
+5. Does the final sentence set up the next paragraph or close the section?
+
+If any answer is unclear, fix structure and evidence before polishing style.

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -12,6 +12,7 @@ project_doc_fallback_filenames = ["AGENTS.md"]
     [mcp_servers.code-index]
     command = "uvx"
     args    = ["code-index-mcp", "--project-path", "."]
+    cwd     = "."
 
     [mcp_servers.graphify]
     command = "python3"

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -11,21 +11,11 @@ project_doc_fallback_filenames = ["AGENTS.md"]
 
     [mcp_servers.code-index]
     command = "uvx"
-    args    = ["code-index-mcp", "--project-path", "/home/jd/repos/prml-vslam"]
+    args    = ["code-index-mcp", "--project-path", "."]
 
     [mcp_servers.graphify]
-    command = "uv"
-    args = [
-        "run",
-        "--preview-features",
-        "extra-build-dependencies",
-        "--group",
-        "dev",
-        "python",
-        "-m",
-        "graphify.serve",
-        "graphify-out/graph.json",
-    ]
+    command = "python3"
+    args    = [".agents/scripts/graphify_repo.py", "mcp"]
 
     [mcp_servers.mempalace]
     command = "python3"
@@ -55,4 +45,8 @@ enabled = true
 
 [[skills.config]]
 path    = "../.agents/skills/rerun-slam-integration"
+enabled = true
+
+[[skills.config]]
+path    = "../.agents/skills/scientific-writing"
 enabled = true

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -17,24 +17,17 @@
       ]
     },
     "graphify": {
-      "command": "uv",
+      "command": "python3",
       "args": [
-        "run",
-        "--preview-features",
-        "extra-build-dependencies",
-        "--group",
-        "dev",
-        "python",
-        "-m",
-        "graphify.serve",
-        "graphify-out/graph.json"
+        ".agents/scripts/graphify_repo.py",
+        "mcp"
       ]
     },
     "mempalace": {
-      "command": "bash",
+      "command": "python3",
       "args": [
-        "-lc",
-        "cd \"$(git rev-parse --show-toplevel)\" && exec .venv/bin/python -m mempalace.mcp_server --palace .artifacts/mempalace/palace"
+        ".agents/skills/mempalace-repo/scripts/mempalace_repo.py",
+        "mcp"
       ]
     }
   },

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ This repository owns the configuration, artifact layout, evaluation, and reporti
 - `README.md`: repository workflow, setup, developer commands, and high-level deliverables.
 - `docs/Questions.md`: high-quality human-maintained ground truth for challenge intent, clarified requirements, operator-facing scope, and product constraints. Consult it whenever a task touches project scope, assumptions, or evaluation intent.
 - `.agents/references/agent_reference.md`: lookup material for Context7 library IDs and primary sources relevant to this project.
+- `.agents/references/agent_scaffold.md`: routing contract for repo-local agent instructions, skills, references, MCP/tool use, and derived evidence surfaces.
 - The nearest nested `AGENTS.md` overrides this file for its subtree.
 
 ## Repo Map
@@ -36,6 +37,7 @@ This repository owns the configuration, artifact layout, evaluation, and reporti
 
 - When drafting requirements or specs, first extract every explicit user requirement before translating it into product or engineering requirements.
 - When promoting prompt-derived guidance into scaffold files or skills, persist only reusable rules, boundaries, and stable facts. Keep one-off task wording, temporary branch context, and transient cleanup notes out of canonical guidance.
+- Use `.agents/references/agent_scaffold.md` before adding or reorganizing agent skills, references, MCP wiring, or scaffold instructions.
 - Prefer package `README.md` and `REQUIREMENTS.md` files for ownership and implementation notes rather than restating that material in nested `AGENTS.md` files.
 - Resolve discoverable repo facts locally before asking questions. If ambiguity still materially changes the spec, ask clarifying questions before finalizing it. In Plan Mode, prefer extensive clarification when ambiguity remains.
 

--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,7 @@ GRAPHIFY_GRAPH ?= $(GRAPHIFY_DIR)/graph.json
 GRAPHIFY_HTML ?= $(GRAPHIFY_DIR)/graph.html
 GRAPHIFY_PYTHON ?= $(UV_RUN) --preview-features extra-build-dependencies --group dev python
 GRAPHIFY_CLI ?= $(UV_RUN) --preview-features extra-build-dependencies --group dev graphify
+GRAPHIFY_HELPER ?= .agents/scripts/graphify_repo.py
 
 BIB_FILE ?= docs/references.bib
 BIB_CACHE_DIR ?= .cache/bib
@@ -99,21 +100,10 @@ open3d-stubs: ## Regenerate repo-local Open3D .pyi files
 graphify: graphify-status ## Show a concise graphify dashboard
 
 graphify-status: ## Check graphify artifacts and Python runtime availability
-	@test -d "$(GRAPHIFY_DIR)" || { echo "Missing graphify directory: $(GRAPHIFY_DIR)"; exit 1; }
-	@test -f "$(GRAPHIFY_REPORT)" || { echo "Missing graphify report: $(GRAPHIFY_REPORT)"; exit 1; }
-	@test -f "$(GRAPHIFY_GRAPH)" || { echo "Missing graphify graph data: $(GRAPHIFY_GRAPH)"; exit 1; }
-	@printf "graphify artifacts: %s\n" "$(GRAPHIFY_DIR)"
-	@printf "report: %s\n" "$(GRAPHIFY_REPORT)"
-	@printf "graph data: %s\n" "$(GRAPHIFY_GRAPH)"
-	@test ! -f "$(GRAPHIFY_HTML)" || printf "viewer: %s\n" "$(GRAPHIFY_HTML)"
-	@$(GRAPHIFY_PYTHON) -c 'from importlib.metadata import version; print("runtime: available (graphifyy " + version("graphifyy") + ")")'
-	@$(GRAPHIFY_PYTHON) -c 'import json, re; from pathlib import Path; report = Path("$(GRAPHIFY_REPORT)").read_text(encoding="utf-8"); graph = json.loads(Path("$(GRAPHIFY_GRAPH)").read_text(encoding="utf-8")); date = re.search(r"^# Graph Report - .*\(([^)]*)\)", report, re.M); summary = re.search(r"^- (\d+) nodes .+? (\d+) edges .+? (\d+) communities detected", report, re.M); nodes = graph.get("nodes", []); links = graph.get("links", graph.get("edges", [])); print("graph date: " + (date.group(1) if date else "unknown")); print("nodes: " + (summary.group(1) if summary else str(len(nodes)))); print("links: " + (summary.group(2) if summary else str(len(links)))); print("communities: " + (summary.group(3) if summary else "unknown"))'
-	@if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then dirty=$$(git status --short -- "$(GRAPHIFY_REPORT)" "$(GRAPHIFY_GRAPH)" "$(GRAPHIFY_HTML)"); if [ -n "$$dirty" ]; then echo "artifact dirty state: modified"; else echo "artifact dirty state: clean"; fi; fi
-	@printf "next: make graphify-report | make graphify-rebuild | make graphify-hook-install\n"
+	@$(GRAPHIFY_PYTHON) $(GRAPHIFY_HELPER) status
 
 graphify-report: ## Print the top of the graphify report
-	@test -f "$(GRAPHIFY_REPORT)" || { echo "Missing graphify report: $(GRAPHIFY_REPORT)"; exit 1; }
-	@$(GRAPHIFY_PYTHON) -c 'import re; from pathlib import Path; report = Path("$(GRAPHIFY_REPORT)").read_text(encoding="utf-8"); print(report.splitlines()[0]); wanted = ("Corpus Check", "Summary", "Suggested Questions"); [print("\n## " + name + "\n" + match.group(1).strip()) for name in wanted for match in [re.search(r"^## " + re.escape(name) + r"\n(.*?)(?=^## |\Z)", report, re.M | re.S)] if match]'
+	@$(GRAPHIFY_PYTHON) $(GRAPHIFY_HELPER) report
 
 graphify-rebuild: ## Rebuild graphify code artifacts for this repository
 	$(GRAPHIFY_CLI) update .

--- a/docs/literature/tex-src/README.md
+++ b/docs/literature/tex-src/README.md
@@ -23,10 +23,17 @@ The checked-in manifest for this directory lives at:
 
 - `sources.jsonl`
 
-Each JSONL row describes one paper and the local output names needed to fetch its arXiv e-print source tree and, optionally, its PDF. The current schema is:
+Each JSONL row describes one literature source. ArXiv rows include the local output names needed to fetch the e-print source tree and, optionally, its PDF. Reference-only rows may point to external repositories or other source material.
 
-- required: `arxiv_id`, `tex_dir`
-- optional: `title`, `source_url`, `pdf_url`, `pdf_file`
+- arXiv rows: required `arxiv_id`, `tex_dir`; optional `title`, `source_url`, `pdf_url`, `pdf_file`
+- reference-only rows: set `kind` to a value other than `arxiv` and provide `source_url`
+
+Reference-only rows are kept in the manifest for discovery but skipped by the arXiv downloader.
+
+External sources are also indexed for agent retrieval:
+
+- `graphify add <url>` stores compact URL captures under `raw/` for Graphify's external corpus.
+- `make mempalace-refresh` stages TeX paper sources as normalized text under the derived MemPalace source tree so paper text is searchable without committing extracted arXiv bundles.
 
 Run the downloader from the repo root:
 

--- a/docs/literature/tex-src/sources.jsonl
+++ b/docs/literature/tex-src/sources.jsonl
@@ -2,3 +2,4 @@
 {"title":"MASt3R-SLAM: Real-Time Dense SLAM with 3D Reconstruction Priors","arxiv_id":"2412.12392","tex_dir":"arXiv-MASt3R-SLAM","pdf_file":"MASt3R-SLAM.pdf"}
 {"title":"DROID-SLAM: Deep Visual SLAM for Monocular, Stereo, and RGB-D Cameras","arxiv_id":"2108.10869","tex_dir":"arXiv-DROID-SLAM","pdf_file":"DROID-SLAM.pdf"}
 {"title":"ADVIO: An authentic dataset for visual-inertial odometry.","arxiv_id":"1807.09828","tex_dir":"arXiv-ADVIO","pdf_file":"ADVIO.pdf"}
+{"kind":"repository","title":"SLAM Handbook Public Release","source_url":"https://github.com/SLAM-Handbook-contributors/slam-handbook-public-release"}

--- a/graphify-out/GRAPH_REPORT.md
+++ b/graphify-out/GRAPH_REPORT.md
@@ -1,18 +1,13 @@
-# Graph Report - sweeper-pr88-integration  (2026-06-21)
+# Graph Report - fix-agents-scaffold  (2026-06-21)
 
 ## Corpus Check
-- 474 files · ~2,139,436 words
+- 307 files · ~2,090,710 words
 - Verdict: corpus is large enough that graph structure adds value.
 
 ## Summary
-- 7765 nodes · 37046 edges · 237 communities (204 shown, 33 thin omitted)
-- Extraction: 39% EXTRACTED · 61% INFERRED · 0% AMBIGUOUS · INFERRED: 22525 edges (avg confidence: 0.57)
+- 5018 nodes · 24204 edges · 32 communities detected
+- Extraction: 31% EXTRACTED · 69% INFERRED · 0% AMBIGUOUS · INFERRED: 16776 edges (avg confidence: 0.59)
 - Token cost: 0 input · 0 output
-
-## Graph Freshness
-- Built from commit: `d4f06527`
-- Run `git rev-parse HEAD` and compare to check if the graph is stale.
-- Run `graphify update .` after code changes (no API cost).
 
 ## Community Hubs (Navigation)
 - [[_COMMUNITY_Community 0|Community 0]]
@@ -47,1047 +42,205 @@
 - [[_COMMUNITY_Community 29|Community 29]]
 - [[_COMMUNITY_Community 30|Community 30]]
 - [[_COMMUNITY_Community 31|Community 31]]
-- [[_COMMUNITY_Community 32|Community 32]]
-- [[_COMMUNITY_Community 33|Community 33]]
-- [[_COMMUNITY_Community 34|Community 34]]
-- [[_COMMUNITY_Community 35|Community 35]]
-- [[_COMMUNITY_Community 36|Community 36]]
-- [[_COMMUNITY_Community 37|Community 37]]
-- [[_COMMUNITY_Community 38|Community 38]]
-- [[_COMMUNITY_Community 39|Community 39]]
-- [[_COMMUNITY_Community 40|Community 40]]
-- [[_COMMUNITY_Community 41|Community 41]]
-- [[_COMMUNITY_Community 42|Community 42]]
-- [[_COMMUNITY_Community 43|Community 43]]
-- [[_COMMUNITY_Community 44|Community 44]]
-- [[_COMMUNITY_Community 45|Community 45]]
-- [[_COMMUNITY_Community 46|Community 46]]
-- [[_COMMUNITY_Community 47|Community 47]]
-- [[_COMMUNITY_Community 48|Community 48]]
-- [[_COMMUNITY_Community 49|Community 49]]
-- [[_COMMUNITY_Community 50|Community 50]]
-- [[_COMMUNITY_Community 51|Community 51]]
-- [[_COMMUNITY_Community 52|Community 52]]
-- [[_COMMUNITY_Community 53|Community 53]]
-- [[_COMMUNITY_Community 54|Community 54]]
-- [[_COMMUNITY_Community 55|Community 55]]
-- [[_COMMUNITY_Community 56|Community 56]]
-- [[_COMMUNITY_Community 57|Community 57]]
-- [[_COMMUNITY_Community 58|Community 58]]
-- [[_COMMUNITY_Community 59|Community 59]]
-- [[_COMMUNITY_Community 60|Community 60]]
-- [[_COMMUNITY_Community 61|Community 61]]
-- [[_COMMUNITY_Community 62|Community 62]]
-- [[_COMMUNITY_Community 63|Community 63]]
-- [[_COMMUNITY_Community 64|Community 64]]
-- [[_COMMUNITY_Community 65|Community 65]]
-- [[_COMMUNITY_Community 66|Community 66]]
-- [[_COMMUNITY_Community 67|Community 67]]
-- [[_COMMUNITY_Community 68|Community 68]]
-- [[_COMMUNITY_Community 69|Community 69]]
-- [[_COMMUNITY_Community 70|Community 70]]
-- [[_COMMUNITY_Community 71|Community 71]]
-- [[_COMMUNITY_Community 72|Community 72]]
-- [[_COMMUNITY_Community 73|Community 73]]
-- [[_COMMUNITY_Community 74|Community 74]]
-- [[_COMMUNITY_Community 75|Community 75]]
-- [[_COMMUNITY_Community 76|Community 76]]
-- [[_COMMUNITY_Community 77|Community 77]]
-- [[_COMMUNITY_Community 78|Community 78]]
-- [[_COMMUNITY_Community 79|Community 79]]
-- [[_COMMUNITY_Community 80|Community 80]]
-- [[_COMMUNITY_Community 81|Community 81]]
-- [[_COMMUNITY_Community 82|Community 82]]
-- [[_COMMUNITY_Community 83|Community 83]]
-- [[_COMMUNITY_Community 84|Community 84]]
-- [[_COMMUNITY_Community 85|Community 85]]
-- [[_COMMUNITY_Community 86|Community 86]]
-- [[_COMMUNITY_Community 87|Community 87]]
-- [[_COMMUNITY_Community 88|Community 88]]
-- [[_COMMUNITY_Community 89|Community 89]]
-- [[_COMMUNITY_Community 90|Community 90]]
-- [[_COMMUNITY_Community 91|Community 91]]
-- [[_COMMUNITY_Community 92|Community 92]]
-- [[_COMMUNITY_Community 93|Community 93]]
-- [[_COMMUNITY_Community 94|Community 94]]
-- [[_COMMUNITY_Community 95|Community 95]]
-- [[_COMMUNITY_Community 96|Community 96]]
-- [[_COMMUNITY_Community 97|Community 97]]
-- [[_COMMUNITY_Community 98|Community 98]]
-- [[_COMMUNITY_Community 99|Community 99]]
-- [[_COMMUNITY_Community 100|Community 100]]
-- [[_COMMUNITY_Community 101|Community 101]]
-- [[_COMMUNITY_Community 102|Community 102]]
-- [[_COMMUNITY_Community 103|Community 103]]
-- [[_COMMUNITY_Community 104|Community 104]]
-- [[_COMMUNITY_Community 105|Community 105]]
-- [[_COMMUNITY_Community 106|Community 106]]
-- [[_COMMUNITY_Community 107|Community 107]]
-- [[_COMMUNITY_Community 108|Community 108]]
-- [[_COMMUNITY_Community 109|Community 109]]
-- [[_COMMUNITY_Community 110|Community 110]]
-- [[_COMMUNITY_Community 111|Community 111]]
-- [[_COMMUNITY_Community 112|Community 112]]
-- [[_COMMUNITY_Community 113|Community 113]]
-- [[_COMMUNITY_Community 114|Community 114]]
-- [[_COMMUNITY_Community 115|Community 115]]
-- [[_COMMUNITY_Community 116|Community 116]]
-- [[_COMMUNITY_Community 117|Community 117]]
-- [[_COMMUNITY_Community 118|Community 118]]
-- [[_COMMUNITY_Community 119|Community 119]]
-- [[_COMMUNITY_Community 120|Community 120]]
-- [[_COMMUNITY_Community 121|Community 121]]
-- [[_COMMUNITY_Community 122|Community 122]]
-- [[_COMMUNITY_Community 123|Community 123]]
-- [[_COMMUNITY_Community 124|Community 124]]
-- [[_COMMUNITY_Community 125|Community 125]]
-- [[_COMMUNITY_Community 126|Community 126]]
-- [[_COMMUNITY_Community 127|Community 127]]
-- [[_COMMUNITY_Community 128|Community 128]]
-- [[_COMMUNITY_Community 129|Community 129]]
-- [[_COMMUNITY_Community 130|Community 130]]
-- [[_COMMUNITY_Community 131|Community 131]]
-- [[_COMMUNITY_Community 132|Community 132]]
-- [[_COMMUNITY_Community 133|Community 133]]
-- [[_COMMUNITY_Community 134|Community 134]]
-- [[_COMMUNITY_Community 135|Community 135]]
-- [[_COMMUNITY_Community 136|Community 136]]
-- [[_COMMUNITY_Community 137|Community 137]]
-- [[_COMMUNITY_Community 138|Community 138]]
-- [[_COMMUNITY_Community 139|Community 139]]
-- [[_COMMUNITY_Community 140|Community 140]]
-- [[_COMMUNITY_Community 141|Community 141]]
-- [[_COMMUNITY_Community 142|Community 142]]
-- [[_COMMUNITY_Community 143|Community 143]]
-- [[_COMMUNITY_Community 144|Community 144]]
-- [[_COMMUNITY_Community 145|Community 145]]
-- [[_COMMUNITY_Community 146|Community 146]]
-- [[_COMMUNITY_Community 147|Community 147]]
-- [[_COMMUNITY_Community 148|Community 148]]
-- [[_COMMUNITY_Community 149|Community 149]]
-- [[_COMMUNITY_Community 150|Community 150]]
-- [[_COMMUNITY_Community 151|Community 151]]
-- [[_COMMUNITY_Community 152|Community 152]]
-- [[_COMMUNITY_Community 153|Community 153]]
-- [[_COMMUNITY_Community 154|Community 154]]
-- [[_COMMUNITY_Community 155|Community 155]]
-- [[_COMMUNITY_Community 156|Community 156]]
-- [[_COMMUNITY_Community 157|Community 157]]
-- [[_COMMUNITY_Community 158|Community 158]]
-- [[_COMMUNITY_Community 159|Community 159]]
-- [[_COMMUNITY_Community 160|Community 160]]
-- [[_COMMUNITY_Community 161|Community 161]]
-- [[_COMMUNITY_Community 162|Community 162]]
-- [[_COMMUNITY_Community 163|Community 163]]
-- [[_COMMUNITY_Community 164|Community 164]]
-- [[_COMMUNITY_Community 165|Community 165]]
-- [[_COMMUNITY_Community 166|Community 166]]
-- [[_COMMUNITY_Community 167|Community 167]]
-- [[_COMMUNITY_Community 168|Community 168]]
-- [[_COMMUNITY_Community 169|Community 169]]
-- [[_COMMUNITY_Community 170|Community 170]]
-- [[_COMMUNITY_Community 171|Community 171]]
-- [[_COMMUNITY_Community 172|Community 172]]
-- [[_COMMUNITY_Community 173|Community 173]]
-- [[_COMMUNITY_Community 175|Community 175]]
-- [[_COMMUNITY_Community 176|Community 176]]
-- [[_COMMUNITY_Community 177|Community 177]]
-- [[_COMMUNITY_Community 178|Community 178]]
-- [[_COMMUNITY_Community 179|Community 179]]
-- [[_COMMUNITY_Community 180|Community 180]]
-- [[_COMMUNITY_Community 181|Community 181]]
-- [[_COMMUNITY_Community 182|Community 182]]
-- [[_COMMUNITY_Community 183|Community 183]]
-- [[_COMMUNITY_Community 184|Community 184]]
-- [[_COMMUNITY_Community 185|Community 185]]
-- [[_COMMUNITY_Community 186|Community 186]]
-- [[_COMMUNITY_Community 188|Community 188]]
-- [[_COMMUNITY_Community 189|Community 189]]
-- [[_COMMUNITY_Community 190|Community 190]]
-- [[_COMMUNITY_Community 191|Community 191]]
-- [[_COMMUNITY_Community 192|Community 192]]
-- [[_COMMUNITY_Community 193|Community 193]]
-- [[_COMMUNITY_Community 194|Community 194]]
-- [[_COMMUNITY_Community 195|Community 195]]
-- [[_COMMUNITY_Community 196|Community 196]]
-- [[_COMMUNITY_Community 197|Community 197]]
-- [[_COMMUNITY_Community 198|Community 198]]
-- [[_COMMUNITY_Community 199|Community 199]]
-- [[_COMMUNITY_Community 200|Community 200]]
-- [[_COMMUNITY_Community 201|Community 201]]
-- [[_COMMUNITY_Community 202|Community 202]]
-- [[_COMMUNITY_Community 203|Community 203]]
-- [[_COMMUNITY_Community 204|Community 204]]
-- [[_COMMUNITY_Community 205|Community 205]]
-- [[_COMMUNITY_Community 206|Community 206]]
-- [[_COMMUNITY_Community 207|Community 207]]
-- [[_COMMUNITY_Community 208|Community 208]]
-- [[_COMMUNITY_Community 209|Community 209]]
-- [[_COMMUNITY_Community 210|Community 210]]
-- [[_COMMUNITY_Community 211|Community 211]]
-- [[_COMMUNITY_Community 212|Community 212]]
-- [[_COMMUNITY_Community 213|Community 213]]
-- [[_COMMUNITY_Community 214|Community 214]]
-- [[_COMMUNITY_Community 215|Community 215]]
-- [[_COMMUNITY_Community 216|Community 216]]
-- [[_COMMUNITY_Community 217|Community 217]]
-- [[_COMMUNITY_Community 218|Community 218]]
-- [[_COMMUNITY_Community 219|Community 219]]
-- [[_COMMUNITY_Community 220|Community 220]]
-- [[_COMMUNITY_Community 221|Community 221]]
-- [[_COMMUNITY_Community 222|Community 222]]
-- [[_COMMUNITY_Community 223|Community 223]]
-- [[_COMMUNITY_Community 224|Community 224]]
-- [[_COMMUNITY_Community 225|Community 225]]
-- [[_COMMUNITY_Community 226|Community 226]]
-- [[_COMMUNITY_Community 227|Community 227]]
-- [[_COMMUNITY_Community 228|Community 228]]
-- [[_COMMUNITY_Community 229|Community 229]]
-- [[_COMMUNITY_Community 230|Community 230]]
-- [[_COMMUNITY_Community 234|Community 234]]
 
 ## God Nodes (most connected - your core abstractions)
-1. `StageKey` - 829 edges
-2. `MethodId` - 526 edges
-3. `SequenceManifest` - 448 edges
-4. `DatasetId` - 382 edges
-5. `PathConfig` - 381 edges
-6. `PreparedBenchmarkInputs` - 379 edges
-7. `TransientPayloadRef` - 337 edges
-8. `StageOutcome` - 318 edges
-9. `ReferenceSource` - 301 edges
-10. `ArtifactRef` - 283 edges
+1. `StageKey` - 453 edges
+2. `SequenceManifest` - 435 edges
+3. `PreparedBenchmarkInputs` - 367 edges
+4. `DatasetId` - 363 edges
+5. `PathConfig` - 294 edges
+6. `ReferenceSource` - 286 edges
+7. `ArtifactRef` - 283 edges
+8. `MethodId` - 280 edges
+9. `StageRuntimeStatus` - 238 edges
+10. `RunConfig` - 219 edges
 
 ## Surprising Connections (you probably didn't know these)
-- `MetricsPageState` --calls--> `test_metrics_page_state_preserves_persisted_view_fields()`  [INFERRED]
-  src/prml_vslam/app/models.py → tests/test_app.py
-- `GroundAlignmentMetadata` --uses--> `Focused tests for derived ground-plane alignment.`  [INFERRED]
-  src/prml_vslam/interfaces/alignment.py → tests/test_ground_alignment.py
-- `_adapt_checkpoint_state_dict()` --calls--> `test_lingbot_checkpoint_pos_embed_can_be_dropped_for_smaller_image_grid()`  [INFERRED]
-  src/prml_vslam/methods/lingbot/adapter.py → tests/test_lingbot_method.py
-- `_adapt_checkpoint_state_dict()` --calls--> `test_lingbot_checkpoint_pos_embed_interpolates_to_smaller_image_grid()`  [INFERRED]
-  src/prml_vslam/methods/lingbot/adapter.py → tests/test_lingbot_method.py
-- `_adapt_checkpoint_state_dict()` --calls--> `test_lingbot_checkpoint_pos_embed_requires_policy_for_smaller_image_grid()`  [INFERRED]
-  src/prml_vslam/methods/lingbot/adapter.py → tests/test_lingbot_method.py
+- `test_lingbot_config_rejects_invalid_runtime_values()` --calls--> `LingbotMapSlamBackendConfig`  [INFERRED]
+  tests/test_lingbot_method.py → src/prml_vslam/methods/stage/backend_config.py
+- `Focused tests for derived ground-plane alignment.` --uses--> `GroundAlignmentMetadata`  [INFERRED]
+  tests/test_ground_alignment.py → src/prml_vslam/interfaces/alignment.py
+- `Small runtime sources used by focused pipeline smoke tests.` --uses--> `SequenceManifest`  [INFERRED]
+  tests/pipeline_testing_support.py → src/prml_vslam/sources/contracts.py
+- `Minimal offline source for pipeline smoke tests.` --uses--> `SequenceManifest`  [INFERRED]
+  tests/pipeline_testing_support.py → src/prml_vslam/sources/contracts.py
+- `Finite in-memory packet stream for streaming smoke tests.` --uses--> `SequenceManifest`  [INFERRED]
+  tests/pipeline_testing_support.py → src/prml_vslam/sources/contracts.py
 
-## Import Cycles
-- 2-file cycle: `src/prml_vslam/sources/datasets/record3d/__init__.py -> src/prml_vslam/sources/datasets/record3d/record3d_service.py -> src/prml_vslam/sources/datasets/record3d/__init__.py`
-- 2-file cycle: `src/prml_vslam/sources/datasets/record3d/__init__.py -> src/prml_vslam/sources/datasets/record3d/record3d_sequence.py -> src/prml_vslam/sources/datasets/record3d/__init__.py`
-- 2-file cycle: `src/prml_vslam/sources/datasets/advio/__init__.py -> src/prml_vslam/sources/datasets/advio/advio_sequence.py -> src/prml_vslam/sources/datasets/advio/__init__.py`
-- 2-file cycle: `src/prml_vslam/reconstruction/config.py -> src/prml_vslam/reconstruction/open3d_tsdf.py -> src/prml_vslam/reconstruction/config.py`
-- 3-file cycle: `src/prml_vslam/sources/datasets/tum_rgbd/__init__.py -> src/prml_vslam/sources/datasets/tum_rgbd/tum_rgbd_service.py -> src/prml_vslam/sources/datasets/tum_rgbd/tum_rgbd_sequence.py -> src/prml_vslam/sources/datasets/tum_rgbd/__init__.py`
-- 3-file cycle: `src/prml_vslam/sources/datasets/record3d/__init__.py -> src/prml_vslam/sources/datasets/record3d/record3d_service.py -> src/prml_vslam/sources/datasets/record3d/record3d_sequence.py -> src/prml_vslam/sources/datasets/record3d/__init__.py`
-- 3-file cycle: `src/prml_vslam/sources/datasets/advio/__init__.py -> src/prml_vslam/sources/datasets/advio/advio_service.py -> src/prml_vslam/sources/datasets/advio/advio_sequence.py -> src/prml_vslam/sources/datasets/advio/__init__.py`
-
-## Communities (237 total, 33 thin omitted)
+## Communities
 
 ### Community 0 - "Community 0"
-Cohesion: 0.02
-Nodes (241): ArtifactRef, Reject negative custom resource quantities., Allow only exact artifact keys or safe ``prefix:*`` selectors., Return the declared output paths for a generic stage section., Return deterministic output paths declared by this stage., Return whether the configured stage can run., Build a failed :class:`StageOutcome` using this stage's identity., Stable hash inputs for generic stage failure provenance. (+233 more)
+Cohesion: 0.01
+Nodes (405): _build_artifacts(), _DensePredictionArtifacts, _ensure_uint8_rgb_from_uimg(), _estimate_camera_intrinsics_from_frame(), _InProcessManager, _InProcessValue, Mast3rSlamSession, Canonical MASt3R-SLAM backend adapter (offline + streaming).  This adapter wraps (+397 more)
 
 ### Community 1 - "Community 1"
-Cohesion: 0.04
-Nodes (133): Record3DDatasetPageState, Record3DDatasetPoseSource, Apply one Record3D preview start or stop action., Render ADVIO normalized loop preview controls., Render TUM RGB-D normalized loop preview controls., Render Record3D normalized loop preview controls., Render the shared normalized dataset loop-preview control., Render the current shared preview-runtime snapshot. (+125 more)
+Cohesion: 0.01
+Nodes (414): build_advio_page_data(), _scene_rows(), AdvioDownloadManager, _ensure_directory_parent(), Return the cache directory used for downloaded scene archives., Return one catalog scene by id., Return local availability status for every catalog scene., Download selected ADVIO scenes and extract complete scene payloads. (+406 more)
 
 ### Community 2 - "Community 2"
-Cohesion: 0.04
-Nodes (56): _format_value(), _get_type_name(), _normalize_ipc_value(), BaseModel, CameraIntrinsicsSample, load_camera_intrinsics_yaml(), Build the shared DTO from a flat 9-value column-major payload., Build the shared DTO from a flat 9-value row-major payload. (+48 more)
+Cohesion: 0.01
+Nodes (474): handle_advio_preview_action(), Controller helpers for the ADVIO Streamlit page., Persist the current ADVIO download-form state., Keep persisted preview state aligned with the runtime snapshot., Apply one preview-form action and return an error message when it fails., sync_advio_download_state(), sync_advio_preview_state(), AdvioEnvironment (+466 more)
 
 ### Community 3 - "Community 3"
-Cohesion: 0.04
-Nodes (209): AdvioFixedpointFitMode, ADVIO fixedpoint registration helpers.  The official ADVIO visualization registe, Estimate a no-scale rigid transform from provider RDF world to fixpoints., Apply one fixedpoint registration to a provider RDF trajectory., Crop registered ADVIO trajectories and express them in one GT local frame., Build a frame-labelled camera pose from a matrix., Rigid registration mode selected for one ADVIO provider trajectory., ADVIO fixpoints converted to repository RDF coordinates. (+201 more)
+Cohesion: 0.03
+Nodes (379): AdvioFixedpointFitMode, AdvioFixpointSet, Rigid registration mode selected for one ADVIO provider trajectory., ADVIO fixpoints converted to repository RDF coordinates., AdvioRawCoordinateBasis, Raw coordinate bases used by official ADVIO provider artifacts., AdvioSceneMetadata, Describe one ADVIO scene committed into the repository catalog. (+371 more)
 
 ### Community 4 - "Community 4"
-Cohesion: 0.04
-Nodes (81): Whether the backend can emit live preview payloads., Whether the backend may emit native visualization artifacts., Whether the backend supports repository trajectory evaluation., Return backend-owned default resource hints., Whether the backend supports offline execution., Whether the backend supports streaming execution., Whether the backend can expose point-cloud outputs., Whether the backend can emit live preview payloads. (+73 more)
+Cohesion: 0.01
+Nodes (300): BaseConfig, _ConfigFactory, FactoryConfig, from_toml(), _normalize_value(), Shared config and config-as-factory helpers for the repository.  This module own, Render the config as a Rich tree for quick human inspection., Mixin for configs that construct one runtime owner or adapter.      This pattern (+292 more)
 
 ### Community 5 - "Community 5"
-Cohesion: 0.05
-Nodes (125): BaseConfig, PipelinePlanContext, Inputs available while compiling a deterministic run plan., GroundAlignmentStageConfig, Stage-owned policy for derived ground-plane alignment., CloudAlignmentStageConfig, Offline policy for aligning SLAM clouds before dense-cloud metrics., Ensure every section carries its canonical target stage key. (+117 more)
+Cohesion: 0.01
+Nodes (343): build_crowd_density_figure(), build_local_readiness_figure(), build_scene_attribute_figure(), build_scene_mix_figure(), Plotly figure builders for the ADVIO dataset page., Build a crowd-density composition chart., Build a scene-attribute prevalence chart., Build a stacked venue/environment overview for the catalog. (+335 more)
 
 ### Community 6 - "Community 6"
-Cohesion: 0.07
-Nodes (58): PreviewSessionSnapshot, PreviewStreamState, Record3DStreamSnapshot, extract_pose_position(), PacketSessionMetrics, PacketSessionRuntime, App-owned preview runtime primitives for live packet consumers., Return packet-rate snapshot fields. (+50 more)
+Cohesion: 0.03
+Nodes (248): BaseStageRuntime, FailureFingerprint, Reject negative custom resource quantities., Allow only exact artifact keys or safe ``prefix:*`` selectors., Return the declared output paths for a generic stage section., Return deterministic output paths declared by this stage., Return whether the configured stage can run., Build a failed :class:`StageOutcome` using this stage's identity. (+240 more)
 
 ### Community 7 - "Community 7"
-Cohesion: 0.06
-Nodes (39): validate_dataset_root(), validate_sequence_ids(), _valid_artifact_selector(), from_column_major_flat_k(), from_matrices(), from_matrix(), from_row_major_flat_k(), validate_artifact_key_selectors() (+31 more)
+Cohesion: 0.01
+Nodes (292): align_estimate_sim3(), CloudAlignmentService, icp_point_cloud_path(), is_gravity_aligned_target(), ICP point-cloud alignment service., Materialize offline point-cloud alignment artifacts before cloud metrics., Refine a trajectory-Sim(3)-aligned cloud against a reference cloud with ICP., Return True when both trajectories have enough geometric spread for Sim(3) align (+284 more)
 
 ### Community 8 - "Community 8"
-Cohesion: 0.04
-Nodes (61): AbstractEventLoop, BaseException, decode_record3d_wifi_depth(), _parse_depth_range(), _parse_intrinsic_matrix(), _parse_original_size(), Metadata parsing and packet decoding for Record3D Wi-Fi streaming., Decode the HSV-encoded Record3D Wi-Fi depth half into a depth map. (+53 more)
+Cohesion: 0.02
+Nodes (210): _adapt_checkpoint_state_dict(), _as_numpy(), _build_lingbot_artifacts(), _cast_aggregator_for_inference(), _decode_pose_predictions(), _expect_lingbot_config(), _extract_checkpoint_state_dict(), _extract_dense_prediction_artifacts() (+202 more)
 
 ### Community 9 - "Community 9"
-Cohesion: 0.09
-Nodes (49): ObservationIndexEntry, One row in a durable observation sequence index., build(), stage_manifests(), materialize_manifest(), Materialize the run-owned source manifest for this source stage., iter_sequence_manifest_observations(), Yield RGB observations from a normalized source sequence manifest. (+41 more)
+Cohesion: 0.02
+Nodes (177): build_advio_comparison_trajectories(), Build ADVIO explorer overlays with explicit comparison semantics., _coerce_view_graph(), _coerce_view_graph_node(), load_vista_confidences(), load_vista_estimated_intrinsics_series(), load_vista_intrinsics_matrices(), load_vista_native_trajectory() (+169 more)
+
+### Community 10 - "Community 10"
+Cohesion: 0.02
+Nodes (81): Return the user-facing reconstruction label., Configure the minimal Open3D TSDF reconstruction backend.      The repo targets, Return the concrete reconstruction backend type., Instantiate the Open3D TSDF backend while ignoring unrelated kwargs., DenseCloudEvaluationArtifact, DenseCloudEvaluationSelection, Persist one dense-cloud evaluation result for later review., Describe normalized durable outputs from one reconstruction run.      The minima (+73 more)
 
 ### Community 11 - "Community 11"
-Cohesion: 0.10
-Nodes (30): AdvioDownloadManager, AdvioEnvironment, AdvioPeopleLevel, AdvioSequenceConfig, AdvioUpstreamMetadata, ADVIO-specific metadata and config models.  This module owns the committed scene, Configure one local ADVIO sequence owner.      This config is the main click-thr, Return the canonical ADVIO folder name used on disk. (+22 more)
+Cohesion: 0.04
+Nodes (146): available_metric_keys(), build_coverage_matrix(), build_heatmap_data(), build_leaderboard(), build_per_sequence_table(), _build_rmse_aggregate_rows(), build_wide_metric_rows(), _clean_records() (+138 more)
 
 ### Community 12 - "Community 12"
-Cohesion: 0.08
-Nodes (40): report_path(), analyze_file(), analyze_source(), count_grouped_stats(), count_module_stats(), count_stats(), extract_markers(), iter_python_files() (+32 more)
+Cohesion: 0.04
+Nodes (97): Log a warning message., ape_error_colors(), augment_viewer_recording_with_ground_plane(), build_default_blueprint(), create_recording_stream(), _decimate_rows(), _entity_token(), evaluation_case_root() (+89 more)
 
 ### Community 13 - "Community 13"
-Cohesion: 0.08
-Nodes (48): evaluation_case_root(), evaluation_metric_root(), reconstruction_point_cloud_path(), reference_color(), reference_points_path(), reference_trajectory_path(), sim3_transform_path(), slam_aligned_point_cloud_path() (+40 more)
+Cohesion: 0.03
+Nodes (108): advio_common_start_local_trajectories(), advio_frame_transform_from_pose(), AdvioFixedpointRegistration, apply_advio_fixedpoint_registration(), estimate_advio_fixedpoint_registration(), _estimate_rigid_no_scale(), _gravity_tilt_deg(), _horizontal_span_m() (+100 more)
 
 ### Community 14 - "Community 14"
-Cohesion: 0.05
-Nodes (112): AdvioManifestAssets, _advio_aligned_diagnostic_reference(), _advio_aligned_diagnostic_references(), _benchmark_artifact_paths(), _cleanup_temporary_entry_root(), _compatible_entry_identity(), _compatible_entry_profile(), _compatible_entry_score() (+104 more)
+Cohesion: 0.07
+Nodes (46): _assert_slug(), build_run_config_from_sweep_item(), _build_run_id(), expand_sweep(), _load_slam_stage_from_template(), load_sweep_config(), _load_toml_payload(), _resolve_path() (+38 more)
 
 ### Community 15 - "Community 15"
-Cohesion: 0.05
-Nodes (45): Enum, IntEnum, Return a compact JSON-ready subset for UI details and telemetry sinks., _camera_pose_from_binding(), _device_from_binding(), _intrinsics_from_binding(), build_record3d_frame_details(), list_record3d_usb_devices() (+37 more)
+Cohesion: 0.12
+Nodes (37): test_load_recording_summary_reports_live_keyed_and_tracking_surfaces(), test_write_validation_bundle_emits_report_and_projection_images(), test_write_validation_bundle_respects_explicit_keyed_cloud_limit(), _write_synthetic_recording(), _ancestor_entity_paths(), _component_columns(), _keyed_point_cloud_snapshots(), _latest_live_model_snapshot() (+29 more)
 
 ### Community 16 - "Community 16"
-Cohesion: 0.10
-Nodes (33): Persisted config for the ``gravity.align`` stage., GroundAlignmentConfig, Typed policy contracts for derived ground-plane alignment.  Alignment is a deriv, Policy for optional dominant-ground detection and viewer alignment.      The sta, Ground-alignment pipeline stage integration., GroundAlignmentService, _import_open3d(), _patch_extent_m() (+25 more)
+Cohesion: 0.11
+Nodes (34): build_pipeline_snapshot_render_model(), _coerce_int_metric(), _format_latency(), _format_optional_rate(), _format_queue(), _format_resources(), _format_tasks(), _format_throughput() (+26 more)
 
 ### Community 17 - "Community 17"
-Cohesion: 0.02
-Nodes (180): CaptureFixture, Project the latest run state from the append-only event stream.      Callers sho, RunSnapshot, ObjectRef, PipelineBackend, Execute, monitor, and tear down pipeline runs.      Implementations own the conc, Start one run and return the stable run identifier.          Args:             r, _coordinator_actor_options() (+172 more)
+Cohesion: 0.1
+Nodes (21): caller_namespace(), configure_logging(), _ConsoleLogFormatter, _ConsoleLogHighlighter, _display_name(), from_callsite(), get_console(), _qualify_namespace() (+13 more)
 
 ### Community 18 - "Community 18"
-Cohesion: 0.03
-Nodes (145): FailureFingerprint, Stage-owned runtime integration contracts.  Specs bind the generic runner to dom, Stage-owned integration surface used by generic runtime plumbing., StageRuntimeSpec, StageConfig, PipelineExecutionContext, Return the human-readable label shown in plan previews., Name the canonical target stage vocabulary. (+137 more)
+Cohesion: 0.09
+Nodes (25): DataOnlyConfig, InvalidTargetConfig, NestedPayload, PlainPayload, Tests for the shared Pydantic base-model split., Runtime object used to verify default setup behavior., Config whose runtime target is constructed via ``target_type``., Config without a runtime target. (+17 more)
+
+### Community 19 - "Community 19"
+Cohesion: 1.0
+Nodes (1): Thin Streamlit entrypoint for the PRML VSLAM workbench scaffold.  The file stays
 
 ### Community 20 - "Community 20"
-Cohesion: 0.04
-Nodes (147): _DensePredictionArtifacts, _expect_lingbot_config(), Run LingBot-Map and persist normalized trajectory and dense geometry., Expose active mamba CUDA build paths to FlashInfer's JIT linker., Run LingBot-Map over normalized repository observations., Start a bounded LingBot-Map streaming session over incoming RGB frames., Buffer one RGB streaming observation for LingBot terminal inference., Run LingBot terminal inference and clear streaming state. (+139 more)
+Cohesion: 1.0
+Nodes (1): Ray-specific helpers for future stage runtime deployment.  This module intention
 
 ### Community 21 - "Community 21"
-Cohesion: 0.13
-Nodes (137): AdapterT, VisualizationIntent, TransientPayloadRef, StageRuntimeHandle, BaseDataT, BaseStageRuntime, ArtifactRegistered, RunCompleted (+129 more)
+Cohesion: 1.0
+Nodes (1): Build the shared transform DTO from XYZW quaternion and XYZ translation arrays.
 
 ### Community 22 - "Community 22"
-Cohesion: 0.04
-Nodes (108): LiveUpdateStageRuntime, Blueprint, CameraIntrinsics, Describe one camera raster in a backend- and dataset-neutral way.      Use this, Compatibility import surface for method-owned SLAM artifact contracts., Viewer artifacts associated with one run.      Native upstream recordings and re, VisualizationArtifacts, Normalize durable outputs produced by a SLAM backend.      The bundle is the sci (+100 more)
+Cohesion: 1.0
+Nodes (1): Build the shared transform DTO from a 4x4 homogeneous matrix.
 
 ### Community 23 - "Community 23"
-Cohesion: 0.05
-Nodes (119): Argument, case_sensitive, Context, parse_dataset_id(), dir_okay, DiscoveredRun, Describe one normalized trajectory candidate under a run artifact root., exists (+111 more)
+Cohesion: 1.0
+Nodes (1): Return the compact source label used in logs and diagnostics.
 
 ### Community 24 - "Community 24"
-Cohesion: 0.04
-Nodes (90): dtype, generic, Protocol, compute_disparity(), get_pointmap_vis(), get_view(), load(), save() (+82 more)
+Cohesion: 1.0
+Nodes (1): Disconnect or release the source and any owned runtime resources.
 
 ### Community 25 - "Community 25"
-Cohesion: 0.07
-Nodes (78): BenchmarkInputSource, DatasetSequenceSource, _validate_archive_name(), Download manager for static Record3D `.r3d` archive scenes., Resolve and download Record3D archive scenes into the dataset root., Download selected Record3D `.r3d` archives with SHA-256 verification., Record3DDownloadManager, _redact_url_for_log() (+70 more)
+Cohesion: 1.0
+Nodes (1): Return the short user-facing dataset label.
 
 ### Community 26 - "Community 26"
-Cohesion: 0.15
-Nodes (97): Expand this dataset group into concrete per-sequence source configs., Expand this dataset group into concrete per-sequence source configs., Expand this dataset group into concrete per-sequence source configs., Source-prepared RGB-D reference-cloud sampling policy., RunState, AdvioNormalizedDatasetBuildSource, NormalizedDatasetBuildConfig, TOML contracts for normalized datastore batch builds. (+89 more)
+Cohesion: 1.0
+Nodes (1): Deserialize one IPC payload back into the target validated model type.
 
 ### Community 27 - "Community 27"
-Cohesion: 0.06
-Nodes (65): Stop the worker, disconnect the stream, and update the terminal snapshot., _adapt_checkpoint_state_dict(), _as_numpy(), _build_lingbot_artifacts(), _cast_aggregator_for_inference(), _decode_pose_predictions(), _extract_checkpoint_state_dict(), _extract_dense_prediction_artifacts() (+57 more)
+Cohesion: 1.0
+Nodes (1): Return the human-readable label shown in plan previews.
 
 ### Community 28 - "Community 28"
-Cohesion: 0.05
-Nodes (77): Result of one derived ground-plane alignment attempt.      When :attr:`applied`, DepthMap, PointCloud, PointMap, Typed geometry payload contracts shared across source and viewer boundaries.  Th, Normalize arrays and validate pointmap shape/frame invariants., Represent a metric depth raster with explicit camera semantics., Normalize arrays and validate depth shape/frame invariants. (+69 more)
+Cohesion: 1.0
+Nodes (1): Return whether ``exc`` looks like a transient local Ray connection failure.
 
 ### Community 29 - "Community 29"
-Cohesion: 0.07
-Nodes (72): Inputs available while constructing and executing stage runtimes., PipelineMode, Pipeline execution mode contract., Select whether the run is batch/offline or live/incremental., PlannedSource, Deterministic planning contracts for the pipeline.  This module owns the side-ef, Compact source selection snapshot captured in the deterministic plan., Describe one planned stage in the deterministic execution order. (+64 more)
+Cohesion: 1.0
+Nodes (1): Build one spec from one JSON object.
 
 ### Community 30 - "Community 30"
-Cohesion: 0.07
-Nodes (58): ObservationIndexEntry, OutputContainer, Replay clock used by dataset and video source streams., Select whether replay follows source timing or returns observations immediately., Apply source-timestamp pacing for real-time replay., Reset the clock baseline for a new replay loop or connection., Sleep until the replay timestamp should be emitted., ReplayClock (+50 more)
+Cohesion: 1.0
+Nodes (1): Return the net code-line delta.
 
 ### Community 31 - "Community 31"
-Cohesion: 0.08
-Nodes (66): Observation, ObservationProvenance, Describe where one normalized observation came from., Represent one live, replayed, or file-backed RDF camera observation., FrameTransform, SlamArtifacts, SlamOutputPolicy, test_advio_preview_frame_uses_live_image_renderer() (+58 more)
-
-### Community 32 - "Community 32"
-Cohesion: 0.11
-Nodes (71): AdvioPageState, ArtifactInspectorPageState, DatasetPageData, MetricsPageState, App-owned models for Streamlit page state, snapshots, and view selections., Typed ADVIO dataset-download form payload., Typed ADVIO preview action payload., Computed ADVIO page render payload. (+63 more)
-
-### Community 33 - "Community 33"
-Cohesion: 0.08
-Nodes (66): BaseData, IntrinsicsComparisonDiagnostics, Estimated-vs-reference intrinsics residuals in one raster space., compare_camera_intrinsics_series(), Camera-intrinsics comparison utilities., Compare one estimated intrinsics series against a reference camera model., CameraIntrinsicsSeries, Typed artifact for a sequence of camera intrinsics in one raster space. (+58 more)
-
-### Community 34 - "Community 34"
-Cohesion: 0.08
-Nodes (16): _resolve_handle_payload(), Return the current wall-clock timestamp in nanoseconds., ts_ns(), RunCoordinatorActor, StageRuntimeUpdate, JsonScalar, RunPlan, RuntimeFactory (+8 more)
-
-### Community 36 - "Community 36"
-Cohesion: 0.10
-Nodes (57): AdvioDatasetService, AdvioDownloadManager, DatasetServiceBase, list_local_sequence_ids(), FakePacketStream, Observation, Finite in-memory packet stream for streaming smoke tests., _build_fake_catalog() (+49 more)
-
-### Community 37 - "Community 37"
-Cohesion: 0.07
-Nodes (62): AdvioPageState, compact_dashboard_frame(), Dashboard panels for normalized dataset snapshots., Select one row per sequence and trajectory subject for dashboard charts., Return compact columns for dashboard detail tables., Render top-level normalized-store and download-cache metrics., Render ADVIO-specific catalog composition charts., Render normalized-store dashboard charts for one dataset. (+54 more)
-
-### Community 38 - "Community 38"
-Cohesion: 0.09
-Nodes (55): ObservationSequenceIndex, Durable ``observation_sequence.v1`` index payload., Yield shared observations indefinitely until the caller stops consuming them., Record3DDatasetService, Record3DDownloadManager, NormalizableDatasetSource, test_normalized_store_rejects_ambiguous_compatible_entries(), test_record3d_normalized_store_rejects_runtime_upsampling() (+47 more)
-
-### Community 39 - "Community 39"
-Cohesion: 0.09
-Nodes (58): PipelineTelemetryMetricId, PipelineTelemetryViewMode, build_pipeline_snapshot_render_model(), _coerce_int_metric(), _format_latency(), _format_optional_rate(), _format_queue(), _format_resources() (+50 more)
-
-### Community 40 - "Community 40"
-Cohesion: 0.08
-Nodes (54): handle_advio_preview_action(), _build_live_trajectory_figure(), live_image_data_url(), live_poll_interval(), _prepare_live_image_array(), Shared Streamlit helpers for live-session app pages., Return the fragment refresh interval only while the session is active., Render one keyed start-or-stop button slot and return requested action flags. (+46 more)
-
-### Community 41 - "Community 41"
-Cohesion: 0.10
-Nodes (41): AdvioPreviewRuntimeController, build_context(), _build_pages(), _enter_page(), _load_page_module(), Bootstrap helpers for the packaged PRML VSLAM Streamlit app., Typed per-rerun context passed to page renderers., Construct the typed services and persisted state for one rerun. (+33 more)
-
-### Community 42 - "Community 42"
-Cohesion: 0.11
-Nodes (54): CoverageCell, CoverageMatrix, HeatmapData, PerSequenceRow, Rectangular coverage grid for all sequences × all discovered methods., Metric values for a heatmap of sequences × estimate sources., One filtered metric value for a single sequence, run, and estimate source., Coverage state for one (sequence, method) cell in the coverage matrix. (+46 more)
-
-### Community 43 - "Community 43"
-Cohesion: 0.14
-Nodes (52): AppContext, PipelinePageState, PipelineSourceId, action_from_page_state(), backend_payload_from_action(), build_preview_plan(), build_run_config_from_action(), discover_pipeline_config_paths() (+44 more)
-
-### Community 44 - "Community 44"
-Cohesion: 0.12
-Nodes (42): Trajectory-evaluation metric contracts and artifact manifest schema.  The trajec, Record for a non-primary metric that was attempted but skipped due to a non-fata, Describe one persisted reference-vs-candidate trajectory metric case., Capture the resolved reference/candidate choice for trajectory computation., Long-form trajectory metric statistic row for cross-run aggregation., SelectionSnapshot, SkippedMetricRecord, TrajectoryEvaluationCase (+34 more)
-
-### Community 45 - "Community 45"
-Cohesion: 0.08
-Nodes (46): build_crowd_density_figure(), build_local_readiness_figure(), build_scene_attribute_figure(), build_scene_mix_figure(), Plotly figure builders for the ADVIO dataset page., Build a crowd-density composition chart., Build a scene-attribute prevalence chart., Build a stacked venue/environment overview for the catalog. (+38 more)
-
-### Community 46 - "Community 46"
-Cohesion: 0.15
-Nodes (47): Resolve an ``advio-XX`` slug into the numeric ADVIO sequence id., canonical_sequence_id_for_dataset(), dataset_id_for_source_config(), dataset_service(), _dataset_source_config_from_payload(), default_frame_selection_for_dataset(), normalize_dataset_entries(), normalize_dataset_entry() (+39 more)
-
-### Community 47 - "Community 47"
-Cohesion: 0.09
-Nodes (40): _build_run_id(), expand_sweep(), _load_slam_stage_from_template(), SlamStageConfig, str, _make_item(), _minimal_sweep_toml(), Path (+32 more)
-
-### Community 48 - "Community 48"
-Cohesion: 0.07
-Nodes (29): normalized_store_for_path_config(), FrameSelectionConfig, Record3DStreamingSourceConfig, Record3DStreamingSource, normalized_profile_for_source_config(), _check_extraction_cache(), Source-owned manifest materialization helpers., Adapt a raw video path into the normalized offline source seam. (+21 more)
-
-### Community 49 - "Community 49"
-Cohesion: 0.16
-Nodes (35): _FakeRecordingStream, _ground_alignment_metadata(), _ground_alignment_update(), _payload_ref(), CameraIntrinsics, FrameTransform, Path, StageRuntimeUpdate (+27 more)
-
-### Community 50 - "Community 50"
-Cohesion: 0.09
-Nodes (42): build_depth_intrinsics(), build_rgb_intrinsics(), decode_confidence_frame(), decode_depth_frame_m(), decode_rgb_frame(), index_archive_frames(), _names_by_index(), pose_from_metadata_row() (+34 more)
-
-### Community 51 - "Community 51"
-Cohesion: 0.18
-Nodes (46): _build_rerun_viewer_command(), _launch_rerun_viewer(), _wait_for_pipeline_terminal_snapshot(), paths(), resolve(), PathConfig, RunSnapshot, _advio_run_config() (+38 more)
-
-### Community 52 - "Community 52"
-Cohesion: 0.10
-Nodes (40): Render one fragment-scoped live section., render_live_fragment(), Record3DPageAction, Record3DTransportSelection, handle_record3d_page_action(), Small controller helpers for the Record3D Streamlit page., Apply one Record3D page action and return the latest snapshot., Keep persisted running state aligned with the latest runtime snapshot. (+32 more)
-
-### Community 53 - "Community 53"
-Cohesion: 0.06
-Nodes (33): configure_logging(), _display_name(), from_callsite(), _qualify_namespace(), Logger, LogRecord, ReprHighlighter, Path (+25 more)
-
-### Community 54 - "Community 54"
-Cohesion: 0.08
-Nodes (23): icp_point_cloud_path(), result_path(), CloudAlignmentSelection, CloudAlignmentArtifact, CloudAlignmentSelection, Describe offline point-cloud alignment inputs for benchmark runs., CloudAlignmentService, Refine a trajectory-Sim(3)-aligned cloud against a reference cloud with ICP. (+15 more)
-
-### Community 55 - "Community 55"
-Cohesion: 0.10
-Nodes (34): build_pipeline_viewer_link_model(), AST, _resolve_error_series_path(), TrajectoryEvaluationQueryService, DiscoveredRun, ndarray, Path, PathConfig (+26 more)
-
-### Community 56 - "Community 56"
-Cohesion: 0.15
-Nodes (11): _require_keyframe_index(), _resolve_raster_size(), _resolve_visualization_array(), _set_item_frame_time(), FrameTransform, ndarray, Path, VisualizationItem (+3 more)
-
-### Community 57 - "Community 57"
-Cohesion: 0.14
-Nodes (42): DatasetRunCoverage, build_coverage_matrix(), build_heatmap_data(), build_leaderboard(), build_per_sequence_table(), LeaderboardRow, MetricFilter, _per_sequence_rows_to_frame() (+34 more)
-
-### Community 58 - "Community 58"
-Cohesion: 0.14
-Nodes (32): Console, DatasetDownloadResult, LocalSceneStatus, Path, TumRgbdCatalog, TumRgbdSceneMetadata, Path, TumRgbdCatalog (+24 more)
-
-### Community 59 - "Community 59"
-Cohesion: 0.10
-Nodes (36): Float, build_live_trajectory_figure(), Build a compact 3D ego-trajectory figure for live Record3D poses., _add_3d_end_markers(), _add_3d_trajectory_trace(), _add_xy_end_markers(), _add_xy_trajectory_trace(), _apply_standard_trajectory_3d_layout() (+28 more)
-
-### Community 60 - "Community 60"
-Cohesion: 0.14
-Nodes (35): build_run_config(), test_request_support_error_uses_stage_availability_reason(), MonkeyPatch, Path, _repo_root(), test_run_artifact_paths_include_ground_alignment_json(), test_run_config_build_rejects_ground_alignment_without_point_cloud_outputs(), test_run_ground_alignment_stage_writes_applied_metadata_when_export_enabled() (+27 more)
-
-### Community 61 - "Community 61"
-Cohesion: 0.15
-Nodes (36): Any, DatasetSequenceSource, FrameSelectionConfig, NormalizedDatasetProfile, NormalizedDatasetStore, ReferenceCloudConfig, ReplayMode, SequenceKey (+28 more)
-
-### Community 62 - "Community 62"
-Cohesion: 0.12
-Nodes (9): _build_artifacts(), _ensure_uint8_rgb_from_uimg(), _estimate_camera_intrinsics_from_frame(), Mast3rSlamSession, Any, ndarray, Observation, SlamArtifacts (+1 more)
-
-### Community 63 - "Community 63"
-Cohesion: 0.17
-Nodes (15): DatasetFetchHelper, Thin cache-aware fetch helper for dataset-owned assets., DatasetServiceBase, open_dataset_sequence_stream(), Any, FrameSelectionConfig, NormalizedDatasetProfile, NormalizedDatasetStore (+7 more)
-
-### Community 64 - "Community 64"
-Cohesion: 0.09
-Nodes (23): _require_vista_prerequisites(), test_vista_full_streaming_pipeline_end_to_end(), _wait_for_terminal_snapshot(), ObservationStream, build_advio_demo_run_config(), build_runtime_source_from_run_config(), _CappedPacketStream, _CappedStreamingSource (+15 more)
-
-### Community 65 - "Community 65"
-Cohesion: 0.11
-Nodes (29): CloudAlignmentStageInput, Point-cloud alignment stage runtime input contracts., Inputs required to refine a Sim(3)-aligned SLAM cloud against a reference cloud., _write_aligned_point_cloud(), Path, _planar_yawed_pair(), ndarray, Path (+21 more)
-
-### Community 66 - "Community 66"
-Cohesion: 0.16
-Nodes (36): ndarray, Path, Recording, _ancestor_entity_paths(), _component_columns(), _keyed_point_cloud_snapshots(), _latest_live_model_snapshot(), _latest_transform_matrix_before_or_at_log_tick() (+28 more)
-
-### Community 67 - "Community 67"
-Cohesion: 0.16
-Nodes (30): arcore_ready(), arkit_ready(), _complete_scene_ready(), list_local_sequence_ids(), load_advio_catalog(), offline_ready(), _RelativePathSpec, replay_ready() (+22 more)
-
-### Community 68 - "Community 68"
-Cohesion: 0.12
-Nodes (29): path(), main(), MonkeyPatch, Path, test_advio_download_command_builds_full_scene_request(), test_advio_summary_reports_normalized_entries_and_native_cache(), test_dataset_normalize_accepts_benchmark_build_config_toml(), test_dataset_normalize_advio_defaults_to_15_fps() (+21 more)
-
-### Community 69 - "Community 69"
-Cohesion: 0.13
-Nodes (34): _add_point_cloud_trace(), _add_trajectory_trace(), _apply_comparison_layout(), _build_figure(), build_reference_reconstruction_figure(), build_slam_reference_comparison_figure(), _combined_bounds(), _decimate_mesh() (+26 more)
-
-### Community 70 - "Community 70"
-Cohesion: 0.16
-Nodes (17): _FakeBackend, _FakeBackend, _FakeBackendConfig, _FakeStreamingRuntime, _LazyRgbBackendConfig, _plan(), Observation, Path (+9 more)
-
-### Community 71 - "Community 71"
-Cohesion: 0.14
-Nodes (22): _advio_pose_source_from_reference(), _append_aligned_reference_trajectory(), _append_optional_reference_trajectory(), _ensure_advio_tum(), _load_sanitized_optional_advio_trajectory(), _write_advio_trajectory_metadata(), paths(), ReferenceCloudCoordinateStatus (+14 more)
-
-### Community 72 - "Community 72"
-Cohesion: 0.14
-Nodes (27): DatasetRunCoverage, EvaluationSelection, _load_run_sequence_manifest(), _matches_dataset(), _matches_selection(), RunTrajectoryEvaluation, _sim3_alignment_skip_count(), manifest_path() (+19 more)
-
-### Community 73 - "Community 73"
-Cohesion: 0.21
-Nodes (29): _attempt_rows(), _candidate_label(), _inventory_rows(), _metadata_json(), _path_rows(), Streamlit page for inspecting persisted pipeline run artifacts., _raw_preview_language(), _raw_preview_text() (+21 more)
-
-### Community 74 - "Community 74"
-Cohesion: 0.22
-Nodes (32): _ancestor_entity_paths(), _build_repo_owned_recording(), _build_vista_style_reference_recording(), _component_columns(), _latest_transform_matrix_before_or_at_log_tick(), _normalize_entity_path(), _points_array(), ndarray (+24 more)
-
-### Community 75 - "Community 75"
-Cohesion: 0.09
-Nodes (28): build_advio_comparison_trajectories(), Build ADVIO explorer overlays with explicit comparison semantics., build_evo_ape_colormap_figure(), build_stage_telemetry_figure(), ErrorPlotSeries, pointmap_preview_image(), Build a compact rolling telemetry line chart for one stage metric., Trajectory payload needed by pipeline plot builders. (+20 more)
-
-### Community 76 - "Community 76"
-Cohesion: 0.15
-Nodes (22): _ensure_directory_parent(), Return the cache directory used for downloaded scene archives., Return one catalog scene by id., Return local availability status for every catalog scene., Download selected ADVIO scenes and extract complete scene payloads., AdvioCatalog, AdvioDownloadRequest, AdvioLocalSceneStatus (+14 more)
-
-### Community 77 - "Community 77"
-Cohesion: 0.13
-Nodes (24): AdvioCalibration, _expect_float_list(), _expect_mapping(), _expect_matrix(), _extract_camera_mapping(), load_advio_calibration(), load_advio_frame_timestamps_ns(), load_advio_trajectory() (+16 more)
-
-### Community 78 - "Community 78"
-Cohesion: 0.09
-Nodes (21): from_toml(), Declarative base config contracts for pipeline stage planning.  This module owns, to_jsonable(), from_toml(), Any, test_run_config_warns_and_ignores_unknown_fields(), test_stage_config_sections_round_trip_without_runtime_factory(), test_target_generic_stages_toml_parses_into_stage_bundle() (+13 more)
-
-### Community 79 - "Community 79"
-Cohesion: 0.13
-Nodes (24): CameraIntrinsics, float32, float64, int64, NDArray, Path, PoseTrajectory3D, ensure_ground_truth_tum() (+16 more)
-
-### Community 80 - "Community 80"
-Cohesion: 0.13
-Nodes (28): CommandRunner, CompletedProcess, Namespace, Path, Path, Tests for offline follow-enabled Rerun artifact generation., test_create_follow_trajectory_artifact_accepts_explicit_recording_id(), test_create_follow_trajectory_artifact_refuses_existing_output() (+20 more)
-
-### Community 81 - "Community 81"
-Cohesion: 0.14
-Nodes (18): _resolve_dir(), Path, test_path_config_builds_method_repo_and_checkpoint_paths(), test_path_config_builds_normalized_datastore_paths(), test_path_config_builds_run_log_paths_without_creating_by_default(), test_path_config_create_flags_delegate_to_shared_directory_resolver(), Alias for input_frames_dir used in early scaffold versions., Resolve a directory and optionally create it. (+10 more)
-
-### Community 82 - "Community 82"
-Cohesion: 0.09
-Nodes (24): RuntimeConfig, RuntimeConfig, DataOnlyConfig, InvalidTargetConfig, NestedPayload, PlainPayload, Path, Tests for the shared Pydantic base-model split. (+16 more)
-
-### Community 83 - "Community 83"
-Cohesion: 0.08
-Nodes (23): Current Discrepancies, Current Scope, Frame Conventions, Postprocessing Steps, Preprocessing Steps, Rerun Logging, ViSTA-SLAM Wrapper, Resolved Rerun Pointmap Regression (+15 more)
-
-### Community 84 - "Community 84"
-Cohesion: 0.18
-Nodes (26): AdvioSceneMetadata, Describe one ADVIO scene committed into the repository catalog., Return the compact scene label shown in the app and CLI., _advio_camera_frame(), advio_pose_frames(), _advio_provider_world_frame(), load_advio_served_trajectory(), _poses_for_frame_timestamps() (+18 more)
-
-### Community 85 - "Community 85"
-Cohesion: 0.20
-Nodes (27): parse_optional_float(), parse_optional_int(), _advio_record_sequence_id(), _backend_spec_for_method(), _coerce_lingbot_image_size_to_patch_grid(), _optional_path_input(), _path_input(), _render_advio_source_settings() (+19 more)
-
-### Community 86 - "Community 86"
-Cohesion: 0.07
-Nodes (28): Add, Canonical Stage Result, Collapse, Coordinator Responsibility Boundary, Current To Target Responsibility Map, DTO Simplification Targets, Durable Run Events And Live Updates, Future Recommended Implementation Order (+20 more)
-
-### Community 87 - "Community 87"
-Cohesion: 0.14
-Nodes (26): from_json(), ArxivSourceSpec, download_file(), fetch_pdf(), fetch_tex_source(), load_manifest(), main(), normalize_member_path() (+18 more)
-
-### Community 88 - "Community 88"
-Cohesion: 0.21
-Nodes (25): _decode_primary_metric(), _encode_primary_metric(), _load_error_series_by_label(), _load_error_values(), _metric_label(), _multi_select(), Streamlit page for persisted trajectory benchmark aggregation., Render the dataset-wide benchmark summary view. (+17 more)
-
-### Community 89 - "Community 89"
-Cohesion: 0.07
-Nodes (26): 1. Numeric Prototype And Evidence, 2. Dataset-Local Fixedpoint Registration API, 3. Normalized Datastore Publication, 4. Profile And Query Contract, 5. Evaluation Contract, 6. Documentation And Operator Surfaces, ADVIO Fixedpoint Preprocessing Ralplan Draft, Alternatives Rejected (+18 more)
-
-### Community 90 - "Community 90"
-Cohesion: 0.07
-Nodes (26): 1. Numeric Prototype And Evidence, 2. Dataset-Local Fixedpoint Registration API, 3. Normalized Datastore Publication, 4. Profile And Query Contract, 5. Evaluation Contract, 6. Documentation And Operator Surfaces, ADVIO Fixedpoint Preprocessing Ralplan Draft, Alternatives Rejected (+18 more)
-
-### Community 91 - "Community 91"
-Cohesion: 0.14
-Nodes (21): from_evo_statistics(), MetricStats, Capture scalar summary statistics for one evaluated error series., Build stats from ``evo``'s ``metric.get_all_statistics()`` payload., Evaluation services: trajectory APE/RPE computation and persistence., AlignmentUnsupportedError, compute_trajectory_ape_preview(), compute_trajectory_rpe_preview() (+13 more)
-
-### Community 92 - "Community 92"
-Cohesion: 0.08
-Nodes (20): Boundary, Current Scope, Eval, Stage Integration, Concrete Backends, I/O And Protocols, Methods, Stage Integration (+12 more)
-
-### Community 93 - "Community 93"
-Cohesion: 0.14
-Nodes (18): Return the artifact-root identifier used in persisted evaluation rows., stable_run_id(), _entity_token(), _infer_coordinate_status(), _infer_target_frame(), _method_world_frame(), _reference_target_frame_for_evaluation(), _write_error_series() (+10 more)
-
-### Community 94 - "Community 94"
-Cohesion: 0.14
-Nodes (7): PayloadResolver, _resolve_update_payloads(), ActorHandle, ndarray, StageRuntimeUpdate, _BaseRerunEventSink, Repo-owned Rerun observer sinks and Ray sidecar actors.
-
-### Community 95 - "Community 95"
-Cohesion: 0.30
-Nodes (21): AdvioPageData, AdvioPreviewFormData, build_advio_page_data(), Controller helpers for the ADVIO Streamlit page., Persist the current ADVIO download-form state., Keep persisted preview state aligned with the runtime snapshot., Apply one preview-form action and return an error message when it fails., _scene_rows() (+13 more)
-
-### Community 96 - "Community 96"
-Cohesion: 0.09
-Nodes (19): ADVIO Dataset Guide, Current Surface, File Conventions, Ground-Truth Fixpoints, Ground Truth Versus Device Poses, References, Repo Interpretation For Visualization, Backend Config Shape (+11 more)
-
-### Community 97 - "Community 97"
-Cohesion: 0.21
-Nodes (20): config_warnings(), validate_stage_keys(), _collect_unknown_field_warnings(), _compile_run_plan(), _discriminator_matches(), _expected_source_fps(), _fps_for_duration(), _fps_for_timestamps_ns() (+12 more)
-
-### Community 98 - "Community 98"
-Cohesion: 0.23
-Nodes (18): Open3dTsdfBackend, Open3dTsdfBackendConfig, Canonical reconstruction backend configs.  These are package-owned method-select, Provide the package-local runtime contract shared by reconstruction configs., Return the user-facing reconstruction label., Configure the minimal Open3D TSDF reconstruction backend.      The repo targets, Return the concrete reconstruction backend type., Instantiate the Open3D TSDF backend while ignoring unrelated kwargs. (+10 more)
-
-### Community 99 - "Community 99"
-Cohesion: 0.18
-Nodes (23): available_metric_keys(), _build_rmse_aggregate_rows(), build_wide_metric_rows(), _clean_records(), filter_metric_rows(), metric_frame_to_rows(), _metric_frame_with_estimate_parts(), _metric_frame_with_pose_names() (+15 more)
-
-### Community 100 - "Community 100"
-Cohesion: 0.18
-Nodes (22): _install_fake_pose_decoder(), MonkeyPatch, Path, test_lingbot_app_action_coerces_sparse_output(), test_lingbot_app_editor_coerces_invalid_grid_and_depth(), test_lingbot_app_editor_preserves_gpu_fit_backend_fields(), test_lingbot_artifact_builder_accepts_batched_single_frame_images(), test_lingbot_artifact_builder_rejects_missing_confidence_when_filtering() (+14 more)
-
-### Community 101 - "Community 101"
-Cohesion: 0.13
-Nodes (23): Path, test_artifact_visualizations_include_sim3_and_icp_cloud_alignment_outputs(), test_artifact_visualizations_use_reconstruction_cloud_not_source_reference(), test_attach_recording_sinks_configures_grpc_and_file_together(), test_attach_recording_sinks_replaces_stale_rrd_file(), test_log_clear_logs_recursive_clear(), test_log_ground_plane_patch_logs_fill_and_outline(), test_log_line_strip3d_logs_one_strip() (+15 more)
-
-### Community 102 - "Community 102"
-Cohesion: 0.09
-Nodes (21): Boundaries To Other Packages, Design Goals, Directory roles, File-by-file, Mental Model, Metrics Pattern, Package Responsibilities, Page Pattern (+13 more)
-
-### Community 103 - "Community 103"
-Cohesion: 0.09
-Nodes (23): App And CLI Contract, Artifact Serialization, Backend And Source Muxing, Config Hierarchy, Decision Register, IO Versus Datasets, Offline And Streaming SLAM Lifecycle, Placeholder Stages (+15 more)
-
-### Community 104 - "Community 104"
-Cohesion: 0.13
-Nodes (17): Render the shared intrinsics matrix in the compact LaTeX form used by UI surface, Build the shared transform DTO from a 4x4 homogeneous matrix., Build the shared transform DTO from XYZW quaternion and XYZ translation arrays., Return the normalized unit quaternion in XYZW order., Return the translation component in XYZ order., Return the transform as a 4x4 homogeneous matrix., _build_viewer_transform(), float64 (+9 more)
-
-### Community 105 - "Community 105"
-Cohesion: 0.13
-Nodes (22): collect_dirty_diff_stats(), diff_bucket(), GitFileChange, module_bucket(), parse_git_name_status(), Path, One Git worktree file change relative to HEAD., Return the path that should own this change in reports. (+14 more)
-
-### Community 106 - "Community 106"
-Cohesion: 0.23
-Nodes (21): ArtifactRow, _apply_snapshot_fallbacks(), _candidate_from_root(), _canonical_path_rows(), _derive_slam_artifacts(), discover_run_artifact_roots(), _file_inventory(), _format_size() (+13 more)
-
-### Community 107 - "Community 107"
-Cohesion: 0.10
-Nodes (5): finish_streaming(), ObservationStream, start_streaming(), Package-local execution seams for reconstruction backends.  Reconstruction is th, Blockingly deliver shared :class:`Observation` values.
-
-### Community 108 - "Community 108"
-Cohesion: 0.09
-Nodes (22): Base Setup, CLI Commands, Codex History Utilities, Dataset Downloads and VSLAM Datastore, Dataset × Method Sweep, Install Mamba on Unix, LingBot/CUDA Setup, LingBot sweeps (+14 more)
-
-### Community 109 - "Community 109"
-Cohesion: 0.16
-Nodes (16): FrameSelectionConfig, ndarray, ObservationSequenceRef, Path, PreparedBenchmarkInputs, ReferenceCloudRef, SequenceManifest, TumRgbdCatalog (+8 more)
-
-### Community 110 - "Community 110"
-Cohesion: 0.13
-Nodes (16): preprocess_rgb_for_normalized_store(), Shared normalized-store RGB raster preprocessing., Downscale one RGB raster into the canonical normalized-store cache size., Resize a depth raster to the preprocessed RGB shape without changing depth units, Scale camera intrinsics into the preprocessed normalized-store raster., Write a normalized-store RGB PNG with high compression., resize_depth_to_rgb_preprocessing(), RgbPreprocessingResult (+8 more)
-
-### Community 111 - "Community 111"
-Cohesion: 0.19
-Nodes (17): Evaluation entry surface for persisted benchmark artifacts.  The :mod:`prml_vsla, _infer_coord_status_for_dataset(), _infer_target_frame_for_dataset(), _load_benchmark_inputs(), _load_run_sequence_manifest(), _reference_trajectory_filename(), _remap_artifact_path(), _remap_reference() (+9 more)
-
-### Community 112 - "Community 112"
-Cohesion: 0.10
-Nodes (20): Available Agent Types For Follow-Up, Consensus Amendments, Decision, Decision Drivers, Option A: Dataset-aware benchmark trajectory normalization policy, Option B: Introduce a shared target-frame transform contract for all datasets, Option C: Keep first-pose rebasing but recompute ADVIO aligned variants afterward, Principles (+12 more)
-
-### Community 113 - "Community 113"
-Cohesion: 0.22
-Nodes (19): load_advio_fixpoints(), advio_basis_metadata(), advio_basis_provenance(), AdvioBasisMetadata, AdvioRawCoordinateBasis, basis_for_pose_source(), _flatten_matrix(), _pose_matrix() (+11 more)
-
-### Community 114 - "Community 114"
-Cohesion: 0.10
-Nodes (19): Work Packages, WP 0: Project Organisation - Issues, WP 10: (Optional) Ground Truth Creation -> Grab if you're bored!, WP 11: (Optional) ARCore - Grab if you're bored!, WP 1.1: ADVIO Dataset, WP 1.2: Mobile Client (Record 3D), WP 1.3: Acquisition of own Dataset, WP 1: Video Source (+11 more)
-
-### Community 115 - "Community 115"
-Cohesion: 0.10
-Nodes (18): Current Limitations, Current Transport Support, Record3D Sources, Repo-Owned Entry Points, Exposed Python Types, Exposed `Record3DStream` Methods And Callbacks, Official Demo Client Methods, Official Signaling And Metadata Endpoints (+10 more)
-
-### Community 116 - "Community 116"
-Cohesion: 0.19
-Nodes (18): FrameTransform, ObservationStream, Path, PoseTrajectory3D, ReplayMode, TumRgbdFrameAssociation, TumRgbdPoseSource, ObservationStream (+10 more)
-
-### Community 117 - "Community 117"
-Cohesion: 0.16
-Nodes (16): ICP point-cloud alignment service., Materialize offline point-cloud alignment artifacts before cloud metrics., _apply_sim3_cloud_use_policy(), ndarray, PoseTrajectory3D, TrajectoryAlignmentArtifact, align_estimate_sim3(), is_gravity_aligned_target() (+8 more)
-
-### Community 118 - "Community 118"
-Cohesion: 0.12
-Nodes (14): code_lines_for_source(), count_code_line_delta(), count_source_code_delta(), DiffStats, extract_docstring_lines(), Count this delta as affecting one file when it has code-line changes., Merge two code-line delta objects., Return line numbers occupied by module, class, and function docstrings. (+6 more)
-
-### Community 119 - "Community 119"
-Cohesion: 0.11
-Nodes (18): Compact Ownership Note, Decision Drivers, Execution Handoff Recommendation, Option A: Non-overlap cleanup now, Option B: WIP-first serialization, Option C: Forced integrated cleanup, Phase 1: Behavior lock and fallback inventory, Phase 2: Split the Streamlit dataset page into renderer/controller/query/preview owners (+10 more)
-
-### Community 120 - "Community 120"
-Cohesion: 0.16
-Nodes (14): Path, Tests for centralized repository path handling., test_path_config_builds_dataset_paths(), test_path_config_is_immutable_after_construction(), test_path_config_keeps_explicit_pipeline_config_paths_root_relative(), test_path_config_rejects_non_toml_config_paths(), test_path_config_resolves_root_relative_defaults(), test_path_config_routes_bare_pipeline_configs_into_repo_config_dir() (+6 more)
-
-### Community 121 - "Community 121"
-Cohesion: 0.29
-Nodes (17): advio_common_start_local_trajectories(), advio_frame_transform_from_pose(), AdvioFixedpointRegistration, AdvioFixpointSet, apply_advio_fixedpoint_registration(), estimate_advio_fixedpoint_registration(), _estimate_rigid_no_scale(), _gravity_tilt_deg() (+9 more)
-
-### Community 122 - "Community 122"
-Cohesion: 0.18
-Nodes (8): Artifact And Raster Ownership, Canonical Ownership, Interfaces And Contracts, Pipeline Center, Pose And Transform Ownership, Wrapper Implications, Questions Q&A 26.03.2026, Team
-
-### Community 123 - "Community 123"
-Cohesion: 0.18
-Nodes (6): StageResult, StageRuntimeStatus, TrajectoryAlignmentStageInput, Bounded runtime adapter for the Sim(3) trajectory alignment stage., _resolve_reference(), TrajectoryAlignmentRuntime
-
-### Community 124 - "Community 124"
-Cohesion: 0.11
-Nodes (17): Decision Drivers, Handoff Recommendation, Implementation Plan, Option A: Non-overlap cleanup now (chosen), Option B: WIP-first serialization, Option C: Forced integrated takeover, Options, Phase 0: Hard ownership gate (+9 more)
-
-### Community 125 - "Community 125"
-Cohesion: 0.11
-Nodes (17): ADR, Decision, Decision Drivers, Execution Handoff Recommendation, Option A: WIP-first serialization (recommended), Option B: Non-overlap cleanup now, Option C: Forced integrated refactor now, Phase 0: Execution preflight and ownership checkpoint (+9 more)
-
-### Community 126 - "Community 126"
-Cohesion: 0.19
-Nodes (12): DenseCloudEvaluationArtifact, DenseCloudEvaluationSelection, DenseCloudEvaluationArtifact, DenseCloudEvaluationSelection, Shared evaluation contracts not owned by trajectory metric manifests.  Trajector, Persist one dense-cloud evaluation result for later review., Describe the resolved dense-cloud inputs for one evaluation action., DenseCloudEvaluator (+4 more)
-
-### Community 127 - "Community 127"
-Cohesion: 0.24
-Nodes (11): _set_frame_time(), _FakeRecordingStream, _keyframe_update(), _payload_ref(), MonkeyPatch, StageRuntimeUpdate, TransientPayloadRef, test_policy_does_not_log_diagnostic_preview_by_default() (+3 more)
-
-### Community 128 - "Community 128"
-Cohesion: 0.32
-Nodes (16): _artifact_ref(), _camera_positions(), _floor_and_wall_scene(), _identity_pose(), FrameTransform, ndarray, Path, SimpleNamespace (+8 more)
-
-### Community 129 - "Community 129"
-Cohesion: 0.23
-Nodes (10): _keyframe_update(), _payload_ref(), _pose_update(), StageRuntimeUpdate, TransientPayloadRef, _source_update(), _StrictFakeRecordingStream, test_policy_logs_live_model_and_keyed_history_on_frame_timeline() (+2 more)
-
-### Community 130 - "Community 130"
-Cohesion: 0.12
-Nodes (16): 1. Launch and planning are still mixed, 2. Stage-key vocabulary is target-only, 3. Migration DTOs are removed from the active launch path, 4. Runtime-manager wording matches current execution, 5. Planned stage coverage is intentionally uneven, Current Simplification Targets, Durable versus live state, Executive Summary (+8 more)
-
-### Community 131 - "Community 131"
-Cohesion: 0.12
-Nodes (16): Assumptions And Deferred Decisions, Change Inventory For Later Implementation, Failure Modes And Availability, Input Source Normalization, Open3D TSDF Backend Contract, Ownership And Normalization Boundary, Purpose And Relationship To Pipeline Refactor, Reconstruction Stage Target Architecture (+8 more)
-
-### Community 132 - "Community 132"
-Cohesion: 0.12
-Nodes (3): validate_patch_grid(), build_slam_backend_config(), test_lingbot_backend_config_is_discriminated()
-
-### Community 133 - "Community 133"
-Cohesion: 0.30
-Nodes (13): CameraIntrinsicsSeries, ndarray, Path, _build_estimated_intrinsics_series(), _build_unfiltered_cloud_export(), _load_native_point_cloud(), _load_unfiltered_cloud_colors(), Native artifact normalization helpers for ViSTA-SLAM.  This module handles end-o (+5 more)
-
-### Community 134 - "Community 134"
-Cohesion: 0.22
-Nodes (14): ArtifactRef, ObservationSequenceRef, ReferenceCloudRef, ReferenceSource, ReferenceTrajectoryRef, RunArtifactPaths, SourceStageOutput, _entity_token() (+6 more)
-
-### Community 135 - "Community 135"
-Cohesion: 0.13
-Nodes (15): App / CLI Remote Coordinator Attach, Distributed Ray / Same-LAN Execution, DTO Ownership Cleanup, First Slice Boundary, Locked Decisions From Review Triage, Naming Migration Map, Pipeline Refactor Review A01 Actions, Primary Runtime Refactor Actions (+7 more)
-
-### Community 136 - "Community 136"
-Cohesion: 0.20
-Nodes (11): ObservationSequenceIndex, _load_depth(), _load_rgb(), Source-owned file-backed observation sequence loading.  The source reads durable, Yield observations by resolving payload paths from the sequence ref.          RG, _resolve_payload(), _validate_index_matches_ref(), ndarray (+3 more)
-
-### Community 137 - "Community 137"
-Cohesion: 0.13
-Nodes (14): ADR, Architect Iteration 1 Revision, Available Agent Roster, Decision, Decision Drivers, Principles, Ralph Execution Handoff, RALPLAN-DR Summary (+6 more)
-
-### Community 138 - "Community 138"
-Cohesion: 0.14
-Nodes (13): Active ADVIO alignment WIP boundary, Current branch and worktree evidence, Desired outcome, HIGH: profile compatibility fallback in normalized store, HIGH: source trajectory fallback in benchmark inputs, Likely codebase touchpoints, MEDIUM/HIGH boundary sink: normalized_store.py, MEDIUM/LOW mixed Streamlit page (+5 more)
-
-### Community 139 - "Community 139"
-Cohesion: 0.25
-Nodes (10): Typed contracts for reconstruction adapters.  This module owns the method ids an, Describe normalized durable outputs from one reconstruction run.      The minima, ReconstructionArtifacts, Public reconstruction entry surface for reference-scene builders.  The :mod:`prm, OfflineReconstructionBackend, Consume typed RGB-D observations and write normalized artifacts.      Implementa, Reconstruct one scene from an offline sequence of RGB-D observations.          A, Observation (+2 more)
-
-### Community 140 - "Community 140"
-Cohesion: 0.31
-Nodes (12): Render camera intrinsics using the shared LaTeX presentation., render_camera_intrinsics(), Rendering helpers for the Pipeline page run snapshot., Render the current pipeline run snapshot., _render_pipeline_artifacts_tab(), _render_pipeline_notice(), _render_pipeline_plan_tab(), render_pipeline_snapshot() (+4 more)
-
-### Community 141 - "Community 141"
-Cohesion: 0.26
-Nodes (10): ape_translation_rmse(), benchmark_paths(), nearest(), norm(), print_sweep_summary(), print_trajectory_offsets(), read_metrics(), read_tum() (+2 more)
-
-### Community 143 - "Community 143"
-Cohesion: 0.15
-Nodes (13): Camera-Complete 3D Entities Need A Pinhole, Current Discrepancy Matrix, Current Repo-Specific Findings, Keep Upstream ViSTA World Semantics Unless A Shared Alignment Layer Exists, Live Pointmaps And Exported Dense Clouds Are Different Products, `preview_rgb` Is Diagnostic Preview Only, Recommended Integration Pattern, Still Useful Follow-Ups (+5 more)
-
-### Community 144 - "Community 144"
-Cohesion: 0.26
-Nodes (10): Open3dTsdfBackendConfig, Persist side metadata for one normalized reconstruction output.      PLY geometr, ReconstructionMetadata, _import_open3d(), Integrate one offline RGB-D sequence into a fused world-space cloud.          Th, _rgbd_image_and_intrinsic(), Observation, Path (+2 more)
-
-### Community 145 - "Community 145"
-Cohesion: 0.32
-Nodes (7): _BlockingPacketStream, _packet(), Observation, Record3DDevice, test_advio_preview_runtime_controller_processes_one_packet(), test_record3d_runtime_controller_formats_usb_source_label(), _wait_for_snapshot()
-
-### Community 146 - "Community 146"
-Cohesion: 0.18
-Nodes (11): Current Affected Tree, Explicit Non-Targets, Implementation Hurdles, Leaf-Symbol Rule, Migration Aliases, Ownership Rules, Pipeline Refactor Target Directory Tree, Purpose (+3 more)
-
-### Community 147 - "Community 147"
-Cohesion: 0.18
-Nodes (11): Bounded Stage Runtimes, Core Stage And Protocol Seams, Current Stage Views, Durable Events And Snapshot Projection, How To Read This Note, Linear Stage Contract Flow, Ownership Map, Pipeline Stage Protocols And DTOs (+3 more)
-
-### Community 148 - "Community 148"
-Cohesion: 0.18
-Nodes (10): ADVIO Fixedpoint Preprocessing Context, Constraints, Desired Outcome, Likely Code Touchpoints, Open Todos And Resolved Planning Decisions, Repo-Local Evidence, Research Sources, Task Statement (+2 more)
-
-### Community 149 - "Community 149"
-Cohesion: 0.18
-Nodes (11): Boundaries, Current Implementation, Datasets, Main Entry Points, Normalized Store Batch Builds, Offline Boundary, Output DTOs, Source-Config Boundary (+3 more)
-
-### Community 150 - "Community 150"
-Cohesion: 0.18
-Nodes (11): Core Interface Shape, Current State, DTO Design For Easy Rerun Integration, Open3D TSDF Scope, Package Boundaries, Package Surface, Primary External References, Reconstruction Guide (+3 more)
-
-### Community 151 - "Community 151"
-Cohesion: 0.18
-Nodes (10): ADVIO trajectory preservation, Claims To Prove, Evidence To Report, Final Gates, Non-ADVIO first-pose normalization, Public source path smoke, Representative Run Verification, Stale-entry rejection (+2 more)
-
-### Community 152 - "Community 152"
-Cohesion: 0.33
-Nodes (7): _load_agents_db_module(), Any, Path, test_resolve_issue_moves_record_to_resolved_collection(), test_resolve_refactor_moves_record_to_resolved_collection(), test_resolve_todo_moves_record_to_resolved_collection(), _write_toml()
-
-### Community 153 - "Community 153"
-Cohesion: 0.18
-Nodes (11): Association Semantics, Calibration And Transform Semantics, Current Scope, Depth And Point-Cloud Semantics, File Conventions, Ground-Truth Frame Semantics, Official Capture Characteristics, Repo Interpretation For Pipeline Inputs (+3 more)
-
-### Community 154 - "Community 154"
-Cohesion: 0.27
-Nodes (9): interpolate_trajectory_poses(), _nearest_timestamp_indices(), ADVIO trajectory interpolation helpers., Interpolate positions and nearest-neighbor rotations at requested timestamps., float64, FrameTransform, int64, NDArray (+1 more)
-
-### Community 155 - "Community 155"
-Cohesion: 0.20
-Nodes (6): Expand this dataset group into concrete per-sequence source configs., Expand this dataset group into concrete per-sequence source configs., Expand this dataset group into concrete per-sequence source configs., AdvioSourceConfig, Record3DDatasetSourceConfig, TumRgbdSourceConfig
-
-### Community 156 - "Community 156"
-Cohesion: 0.20
-Nodes (9): ADVIO Fixedpoint Preprocessing Consensus Handoff, Architect Review, Consensus Gate, Critic Review, Decision, Execution Handoff Guidance, Planning Artifacts, Required Contract (+1 more)
-
-### Community 157 - "Community 157"
-Cohesion: 0.20
-Nodes (8): Challenge 5: Uncalibrated Monocular VSLAM, Challenge Context, Deliverables, Documentation Map, Evaluation, Quick Entry, Starting Points, Status
-
-### Community 158 - "Community 158"
-Cohesion: 0.20
-Nodes (6): ObservationStream, Source replay behavior seams., Disconnect or release the source and any owned runtime resources., Wait for and return the next normalized source observation., Any, Observation
-
-### Community 159 - "Community 159"
-Cohesion: 0.33
-Nodes (3): Path, attach_recording_sinks(), _RerunSinkOptions
-
-### Community 160 - "Community 160"
-Cohesion: 0.38
-Nodes (9): _ensure_setup_file(), _has_nvcc(), main(), _prepend_existing_paths(), _prepend_path(), Path, Build the optional CUDA RoPE2D extension for the bundled ViSTA-SLAM checkout., Build ViSTA-SLAM's optional cuRoPE2D extension in-place. (+1 more)
-
-### Community 161 - "Community 161"
-Cohesion: 0.24
-Nodes (3): SampledObservationStream, Any, Observation
-
-### Community 162 - "Community 162"
-Cohesion: 0.20
-Nodes (10): APIs We Actively Use, Canonical Entity Layout, Current And Future Modalities, Current Implementation, Frame Conventions, Repo Conventions, Rerun Conventions That Matter Here, Rerun Mental Model (+2 more)
-
-### Community 163 - "Community 163"
-Cohesion: 0.22
-Nodes (9): Additional Explicitly Out-Of-Scope Audited Symbols, Additional Kept Shared, Domain, And Protocol Symbols, Additional Pipeline And Runtime Migration Contacts, Config Migration And Compatibility, Dataset, IO, App, Plotting, And Inspection DTOs Out Of Scope, Eval-Owned DTOs And Future Specialization, Kept Canonical Domain And Shared DTOs, Pipeline DTO Migration Ledger (+1 more)
-
-### Community 164 - "Community 164"
-Cohesion: 0.22
-Nodes (8): Artifact Selection, Cleanup Timing, Migration Note For `vista-full.toml`, Pipeline Stage Artifact Cleanup Policy, Provenance, Target Contract, Terminal Status Policy, Tests To Add With Implementation
-
-### Community 165 - "Community 165"
-Cohesion: 0.47
-Nodes (7): _copy_local_file(), _hash_matches(), _needs_refresh(), _parse_known_hash(), Fetch one asset into a stable local path and report whether it was refreshed., _resolve_local_source(), Path
-
-### Community 166 - "Community 166"
-Cohesion: 0.33
-Nodes (7): _refresh_pipeline_telemetry_state(), _render_pipeline_telemetry_controls(), _render_pipeline_viewer_link(), _render_telemetry_stage_selector(), AppContext, RunSnapshot, StageKey
-
-### Community 167 - "Community 167"
-Cohesion: 0.36
-Nodes (3): Public TUM RGB-D dataset surface for app, tests, and pipeline integration.  This, paths(), TUM RGB-D-specific metadata and config models.  This module owns the committed s
-
-### Community 168 - "Community 168"
-Cohesion: 0.22
-Nodes (8): Approved Implementation Scope While WIP-active, Architect Gate Additions, Architect Verdict, Consensus Direction, Critic Gate Additions, Deferred / Blocked While WIP-active, Resolve review findings reviewed plan, Verification Requirements
-
-### Community 169 - "Community 169"
-Cohesion: 0.22
-Nodes (9): Current State, Explicit Non-Goals, Non-Negotiable Requirements, Pipeline Stage Refactor Requirements, PRML VSLAM Package Requirements, Purpose, Responsibilities, Target State (+1 more)
-
-### Community 170 - "Community 170"
-Cohesion: 0.22
-Nodes (7): ArtifactRef, Observation, SourceStageOutput, TransientPayloadRef, VisualizationItem, Return source reference trajectory/cloud visualization items., Return live source observation visualization items.
-
-### Community 171 - "Community 171"
-Cohesion: 0.31
-Nodes (7): _pose(), FrameTransform, TransientPayloadRef, Tests for the SLAM stage visualization adapter., _ref(), test_keyframe_update_produces_model_and_keyframe_visualization_items(), test_pose_only_update_produces_pose_and_trajectory_items()
-
-### Community 172 - "Community 172"
-Cohesion: 0.22
-Nodes (8): Current State, Explicit Non-Goals, Non-Negotiable Requirements, Purpose, Responsibilities, Target State, Utils Requirements, Validation
-
-### Community 173 - "Community 173"
-Cohesion: 0.25
-Nodes (8): Factory/Muxing Changes, Future Implementation Inventory, Ownership Cleanup, Planning Changes, Target Contract Expectations, Target Runtime Expectations, Tests To Plan With The Code Refactor, Visualization Changes
-
-### Community 175 - "Community 175"
-Cohesion: 0.25
-Nodes (7): ADVIO Local-First-Pose Normalized Datastore Context, Constraints, Desired Outcome, Known Facts And Evidence, Likely Codebase Touchpoints, Task Statement, Unknowns / Watch Points
-
-### Community 176 - "Community 176"
-Cohesion: 0.25
-Nodes (7): Constraints, Context: PR102 ADVIO Trajectory Normalization Regression Fix, Desired Outcome, Existing Evidence, Likely Code Touchpoints, Open Questions, Task Statement
-
-### Community 177 - "Community 177"
-Cohesion: 0.25
-Nodes (7): Constraints, Desired outcome, Known facts/evidence, Likely codebase touchpoints, Record3D First-Pose-Relative Geometry Fix, Task statement, Unknowns/open questions
-
-### Community 178 - "Community 178"
-Cohesion: 0.25
-Nodes (7): Constraints, Desired Outcome, Known Facts And Evidence, Likely Codebase Touchpoints, Sweeper Dataset Page Reconciliation Context, Task Statement, Unknowns / Open Questions
-
-### Community 179 - "Community 179"
-Cohesion: 0.25
-Nodes (5): label(), validate_real_provider(), validate_single_sampling_mode(), Return the effective ADVIO provider for one optional serving config., selected_advio_pose_source()
-
-### Community 180 - "Community 180"
-Cohesion: 0.25
-Nodes (8): Artifact Ownership, Current Entry Points, Extension Rules, Generic DTO And Payload Flow, Generic Stage Lifecycle, PRML VSLAM Pipeline Guide, Runtime Protocols, StageRunner And StageResultStore
-
-### Community 181 - "Community 181"
-Cohesion: 0.25
-Nodes (7): ADR Alternatives Rejected, ADVIO Local-First-Pose Normalized Datastore Ralplan Handoff, Approved Agent Roster, Decision, Implementation Contract, Trajectory Contract, Verification Contract
-
-### Community 182 - "Community 182"
-Cohesion: 0.25
-Nodes (7): Architect Review, Critic Review, Decision, Execution Handoff, Planning Artifacts, Ralplan Consensus Handoff: ADVIO Trajectory Normalization Regression Fix, Status
-
-### Community 183 - "Community 183"
-Cohesion: 0.25
-Nodes (7): Phase 0: Ownership Gate Checks, Phase 1: HIGH Fallback Contract Tests, Phase 2: normalized_store.py Extraction Tests, Phase 3: Streamlit Read-only Extraction Tests, Phase 4: Hygiene and Final Gates, Resolve review findings test specification, Validation Principles
-
-### Community 184 - "Community 184"
-Cohesion: 0.29
-Nodes (4): record3d_devices(), Any, Log a warning message., Log an exception with traceback information.
-
-### Community 185 - "Community 185"
-Cohesion: 0.61
-Nodes (7): _load_history_module(), Path, Tests for the repo-local Codex history utility., test_build_repo_exports_collects_repo_scoped_user_and_agent_messages(), test_render_conversation_markdown_respects_speaker_filter(), test_session_overview_extracts_patch_touched_files_and_verification_commands(), _write_jsonl()
-
-### Community 186 - "Community 186"
-Cohesion: 0.29
-Nodes (6): Action items, claude advisor artifact, Concise summary, Final prompt, Original task, Raw output
-
-### Community 188 - "Community 188"
-Cohesion: 0.33
-Nodes (6): normalize_archive_member(), Shared pure helpers for dataset download managers., Normalize one archive member path and reject unsafe traversal parts., Return the member path relative to one dataset sequence root., relative_sequence_path(), PurePosixPath
-
-### Community 189 - "Community 189"
-Cohesion: 0.29
-Nodes (6): Current State, Evaluation Requirements, Non-Negotiable Requirements, Purpose, Responsibilities, Validation
-
-### Community 190 - "Community 190"
-Cohesion: 0.29
-Nodes (6): Consensus Gate, Execution Lane, Planning Artifacts, Ralplan Architect Review, Ralplan Critic Review, Sweeper Dataset Page Reconciliation Handoff
-
-### Community 191 - "Community 191"
-Cohesion: 0.29
-Nodes (6): Current State, Non-Negotiable Requirements, Purpose, Reconstruction Requirements, Responsibilities, Validation
-
-### Community 192 - "Community 192"
-Cohesion: 0.29
-Nodes (5): Materialize or resolve the normalized :class:`SequenceManifest` for one run., Materialize prepared benchmark inputs that complement the offline sequence., Path, PreparedBenchmarkInputs, SequenceManifest
-
-### Community 193 - "Community 193"
-Cohesion: 0.48
-Nodes (6): _artifact(), ArtifactRef, Path, Tests for reconstruction stage visualization item mapping., test_reconstruction_adapter_maps_cloud_and_mesh_artifacts(), test_reconstruction_adapter_maps_cloud_only_artifacts()
-
-### Community 194 - "Community 194"
-Cohesion: 0.33
-Nodes (5): Installation, MemPalace - PRML VSLAM Codex Plugin, Prerequisites, Repo-Local Workflow, Support
-
-### Community 195 - "Community 195"
-Cohesion: 0.33
-Nodes (5): Current State, Methods Requirements, Non-Negotiable Requirements, Purpose, Responsibilities
-
-### Community 196 - "Community 196"
-Cohesion: 0.33
-Nodes (5): Acceptance Criteria, ADVIO Fixedpoint Preprocessing Test Spec, Evidence Artifacts To Persist During Execution, Integration Checks, Unit Tests
-
-### Community 197 - "Community 197"
-Cohesion: 0.73
-Nodes (5): Path, test_load_recording_summary_reports_live_keyed_and_tracking_surfaces(), test_write_validation_bundle_emits_report_and_projection_images(), test_write_validation_bundle_respects_explicit_keyed_cloud_limit(), _write_synthetic_recording()
-
-### Community 198 - "Community 198"
-Cohesion: 0.40
-Nodes (4): Build Contract, Published PDFs, Report, Update Slides
-
-### Community 200 - "Community 200"
-Cohesion: 0.40
-Nodes (4): observation_metadata_for_transport(), Ray actors that execute streaming source I/O., Drop raster payloads that are transported through explicit Ray refs., Observation
-
-### Community 201 - "Community 201"
-Cohesion: 0.50
-Nodes (4): main(), _normalize_generated_stubs(), Generate repo-local Open3D stubs with Open3D's pybind11-stubgen workflow., Regenerate Open3D `.pyi` files under `typings/open3d`.
-
-### Community 202 - "Community 202"
-Cohesion: 0.50
-Nodes (3): LingBot-Map Method Wrapper, Normalized Artifacts, Parameter Parity
-
-### Community 204 - "Community 204"
-Cohesion: 0.50
-Nodes (3): Non-Negotiable Requirements, Purpose, ViSTA Wrapper Requirements
+Cohesion: 1.0
+Nodes (1): Return the path that should own this change in reports.
 
 ## Knowledge Gaps
-- **663 isolated node(s):** `mempal-hook.sh script`, `generate-unstaged-diff.sh script`, `prml-vslam`, `Namespace`, `Namespace` (+658 more)
+- **262 isolated node(s):** `Thin Streamlit entrypoint for the PRML VSLAM workbench scaffold.  The file stays`, `Frame preprocessing helpers for ViSTA-SLAM.`, `One RGB frame prepared for upstream ViSTA ingestion.`, `Use the exact upstream ViSTA crop-and-resize helper path.`, `Convert one upstream ViSTA array-like payload into a numpy array.` (+257 more)
   These have ≤1 connection - possible missing edges or undocumented components.
-- **33 thin communities (<3 nodes) omitted from report** — run `graphify query` to explore isolated nodes.
+- **Thin community `Community 19`** (2 nodes): `streamlit_app.py`, `Thin Streamlit entrypoint for the PRML VSLAM workbench scaffold.  The file stays`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 20`** (2 nodes): `ray.py`, `Ray-specific helpers for future stage runtime deployment.  This module intention`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 21`** (1 nodes): `Build the shared transform DTO from XYZW quaternion and XYZ translation arrays.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 22`** (1 nodes): `Build the shared transform DTO from a 4x4 homogeneous matrix.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 23`** (1 nodes): `Return the compact source label used in logs and diagnostics.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 24`** (1 nodes): `Disconnect or release the source and any owned runtime resources.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 25`** (1 nodes): `Return the short user-facing dataset label.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 26`** (1 nodes): `Deserialize one IPC payload back into the target validated model type.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 27`** (1 nodes): `Return the human-readable label shown in plan previews.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 28`** (1 nodes): `Return whether ``exc`` looks like a transient local Ray connection failure.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 29`** (1 nodes): `Build one spec from one JSON object.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 30`** (1 nodes): `Return the net code-line delta.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
+- **Thin community `Community 31`** (1 nodes): `Return the path that should own this change in reports.`
+  Too small to be a meaningful cluster - may be noise or needs more connections extracted.
 
 ## Suggested Questions
 _Questions this graph is uniquely positioned to answer:_
 
-- **Why does `StageKey` connect `Community 18` to `Community 0`, `Community 1`, `Community 2`, `Community 3`, `Community 129`, `Community 5`, `Community 6`, `Community 7`, `Community 9`, `Community 10`, `Community 17`, `Community 20`, `Community 21`, `Community 22`, `Community 23`, `Community 26`, `Community 27`, `Community 29`, `Community 31`, `Community 32`, `Community 34`, `Community 166`, `Community 39`, `Community 40`, `Community 41`, `Community 38`, `Community 43`, `Community 46`, `Community 49`, `Community 51`, `Community 52`, `Community 54`, `Community 55`, `Community 60`, `Community 64`, `Community 65`, `Community 197`, `Community 70`, `Community 74`, `Community 81`, `Community 95`, `Community 97`, `Community 98`, `Community 101`, `Community 120`, `Community 123`, `Community 127`?**
-  _High betweenness centrality (0.122) - this node is a cross-community bridge._
-- **Why does `Test package helpers and suites for PRML VSLAM.` connect `Community 10` to `Community 0`, `Community 2`, `Community 3`, `Community 4`, `Community 5`, `Community 9`, `Community 11`, `Community 139`, `Community 15`, `Community 16`, `Community 144`, `Community 18`, `Community 17`, `Community 20`, `Community 21`, `Community 22`, `Community 23`, `Community 24`, `Community 25`, `Community 26`, `Community 28`, `Community 29`, `Community 30`, `Community 31`, `Community 32`, `Community 33`, `Community 36`, `Community 166`, `Community 167`, `Community 38`, `Community 45`, `Community 174`, `Community 48`, `Community 50`, `Community 179`, `Community 53`, `Community 54`, `Community 58`, `Community 61`, `Community 62`, `Community 69`, `Community 199`, `Community 76`, `Community 77`, `Community 78`, `Community 79`, `Community 84`, `Community 91`, `Community 98`, `Community 107`, `Community 111`, `Community 116`?**
-  _High betweenness centrality (0.073) - this node is a cross-community bridge._
-- **Why does `MethodId` connect `Community 20` to `Community 0`, `Community 1`, `Community 3`, `Community 4`, `Community 5`, `Community 6`, `Community 132`, `Community 10`, `Community 17`, `Community 18`, `Community 21`, `Community 22`, `Community 23`, `Community 24`, `Community 26`, `Community 27`, `Community 29`, `Community 31`, `Community 32`, `Community 38`, `Community 39`, `Community 41`, `Community 43`, `Community 47`, `Community 51`, `Community 52`, `Community 55`, `Community 57`, `Community 60`, `Community 62`, `Community 64`, `Community 65`, `Community 68`, `Community 70`, `Community 72`, `Community 85`, `Community 95`, `Community 97`, `Community 100`, `Community 107`?**
-  _High betweenness centrality (0.053) - this node is a cross-community bridge._
-- **Are the 821 inferred relationships involving `StageKey` (e.g. with `AdvioDownloadFormData` and `AdvioPageData`) actually correct?**
-  _`StageKey` has 821 INFERRED edges - model-reasoned connections that need verification._
-- **Are the 520 inferred relationships involving `MethodId` (e.g. with `_DensePredictionArtifacts` and `LingbotMapSlamBackend`) actually correct?**
-  _`MethodId` has 520 INFERRED edges - model-reasoned connections that need verification._
-- **Are the 443 inferred relationships involving `SequenceManifest` (e.g. with `_DensePredictionArtifacts` and `_InProcessManager`) actually correct?**
-  _`SequenceManifest` has 443 INFERRED edges - model-reasoned connections that need verification._
-- **Are the 373 inferred relationships involving `DatasetId` (e.g. with `Controller helpers for the ADVIO Streamlit page.` and `Persist the current ADVIO download-form state.`) actually correct?**
-  _`DatasetId` has 373 INFERRED edges - model-reasoned connections that need verification._
+- **Why does `Test package helpers and suites for PRML VSLAM.` connect `Community 10` to `Community 0`, `Community 1`, `Community 2`, `Community 3`, `Community 4`, `Community 5`, `Community 6`, `Community 7`, `Community 8`, `Community 9`?**
+  _High betweenness centrality (0.105) - this node is a cross-community bridge._
+- **Why does `SequenceManifest` connect `Community 3` to `Community 0`, `Community 1`, `Community 2`, `Community 4`, `Community 6`, `Community 7`, `Community 8`, `Community 10`, `Community 11`?**
+  _High betweenness centrality (0.075) - this node is a cross-community bridge._
+- **Why does `StageKey` connect `Community 6` to `Community 0`, `Community 1`, `Community 2`, `Community 3`, `Community 4`, `Community 7`, `Community 10`, `Community 12`?**
+  _High betweenness centrality (0.070) - this node is a cross-community bridge._
+- **Are the 450 inferred relationships involving `StageKey` (e.g. with `RunConfigOverrideCommand` and `_RerunViewerProcess`) actually correct?**
+  _`StageKey` has 450 INFERRED edges - model-reasoned connections that need verification._
+- **Are the 432 inferred relationships involving `SequenceManifest` (e.g. with `RunConfigOverrideCommand` and `_RerunViewerProcess`) actually correct?**
+  _`SequenceManifest` has 432 INFERRED edges - model-reasoned connections that need verification._
+- **Are the 362 inferred relationships involving `PreparedBenchmarkInputs` (e.g. with `RunConfigOverrideCommand` and `_RerunViewerProcess`) actually correct?**
+  _`PreparedBenchmarkInputs` has 362 INFERRED edges - model-reasoned connections that need verification._
+- **Are the 360 inferred relationships involving `DatasetId` (e.g. with `RunConfigOverrideCommand` and `_RerunViewerProcess`) actually correct?**
+  _`DatasetId` has 360 INFERRED edges - model-reasoned connections that need verification._

--- a/graphify-out/graph.json
+++ b/graphify-out/graph.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:422d2de5d9bb18b78fd17f61ebe4afe8a7e5e47046fed5f19cd44882f1d246b6
-size 15736803
+oid sha256:531c27952603ae81a40250f737d50df713f2f2ffe1a7e17846b639dfce54b973
+size 12452546

--- a/tests/test_graphify_repo.py
+++ b/tests/test_graphify_repo.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+
+def _load_graphify_module() -> Any:
+    module_path = Path(__file__).resolve().parents[1] / ".agents" / "scripts" / "graphify_repo.py"
+    spec = importlib.util.spec_from_file_location("graphify_repo", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load module from {module_path}.")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+GRAPHIFY = _load_graphify_module()
+
+
+def test_lfs_pointer_detection(tmp_path: Path) -> None:
+    pointer = tmp_path / "graph.json"
+    pointer.write_text(
+        "version https://git-lfs.github.com/spec/v1\n"
+        "oid sha256:5976b242c80e9c8bf9917509a5a1db12c6775c6e4fe98e6e7158784eb648a099\n"
+        "size 9859594\n",
+        encoding="utf-8",
+    )
+    materialized = tmp_path / "materialized.json"
+    materialized.write_text('{"nodes": [], "links": []}\n', encoding="utf-8")
+
+    assert GRAPHIFY.is_lfs_pointer(pointer)
+    assert not GRAPHIFY.is_lfs_pointer(materialized)
+
+
+def test_status_reports_pointer_without_json_traceback(tmp_path: Path, monkeypatch: Any, capsys: Any) -> None:
+    repo = tmp_path / "repo"
+    graphify_out = repo / "graphify-out"
+    graphify_out.mkdir(parents=True)
+    (graphify_out / "GRAPH_REPORT.md").write_text(
+        "# Graph Report - demo (2026-06-12)\n\n## Summary\n- 2 nodes · 3 edges · 1 communities detected\n",
+        encoding="utf-8",
+    )
+    (graphify_out / "graph.json").write_text(
+        "version https://git-lfs.github.com/spec/v1\n"
+        "oid sha256:5976b242c80e9c8bf9917509a5a1db12c6775c6e4fe98e6e7158784eb648a099\n"
+        "size 9859594\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(GRAPHIFY, "repo_root", lambda: repo)
+    monkeypatch.setattr(GRAPHIFY, "graphify_version", lambda: "0.4.26")
+    monkeypatch.setattr(GRAPHIFY, "_git_status", lambda _paths: "clean")
+
+    GRAPHIFY.status()
+
+    output = capsys.readouterr().out
+    assert "graph data state: git-lfs pointer" in output
+    assert "nodes: 2" in output
+    assert "artifact dirty state: clean" in output
+
+
+def test_mcp_materializes_pointer_then_execs_graphify_server(tmp_path: Path, monkeypatch: Any) -> None:
+    repo = tmp_path / "repo"
+    graphify_out = repo / "graphify-out"
+    graphify_out.mkdir(parents=True)
+    graph_path = graphify_out / "graph.json"
+    graph_path.write_text(
+        "version https://git-lfs.github.com/spec/v1\n"
+        "oid sha256:5976b242c80e9c8bf9917509a5a1db12c6775c6e4fe98e6e7158784eb648a099\n"
+        "size 9859594\n",
+        encoding="utf-8",
+    )
+    captured: dict[str, Any] = {}
+
+    class PullResult:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(command: list[str], **kwargs: Any) -> PullResult:
+        captured["pull"] = command
+        graph_path.write_text('{"nodes": [], "links": []}\n', encoding="utf-8")
+        return PullResult()
+
+    def fake_execvp(executable: str, argv: list[str]) -> None:
+        captured["exec"] = (executable, argv)
+        raise RuntimeError("stop")
+
+    monkeypatch.setenv("UV_BIN", "/tools/uv")
+    monkeypatch.setattr(GRAPHIFY, "repo_root", lambda: repo)
+    monkeypatch.setattr(GRAPHIFY.subprocess, "run", fake_run)
+    monkeypatch.setattr(GRAPHIFY.os, "execvp", fake_execvp)
+
+    with pytest.raises(RuntimeError, match="stop"):
+        GRAPHIFY.mcp()
+
+    assert captured["pull"] == ["git", "lfs", "pull", "--include=graphify-out/graph.json", "--exclude="]
+    executable, argv = captured["exec"]
+    assert executable == "/tools/uv"
+    assert argv[-3:] == ["-m", "graphify.serve", "graphify-out/graph.json"]

--- a/tests/test_mempalace_repo.py
+++ b/tests/test_mempalace_repo.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+from typing import Any
+
+
+def _load_mempalace_module() -> Any:
+    module_path = (
+        Path(__file__).resolve().parents[1] / ".agents" / "skills" / "mempalace-repo" / "scripts" / "mempalace_repo.py"
+    )
+    spec = importlib.util.spec_from_file_location("mempalace_repo", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load module from {module_path}.")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+MEMPALACE = _load_mempalace_module()
+
+
+def test_run_mempalace_uses_cli_and_explicit_repo_palace(monkeypatch: Any) -> None:
+    calls: list[dict[str, Any]] = []
+    palace = Path("/repo/.artifacts/mempalace/palace")
+
+    def fake_run(command: list[str], **kwargs: Any) -> object:
+        calls.append({"command": command, **kwargs})
+
+        class Result:
+            returncode = 0
+
+        return Result()
+
+    monkeypatch.setenv("MEMPALACE_BIN", "/tools/mempalace")
+    monkeypatch.setattr(MEMPALACE, "repo_root", lambda: Path("/repo"))
+    monkeypatch.setattr(MEMPALACE, "palace_path", lambda: palace)
+    monkeypatch.setattr(MEMPALACE.subprocess, "run", fake_run)
+
+    MEMPALACE.run_mempalace("search", "pipeline")
+
+    assert calls[0]["command"] == ["/tools/mempalace", "--palace", str(palace), "search", "pipeline"]
+    assert calls[0]["cwd"] == Path("/repo")
+    assert calls[0]["env"]["MEMPALACE_PALACE_PATH"] == str(palace)
+
+
+def test_mcp_execs_mempalace_mcp_with_repo_palace(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+    palace = Path("/repo/.artifacts/mempalace/palace")
+
+    monkeypatch.setenv("MEMPALACE_MCP_BIN", "/tools/mempalace-mcp")
+    monkeypatch.setattr(MEMPALACE, "ensure_runtime", lambda: None)
+    monkeypatch.setattr(MEMPALACE, "palace_path", lambda: palace)
+
+    def fake_execve(executable: str, argv: list[str], env: dict[str, str]) -> None:
+        captured.update({"executable": executable, "argv": argv, "env": env})
+        raise RuntimeError("stop")
+
+    monkeypatch.setattr(MEMPALACE.os, "execve", fake_execve)
+
+    try:
+        MEMPALACE.mcp()
+    except RuntimeError as exc:
+        assert str(exc) == "stop"
+
+    assert captured["executable"] == "/tools/mempalace-mcp"
+    assert captured["argv"] == ["/tools/mempalace-mcp", "--palace", str(palace)]
+    assert captured["env"]["MEMPALACE_PALACE_PATH"] == str(palace)
+
+
+def test_linked_worktree_uses_shared_palace_when_local_palace_missing(tmp_path: Path, monkeypatch: Any) -> None:
+    worktree = tmp_path / "repo.worktrees" / "branch"
+    shared = tmp_path / "repo"
+    (worktree / ".agents" / "skills" / "mempalace-repo" / "scripts").mkdir(parents=True)
+    (shared / ".artifacts" / "mempalace" / "palace").mkdir(parents=True)
+
+    monkeypatch.setattr(MEMPALACE, "repo_root", lambda: worktree)
+    monkeypatch.setattr(MEMPALACE, "shared_repo_root", lambda: shared)
+
+    assert MEMPALACE.palace_path() == shared / ".artifacts" / "mempalace" / "palace"
+    assert MEMPALACE.sources_root() == shared / ".artifacts" / "mempalace" / "sources"
+
+
+def test_docs_mining_includes_agent_scaffold(tmp_path: Path, monkeypatch: Any) -> None:
+    repo = tmp_path / "repo"
+    skill = repo / ".agents" / "skills" / "scientific-writing" / "SKILL.md"
+    reference = repo / ".agents" / "references" / "agent_reference.md"
+    backlog = repo / ".agents" / "issues.toml"
+    codex_config = repo / ".codex" / "config.toml"
+    for path in (skill, reference, backlog, codex_config, repo / "README.md"):
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("content", encoding="utf-8")
+
+    monkeypatch.setattr(MEMPALACE, "repo_root", lambda: repo)
+
+    docs = {path.relative_to(repo) for path in MEMPALACE._iter_docs_files()}
+
+    assert Path(".agents/skills/scientific-writing/SKILL.md") in docs
+    assert Path(".agents/references/agent_reference.md") in docs
+    assert Path(".agents/issues.toml") in docs
+    assert Path(".codex/config.toml") in docs
+
+
+def test_init_llm_args_default_local_and_explicit_external_opt_in(monkeypatch: Any) -> None:
+    assert MEMPALACE._init_llm_args() == ["--no-llm"]
+
+    monkeypatch.setenv("MEMPALACE_INIT_LLM", "1")
+    monkeypatch.setenv("MEMPALACE_INIT_LLM_PROVIDER", "openai-compat")
+    monkeypatch.setenv("MEMPALACE_INIT_LLM_MODEL", "gpt-4.1-mini")
+    monkeypatch.setenv("MEMPALACE_INIT_LLM_ENDPOINT", "https://api.example.test/v1")
+    monkeypatch.setenv("MEMPALACE_INIT_LLM_API_KEY", "test-key")
+    monkeypatch.setenv("MEMPALACE_ACCEPT_EXTERNAL_LLM", "1")
+
+    assert MEMPALACE._init_llm_args() == [
+        "--llm-provider",
+        "openai-compat",
+        "--llm-model",
+        "gpt-4.1-mini",
+        "--llm-endpoint",
+        "https://api.example.test/v1",
+        "--llm-api-key",
+        "test-key",
+        "--accept-external-llm",
+    ]
+
+
+def test_mempalace_executable_uses_env_override(monkeypatch: Any) -> None:
+    monkeypatch.setenv("MEMPALACE_BIN", "/custom/mempalace")
+
+    assert MEMPALACE.mempalace_executable() == "/custom/mempalace"
+    assert os.environ["MEMPALACE_BIN"] == "/custom/mempalace"


### PR DESCRIPTION
## Summary
This branch repairs the repo-local agent scaffold around MemPalace and Graphify, makes the Codex/MCP wiring portable across linked worktrees, adds a durable scaffold contract for future AGENTS/skill/reference changes, and records the SLAM Handbook source in the literature manifest. The Graphify artifacts were rebuilt from the final branch state while preserving the repository's Git LFS pointer contract for `graphify-out/graph.json` and `graphify-out/graph.html`.

Focused verification completed:
- `uv run --extra dev pytest tests/test_graphify_repo.py tests/test_mempalace_repo.py -q`
- `python3 -m py_compile .agents/scripts/graphify_repo.py .agents/skills/mempalace-repo/scripts/mempalace_repo.py`
- `python3 - <<'PY' ... tomllib/jsonl validation ... PY`
- `make graphify`
- `git lfs pointer --check --file=graphify-out/graph.json`
- `git lfs pointer --check --file=graphify-out/graph.html`
- `git diff --check`
- `make ci`

## Work Packages
| WP | Scope | Primary surfaces | Status |
| --- | --- | --- | --- |
| WP1 | Repo-local memory tooling | `.agents/skills/mempalace-repo/`, `.agents/scripts/mempalace_startup_context.sh`, `tests/test_mempalace_repo.py` | resolved |
| WP2 | Graphify tooling and MCP preflight | `.agents/scripts/graphify_repo.py`, `Makefile`, `.codex/config.toml`, `tests/test_graphify_repo.py` | resolved |
| WP3 | Agent scaffold contract | `AGENTS.md`, `.agents/references/agent_scaffold.md`, `.agents/references/agent_reference.md`, `.agents/SETUP.md`, `.agents/skills/scientific-writing/SKILL.md` | resolved |
| WP4 | Literature source manifest | `docs/literature/tex-src/README.md`, `docs/literature/tex-src/sources.jsonl` | resolved |
| WP5 | Graphify artifact refresh | `graphify-out/GRAPH_REPORT.md`, `graphify-out/graph.json`, `graphify-out/graph.html` | resolved |

## WP1 — Repo-Local Memory Tooling
### Scope
- Reworks the MemPalace helper to use installed `mempalace` and `mempalace-mcp` executables instead of assuming the package is importable from the repo virtualenv.
- Resolves the repo-local palace path through linked-worktree-aware shared-root fallback while still preferring a local palace when present.
- Makes startup refresh lock handling more robust and stages agent scaffold docs/state into the MemPalace docs wing.
- Keeps external LLM use opt-in for MemPalace initialization through explicit environment variables.

### Key files
- `.agents/skills/mempalace-repo/scripts/mempalace_repo.py`
- `.agents/scripts/mempalace_startup_context.sh`
- `.agents/skills/mempalace-repo/SKILL.md`
- `tests/test_mempalace_repo.py`

### Initial success criteria resolution
- `repo memory helper works without importable mempalace module`: `resolved`
- `linked worktree can reuse shared repo palace`: `resolved`
- `agent scaffold is mined as durable docs context`: `resolved`
- `external LLM initialization is explicit opt-in`: `resolved`

## WP2 — Graphify Tooling And MCP Preflight
### Scope
- Adds a repo-local Graphify helper for status, report extraction, and MCP startup.
- Treats Git LFS pointer files as a valid checkout state for status/report commands.
- Materializes `graphify-out/graph.json` before Graphify MCP startup, with actionable diagnostics if LFS hydration fails.
- Routes `make graphify` and `make graphify-report` through the helper so pointer files no longer trigger JSON tracebacks.

### Key files
- `.agents/scripts/graphify_repo.py`
- `.agents/skills/graphify/SKILL.md`
- `Makefile`
- `.codex/config.toml`
- `tests/test_graphify_repo.py`

### API/path mapping
- `make graphify-status`: now delegates to `.agents/scripts/graphify_repo.py status`.
- `make graphify-report`: now delegates to `.agents/scripts/graphify_repo.py report`.
- MCP server `graphify`: now starts through `python3 .agents/scripts/graphify_repo.py mcp`.
- MCP server `code-index`: now uses `--project-path .` with `cwd = "."` so linked worktrees do not index the primary checkout.

### Initial success criteria resolution
- `Graphify status handles LFS pointers without JSON traceback`: `resolved`
- `Graphify MCP startup materializes graph data first`: `resolved`
- `repo-local MCP paths stay portable`: `resolved`

## WP3 — Agent Scaffold Contract
### Scope
- Adds a compact scaffold contract that defines source order, ownership boundaries, skill header shape, MCP/tool boundaries, and maintenance checks for future AGENTS/skills/reference changes.
- Links the contract from root `AGENTS.md` and the agent reference index.
- Adds a repo-local scientific-writing skill tuned to PRML VSLAM docs/report/slides work instead of generic manuscript defaults.
- Updates setup/reference guidance for Graphify, MemPalace, MCP surfaces, and scaffold maintenance.

### Key files
- `AGENTS.md`
- `.agents/references/agent_scaffold.md`
- `.agents/references/agent_reference.md`
- `.agents/SETUP.md`
- `.agents/skills/scientific-writing/SKILL.md`
- `.codex/config.toml`
- `.gemini/settings.json`

### Initial success criteria resolution
- `scaffold rules have a single durable owner surface`: `resolved`
- `future skill/reference/MCP edits have a routing contract`: `resolved`
- `scientific writing guidance is project-specific`: `resolved`

## WP4 — Literature Source Manifest
### Scope
- Adds the SLAM Handbook public release as a reference-only literature source.
- Documents that the JSONL manifest can contain non-arXiv rows and that those rows are discovery/indexing metadata rather than downloader inputs.

### Key files
- `docs/literature/tex-src/sources.jsonl`
- `docs/literature/tex-src/README.md`

### Initial success criteria resolution
- `sources.jsonl remains valid JSONL`: `resolved`
- `non-arXiv source is documented as reference-only`: `resolved`

## WP5 — Graphify Artifact Refresh
### Scope
- Rebuilt Graphify after the scaffold and manifest changes.
- Preserved `graphify-out/graph.json` and `graphify-out/graph.html` as Git LFS pointer files in the working tree.
- Updated `GRAPH_REPORT.md` to the final branch graph snapshot.

### Key files
- `graphify-out/GRAPH_REPORT.md`
- `graphify-out/graph.json`
- `graphify-out/graph.html`

### Initial success criteria resolution
- `graph rebuilt from final branch state`: `resolved`
- `LFS pointer contract preserved`: `resolved`
- `make graphify reports clean artifact state`: `resolved`
