### PR TITLE
Run streaming SLAM in a Ray actor

### DIFF
--- a/src/prml_vslam/pipeline/backend_ray.py
+++ b/src/prml_vslam/pipeline/backend_ray.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import os
 import shutil
 import time
+from typing import Any, cast
 
 # Ray snapshots this flag at import time. Set it before importing `ray` so the
 # local Streamlit/CLI path does not get rewritten back to `uv run ...`.
@@ -23,6 +24,7 @@ from ray.actor import ActorHandle
 from prml_vslam.pipeline.backend import PipelineBackend, PipelineRuntimeSource
 from prml_vslam.pipeline.config import RunConfig
 from prml_vslam.pipeline.contracts.events import RunEvent
+from prml_vslam.pipeline.contracts.mode import PipelineMode
 from prml_vslam.pipeline.contracts.runtime import RunSnapshot
 from prml_vslam.pipeline.contracts.stages import StageKey
 from prml_vslam.pipeline.placement import RayActorOptions, actor_options_for_stage
@@ -35,6 +37,7 @@ from prml_vslam.utils import Console, PathConfig
 _DEFAULT_NAMESPACE = "prml_vslam.local"
 _MAX_LOCAL_HEAD_INIT_ATTEMPTS = 5
 RayActorOption = str | float | int | dict[str, float] | None
+RayInitKwargs = dict[str, Any]
 _COORDINATOR_LIFECYCLE_OPTIONS: dict[str, int] = {
     "max_restarts": 0,
     "max_task_retries": 0,
@@ -47,7 +50,11 @@ def _coordinator_actor_options(run_config: RunConfig) -> dict[str, RayActorOptio
         "num_cpus": 1.0,
         "num_gpus": 0.0,
     }
-    if run_config.stages.slam.enabled and run_config.stages.slam.backend is not None:
+    if (
+        run_config.mode is PipelineMode.OFFLINE
+        and run_config.stages.slam.enabled
+        and run_config.stages.slam.backend is not None
+    ):
         options = actor_options_for_stage(
             stage_key=StageKey.SLAM,
             run_config=run_config,
@@ -75,7 +82,7 @@ class RayPipelineBackend(PipelineBackend):
     def __init__(self, *, path_config: PathConfig | None = None, namespace: str | None = None) -> None:
         self._path_config = PathConfig() if path_config is None else path_config
         self._namespace = namespace or os.getenv("PRML_VSLAM_RAY_NAMESPACE", _DEFAULT_NAMESPACE)
-        self._console = Console(__name__).child(self.__class__.__name__).child(self._namespace)
+        self._console = Console(__name__).child(self.__class__.__name__).child(str(self._namespace))
         self._coordinators: dict[str, ActorHandle] = {}
         self._local_head = LocalRayHead(path_config=self._path_config, console=self._console)
         self._reuse_local_head = False
@@ -122,7 +129,7 @@ class RayPipelineBackend(PipelineBackend):
 
     def get_snapshot(self, run_id: str) -> RunSnapshot:
         """Fetch the latest projected snapshot from the coordinator actor."""
-        return ray.get(self._coordinator_for(run_id).snapshot.remote())
+        return cast(RunSnapshot, ray.get(self._coordinator_for(run_id).snapshot.remote()))
 
     def get_events(
         self,
@@ -138,7 +145,7 @@ class RayPipelineBackend(PipelineBackend):
         """Resolve one coordinator-owned target transient payload ref."""
         if ref is None:
             return None
-        return ray.get(self._coordinator_for(run_id).read_payload.remote(ref.handle_id))
+        return cast(np.ndarray | None, ray.get(self._coordinator_for(run_id).read_payload.remote(ref.handle_id)))
 
     def shutdown(self, *, preserve_local_head: bool = False) -> None:
         """Detach from Ray and stop any backend-owned shared infrastructure."""
@@ -153,28 +160,31 @@ class RayPipelineBackend(PipelineBackend):
         if not preserve_local_head:
             self._local_head.shutdown()
 
-    def _create_coordinator(self, run_id: str, *, actor_options: dict[str, RayActorOption]):
+    def _create_coordinator(self, run_id: str, *, actor_options: dict[str, RayActorOption]) -> ActorHandle:
         self._shutdown_run(run_id)
-        options = {
+        options: dict[str, Any] = {
             "name": coordinator_actor_name(run_id),
             "namespace": self._namespace,
             **actor_options,
         }
-        if not self._namespace.startswith("pytest-"):
+        if not str(self._namespace).startswith("pytest-"):
             options["lifetime"] = "detached"
-        coordinator = RunCoordinatorActor.options(**options).remote(run_id=run_id, namespace=self._namespace)
+        coordinator_cls = cast(Any, RunCoordinatorActor)
+        coordinator = cast(
+            ActorHandle, coordinator_cls.options(**options).remote(run_id=run_id, namespace=self._namespace)
+        )
         self._coordinators[run_id] = coordinator
         self._console.info("Created coordinator for run '%s' in namespace '%s'.", run_id, self._namespace)
         return coordinator
 
-    def _coordinator_for(self, run_id: str):
+    def _coordinator_for(self, run_id: str) -> ActorHandle:
         coordinator = self._coordinators.get(run_id)
         if coordinator is not None:
             return coordinator
         self._console.debug("Coordinator for run '%s' not cached locally; attempting Ray lookup.", run_id)
         self._ensure_ray()
         try:
-            coordinator = ray.get_actor(coordinator_actor_name(run_id), namespace=self._namespace)
+            coordinator = cast(ActorHandle, ray.get_actor(coordinator_actor_name(run_id), namespace=self._namespace))
         except ValueError:
             raise RuntimeError(f"Coordinator for run '{run_id}' is not available.") from None
         self._coordinators[run_id] = coordinator
@@ -211,14 +221,14 @@ class RayPipelineBackend(PipelineBackend):
             return
         address = os.getenv("PRML_VSLAM_RAY_ADDRESS")
         prepare_ray_environment()
-        init_kwargs = {
+        init_kwargs: RayInitKwargs = {
             "namespace": self._namespace,
             "ignore_reinit_error": True,
             "log_to_driver": self._ray_log_to_driver,
             "include_dashboard": False,
             "_skip_env_hook": True,
         }
-        if not self._namespace.startswith("pytest-"):
+        if not str(self._namespace).startswith("pytest-"):
             init_kwargs["runtime_env"] = build_runtime_env(address=address)
             self._console.debug("Prepared Ray runtime environment for namespace '%s'.", self._namespace)
         if address:
@@ -226,7 +236,7 @@ class RayPipelineBackend(PipelineBackend):
             init_kwargs["address"] = address
             ray.init(**init_kwargs)
             return
-        if self._namespace.startswith("pytest-"):
+        if str(self._namespace).startswith("pytest-"):
             self._console.debug("Initializing in-process Ray runtime for pytest namespace '%s'.", self._namespace)
             ray.init(**init_kwargs)
             return

--- a/src/prml_vslam/pipeline/placement.py
+++ b/src/prml_vslam/pipeline/placement.py
@@ -6,9 +6,8 @@ resources into the Ray-specific actor options used by the backend runtime.
 
 from __future__ import annotations
 
-from typing import TypeAlias
+from typing import Protocol, TypeAlias
 
-from prml_vslam.methods.stage.backend_config import BackendConfigValue
 from prml_vslam.pipeline.config import RunConfig
 from prml_vslam.pipeline.contracts.stages import StageKey
 
@@ -17,11 +16,19 @@ RayActorOptionsValue: TypeAlias = float | int | RayActorResources | None
 RayActorOptions: TypeAlias = dict[str, RayActorOptionsValue]
 
 
+class StageResourceDefaults(Protocol):
+    """Stage backend config surface used by Ray placement."""
+
+    @property
+    def default_resources(self) -> dict[str, float]:
+        """Return backend-default Ray resources keyed by Ray resource name."""
+
+
 def actor_options_for_stage(
     *,
     stage_key: StageKey,
     run_config: RunConfig,
-    backend: BackendConfigValue | None = None,
+    backend: StageResourceDefaults | None = None,
     default_num_cpus: float = 1.0,
     default_num_gpus: float = 0.0,
     restartable: bool = False,
@@ -53,4 +60,10 @@ def actor_options_for_stage(
     }
 
 
-__all__ = ["RayActorOptions", "RayActorOptionsValue", "RayActorResources", "actor_options_for_stage"]
+__all__ = [
+    "RayActorOptions",
+    "RayActorOptionsValue",
+    "RayActorResources",
+    "StageResourceDefaults",
+    "actor_options_for_stage",
+]

--- a/src/prml_vslam/pipeline/ray_runtime/coordinator.py
+++ b/src/prml_vslam/pipeline/ray_runtime/coordinator.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import threading
 from collections import deque
 from dataclasses import dataclass
-from typing import Literal, cast
+from typing import Any, Literal, cast
 
 import numpy as np
 import ray
@@ -25,6 +25,16 @@ from prml_vslam.interfaces.alignment import GroundAlignmentMetadata
 from prml_vslam.interfaces.artifacts import ArtifactRef
 from prml_vslam.methods.stage import SlamStageRuntime
 from prml_vslam.methods.stage.backend_config import SlamBackendConfig
+from prml_vslam.methods.stage.visualization import (
+    ROLE_KEYFRAME_DEPTH,
+    ROLE_KEYFRAME_PINHOLE,
+    ROLE_KEYFRAME_PREVIEW,
+    ROLE_KEYFRAME_RGB,
+    ROLE_MODEL_CAMERA_RGB,
+    ROLE_MODEL_PINHOLE,
+    ROLE_MODEL_PREVIEW,
+    ROLE_SOURCE_RGB,
+)
 from prml_vslam.pipeline.backend import PipelineRuntimeSource
 from prml_vslam.pipeline.config import RunConfig
 from prml_vslam.pipeline.contracts.context import PipelineExecutionContext
@@ -48,6 +58,7 @@ from prml_vslam.pipeline.contracts.mode import PipelineMode
 from prml_vslam.pipeline.contracts.plan import RunPlan
 from prml_vslam.pipeline.contracts.runtime import RunSnapshot, RunState
 from prml_vslam.pipeline.contracts.stages import StageKey
+from prml_vslam.pipeline.placement import actor_options_for_stage
 from prml_vslam.pipeline.ray_runtime.common import (
     DEFAULT_MAX_FRAMES_IN_FLIGHT,
     EVENT_RING_LIMIT,
@@ -68,14 +79,16 @@ from prml_vslam.pipeline.stages.base.contracts import (
     StageRuntimeStatus,
     StageRuntimeUpdate,
     VisualizationIntent,
+    VisualizationItem,
 )
 from prml_vslam.pipeline.stages.base.handles import TransientPayloadRef
 from prml_vslam.pipeline.stages.base.proxy import StageRuntimeHandle
+from prml_vslam.pipeline.stages.base.ray import RayStageRuntimeHandle
 from prml_vslam.pipeline.stages.specs import stage_runtime_spec_for
 from prml_vslam.sources.protocols import OfflineSequenceSource, StreamingSequenceSource
 from prml_vslam.sources.stage.contracts import SourceStageOutput
 from prml_vslam.sources.stage.visualization import ROLE_SOURCE_REFERENCE_TRAJECTORY, SourceVisualizationAdapter
-from prml_vslam.utils import Console, PathConfig, RunArtifactPaths
+from prml_vslam.utils import Console, JsonScalar, PathConfig, RunArtifactPaths
 from prml_vslam.visualization.artifacts import artifact_visualizations
 
 _TERMINAL_STATES = {RunState.COMPLETED, RunState.FAILED, RunState.STOPPED}
@@ -123,13 +136,15 @@ class RunCoordinatorActor:
         self._source_finished = False
         self._streaming_finalized = False
         self._in_flight_frames = 0
+        self._slam_submission_refs: list[ray.ObjectRef[None]] = []
+        self._slam_submission_lock = threading.Lock()
         self._streaming_done = threading.Event()
         self._jsonl_sink: JsonlEventSink | None = None
         self._rerun_sinks: list[_RerunSinkSidecar] = []
         self._worker: threading.Thread | None = None
         self._source_actor: ActorHandle | None = None
         self._streaming_runtime_manager: RuntimeManager | None = None
-        self._slam_runtime_proxy: StageRuntimeHandle | None = None
+        self._slam_runtime_proxy: StageRuntimeHandle | RayStageRuntimeHandle | None = None
         self._run_config: RunConfig | None = None
         self._plan: RunPlan | None = None
         self._slam_backend: SlamBackendConfig | None = None
@@ -158,6 +173,7 @@ class RunCoordinatorActor:
         self._source_finished = False
         self._streaming_finalized = False
         self._in_flight_frames = 0
+        self._slam_submission_refs = []
         self._streaming_done = threading.Event()
         self._source_actor = None
         self._streaming_runtime_manager = None
@@ -292,10 +308,8 @@ class RunCoordinatorActor:
         )
         if self._stop_requested or self._slam_runtime_proxy is None:
             return
-        self._in_flight_frames += 1
-        frame_accepted = False
         try:
-            self._submit_frame_to_slam_runtime(
+            submission_ref = self._submit_frame_to_slam_runtime(
                 packet=packet,
                 frame_ref=frame_ref,
                 depth_ref=depth_ref,
@@ -305,19 +319,16 @@ class RunCoordinatorActor:
                 pose=pose,
                 provenance=provenance,
             )
-            frame_accepted = True
+            if submission_ref is None:
+                self._complete_inline_slam_submission()
+            else:
+                self._track_slam_submission(submission_ref)
         except Exception as exc:
             self._console.error("Streaming SLAM frame submission failed for run '%s': %s", self._run_id, exc)
             self._streaming_error = str(exc)
             self._source_finished = True
             if self._source_actor is not None:
                 self._source_actor.stop.remote()
-        finally:
-            self._in_flight_frames = max(0, self._in_flight_frames - 1)
-            if frame_accepted and self._source_actor is not None and not self._stop_requested:
-                self._source_actor.grant_credit.remote(1)
-        if frame_accepted:
-            self._publish_slam_runtime_updates(self._drain_slam_runtime_updates())
         if self._source_finished and self._in_flight_frames == 0:
             self._finalize_streaming()
 
@@ -344,8 +355,7 @@ class RunCoordinatorActor:
         if not self._has_rerun_sinks():
             return
         payload_resolver = self._self_actor_handle()
-        for update in updates:
-            self._submit_rerun_update(update=update, payload_resolver=payload_resolver)
+        self._submit_rerun_updates(updates=updates, payload_resolver=payload_resolver)
 
     def _submit_frame_to_slam_runtime(
         self,
@@ -358,31 +368,88 @@ class RunCoordinatorActor:
         intrinsics: CameraIntrinsics | None,
         pose: FrameTransform | None,
         provenance: ObservationProvenance,
-    ) -> None:
+    ) -> ray.ObjectRef[None] | None:
         if self._slam_runtime_proxy is None:
             raise RuntimeError("Streaming SLAM runtime has not been started.")
-        self._stage_runner.submit_stream_item(
-            runtime=self._slam_runtime_proxy,
-            item=Observation(
-                seq=packet.seq,
-                timestamp_ns=packet.timestamp_ns,
-                rgb=self._resolve_handle_payload(frame_ref),
-                depth_m=self._resolve_handle_payload(depth_ref) if pose is not None else None,
-                confidence=self._resolve_handle_payload(confidence_ref),
-                pointmap_xyz=self._resolve_handle_payload(pointmap_ref) if pose is not None else None,
-                point_cloud_xyz=packet.point_cloud_xyz if pose is not None else None,
-                point_cloud_rgb=packet.point_cloud_rgb if pose is not None else None,
-                intrinsics=intrinsics,
-                T_world_camera=pose,
-                arrival_timestamp_s=packet.arrival_timestamp_s,
-                provenance=provenance,
-            ),
+        item = Observation(
+            seq=packet.seq,
+            timestamp_ns=packet.timestamp_ns,
+            rgb=self._resolve_handle_payload(frame_ref),
+            depth_m=self._resolve_handle_payload(depth_ref) if pose is not None else None,
+            confidence=self._resolve_handle_payload(confidence_ref),
+            pointmap_xyz=self._resolve_handle_payload(pointmap_ref) if pose is not None else None,
+            point_cloud_xyz=packet.point_cloud_xyz if pose is not None else None,
+            point_cloud_rgb=packet.point_cloud_rgb if pose is not None else None,
+            intrinsics=intrinsics,
+            T_world_camera=pose,
+            arrival_timestamp_s=packet.arrival_timestamp_s,
+            provenance=provenance,
         )
+        if isinstance(self._slam_runtime_proxy, RayStageRuntimeHandle):
+            return self._slam_runtime_proxy.submit_stream_item_async(item)
+        self._stage_runner.submit_stream_item(runtime=self._slam_runtime_proxy, item=item)
+        return None
 
     def _drain_slam_runtime_updates(self) -> list[StageRuntimeUpdate]:
         if self._slam_runtime_proxy is None:
             return []
         return self._slam_runtime_proxy.drain_runtime_updates(max_items=None)
+
+    def _track_slam_submission(self, submission_ref: ray.ObjectRef[None]) -> None:
+        with self._slam_submission_lock:
+            self._slam_submission_refs.append(submission_ref)
+            self._in_flight_frames += 1
+
+    def _complete_inline_slam_submission(self) -> None:
+        if self._source_actor is not None and not self._stop_requested:
+            self._source_actor.grant_credit.remote(1)
+        self._publish_slam_runtime_updates(self._drain_slam_runtime_updates())
+
+    def _streaming_completion_loop(self) -> None:
+        while not self._streaming_done.is_set():
+            completed = self._drain_completed_slam_submissions(timeout_s=0.05)
+            if not completed:
+                self._streaming_done.wait(timeout=0.05)
+            if self._source_finished and self._in_flight_frames == 0:
+                self._finalize_streaming()
+
+    def _drain_completed_slam_submissions(self, *, timeout_s: float) -> int:
+        with self._slam_submission_lock:
+            pending_refs = list(self._slam_submission_refs)
+        if not pending_refs:
+            return 0
+        ready_refs, _ = ray.wait(pending_refs, num_returns=len(pending_refs), timeout=timeout_s)
+        if not ready_refs:
+            return 0
+        ready_set = set(ready_refs)
+        with self._slam_submission_lock:
+            self._slam_submission_refs = [ref for ref in self._slam_submission_refs if ref not in ready_set]
+        for submission_ref in ready_refs:
+            self._complete_slam_submission(submission_ref)
+        return len(ready_refs)
+
+    def _complete_slam_submission(self, submission_ref: ray.ObjectRef[None]) -> None:
+        try:
+            ray.get(submission_ref)
+        except Exception as exc:
+            if isinstance(self._slam_runtime_proxy, RayStageRuntimeHandle):
+                self._slam_runtime_proxy.mark_async_item_failed()
+            self._console.error("Streaming SLAM frame processing failed for run '%s': %s", self._run_id, exc)
+            self._streaming_error = str(exc)
+            self._source_finished = True
+            if self._source_actor is not None:
+                self._source_actor.stop.remote()
+        else:
+            if isinstance(self._slam_runtime_proxy, RayStageRuntimeHandle):
+                self._slam_runtime_proxy.mark_async_item_completed()
+            if self._source_actor is not None and not self._stop_requested:
+                self._source_actor.grant_credit.remote(1)
+            self._publish_slam_runtime_updates(self._drain_slam_runtime_updates())
+        finally:
+            with self._slam_submission_lock:
+                self._in_flight_frames = max(0, self._in_flight_frames - 1)
+        if self._source_finished and self._in_flight_frames == 0:
+            self._finalize_streaming()
 
     def _publish_slam_runtime_updates(self, updates: list[StageRuntimeUpdate]) -> None:
         if not updates:
@@ -393,18 +460,31 @@ class RunCoordinatorActor:
             self._console.warning("Failed to route live SLAM runtime updates for run '%s': %s", self._run_id, exc)
 
     def _cache_slam_runtime_payloads(self, updates: list[StageRuntimeUpdate]) -> None:
+        if self._slam_runtime_proxy is None or not self._rerun_sinks:
+            return
+        cache_export_payloads = any(sidecar.kind == "export" for sidecar in self._rerun_sinks)
+        cache_live_payloads = any(sidecar.kind == "live" for sidecar in self._rerun_sinks)
+        for update in updates:
+            cache_update = (
+                update if cache_export_payloads else self._live_rerun_update(update) if cache_live_payloads else None
+            )
+            if cache_update is None:
+                continue
+            for ref in _payload_refs_for_update(cache_update):
+                payload = self._read_slam_runtime_payload(ref)
+                if payload is not None:
+                    self._remember_handle(ref.handle_id, payload)
+
+    def _read_slam_runtime_payload(self, ref: TransientPayloadRef) -> np.ndarray | None:
+        if isinstance(self._slam_runtime_proxy, RayStageRuntimeHandle):
+            return self._slam_runtime_proxy.read_payload(ref)
         runtime = self._active_slam_runtime()
         if runtime is None:
-            return
-        for update in updates:
-            for item in update.visualizations:
-                for ref in item.payload_refs.values():
-                    payload = runtime.read_payload(ref)
-                    if payload is not None:
-                        self._remember_handle(ref.handle_id, payload)
+            return None
+        return runtime.read_payload(ref)
 
     def _active_slam_runtime(self) -> SlamStageRuntime | None:
-        if self._slam_runtime_proxy is None:
+        if self._slam_runtime_proxy is None or isinstance(self._slam_runtime_proxy, RayStageRuntimeHandle):
             return None
         runtime = self._slam_runtime_proxy.runtime
         if not isinstance(runtime, SlamStageRuntime):
@@ -458,7 +538,7 @@ class RunCoordinatorActor:
                     path_config=path_config,
                     runtime_source=streaming_source,
                 )
-                self._streaming_done.wait()
+                self._streaming_completion_loop()
         except Exception as exc:
             self._record_event(
                 RunFailed(event_id=self._next_event_id(), run_id=self._run_id, ts_ns=ts_ns(), error_message=str(exc))
@@ -719,12 +799,33 @@ class RunCoordinatorActor:
         runtime_manager: RuntimeManager,
     ) -> None:
         stage_key = StageKey.SLAM
-        runtime_proxy = runtime_manager.runtime_for(stage_key)
+        stage_spec = runtime_manager.stage_spec(stage_key)
+        runtime_factory = stage_spec.runtime_factory(context)
+        if runtime_factory is None:
+            raise RuntimeError("Streaming SLAM stage has no runtime factory.")
+        if not isinstance(runtime_factory, type):
+            raise RuntimeError("Ray-hosted streaming SLAM requires a class-based runtime factory.")
+        actor_options = actor_options_for_stage(
+            stage_key=stage_key,
+            run_config=context.run_config,
+            backend=context.run_config.stages.slam.backend,
+            default_num_cpus=1.0,
+            default_num_gpus=0.0,
+            restartable=False,
+            inherit_backend_defaults=True,
+        )
+        remote_options = cast(dict[str, Any], clean_actor_options(actor_options))
+        remote_runtime_cls: Any = ray.remote(**remote_options)(runtime_factory)
+        runtime_proxy = RayStageRuntimeHandle(
+            stage_key=stage_key,
+            actor=cast(ActorHandle, remote_runtime_cls.remote()),
+            resource_assignment=_resource_assignment_for_status(actor_options),
+        )
         self._stage_runner.start_configured_streaming_stage(
             stage_key=stage_key,
             runtime=runtime_proxy,
             stage_config=context.run_config.stages.section(stage_key),
-            stage_spec=runtime_manager.stage_spec(stage_key),
+            stage_spec=stage_spec,
             context=context,
             on_stage_started=self._emit_stage_started,
             on_stage_failed=self._record_stage_failure,
@@ -1036,23 +1137,70 @@ class RunCoordinatorActor:
         payload_resolver: ActorHandle | None,
         destinations: frozenset[_RerunSinkKind] = _RERUN_ALL_DESTINATIONS,
     ) -> None:
-        if self._rerun_sinks:
-            for sidecar in self._rerun_sinks:
-                if sidecar.kind not in destinations:
-                    continue
-                try:
-                    self._log_rerun_update_backlog(update, sidecar=sidecar)
-                    sidecar.last_call = sidecar.actor.observe_update.remote(
-                        update=update,
+        self._submit_rerun_updates(
+            updates=[update],
+            payload_resolver=payload_resolver,
+            destinations=destinations,
+        )
+
+    def _submit_rerun_updates(
+        self,
+        *,
+        updates: list[StageRuntimeUpdate],
+        payload_resolver: ActorHandle | None,
+        destinations: frozenset[_RerunSinkKind] = _RERUN_ALL_DESTINATIONS,
+    ) -> None:
+        if not self._rerun_sinks:
+            return
+        for sidecar in self._rerun_sinks:
+            if sidecar.kind not in destinations:
+                continue
+            routed_updates = [
+                routed_update
+                for update in updates
+                if (
+                    routed_update := (
+                        self._live_rerun_update(update) if sidecar.kind == "live" else _export_rerun_update(update)
+                    )
+                )
+                is not None
+            ]
+            if not routed_updates:
+                continue
+            try:
+                self._log_rerun_update_backlog(routed_updates[-1], sidecar=sidecar)
+                if sidecar.kind == "live":
+                    sidecar.last_call = sidecar.actor.observe_updates.remote(
+                        updates=routed_updates,
                         payload_resolver=payload_resolver,
                     )
-                except Exception as exc:  # pragma: no cover - best-effort sidecar submission
-                    self._console.warning(
-                        "Failed to submit Rerun %s sink runtime update for stage '%s': %s",
-                        sidecar.kind,
-                        update.stage_key.value,
-                        exc,
-                    )
+                else:
+                    for routed_update in routed_updates:
+                        sidecar.last_call = sidecar.actor.observe_update.remote(
+                            update=routed_update,
+                            payload_resolver=payload_resolver,
+                        )
+            except Exception as exc:  # pragma: no cover - best-effort sidecar submission
+                self._console.warning(
+                    "Failed to submit Rerun %s sink runtime update batch ending at stage '%s': %s",
+                    sidecar.kind,
+                    routed_updates[-1].stage_key.value,
+                    exc,
+                )
+
+    def _live_rerun_update(self, update: StageRuntimeUpdate) -> StageRuntimeUpdate | None:
+        run_config = self._run_config
+        if run_config is None:
+            return _export_rerun_update(update)
+        visualizations = [
+            item
+            for item in (_live_rerun_item_for_policy(item, run_config=run_config) for item in update.visualizations)
+            if item is not None
+        ]
+        semantic_events = _rerun_supported_semantic_events(update)
+        if not visualizations and not semantic_events:
+            return None
+        return update.model_copy(update={"visualizations": visualizations, "semantic_events": semantic_events})
 
     def _publish_runtime_updates_from_proxy(self, runtime_proxy: StageRuntimeHandle) -> None:
         updates = runtime_proxy.drain_runtime_updates(max_items=None)
@@ -1061,8 +1209,7 @@ class RunCoordinatorActor:
         with self._lock:
             for update in updates:
                 self._snapshot = self._projector.apply_runtime_update(self._snapshot, update)
-        for update in updates:
-            self._submit_rerun_update(update=update, payload_resolver=None)
+        self._submit_rerun_updates(updates=updates, payload_resolver=None)
 
     def _self_actor_handle(self) -> ActorHandle:
         return ray.get_actor(coordinator_actor_name(self._run_id), namespace=self._namespace)
@@ -1189,6 +1336,69 @@ class RunCoordinatorActor:
             results=self._result_store,
             slam_backend=self._require_slam_backend(),
         )
+
+
+def _resource_assignment_for_status(
+    actor_options: dict[str, float | int | dict[str, float] | None],
+) -> dict[str, JsonScalar]:
+    assignment: dict[str, JsonScalar] = {}
+    for key in ("num_cpus", "num_gpus"):
+        value = actor_options.get(key)
+        if isinstance(value, int | float):
+            assignment[key] = float(value)
+    resources = actor_options.get("resources")
+    if isinstance(resources, dict):
+        for resource_name, value in resources.items():
+            assignment[f"resource:{resource_name}"] = float(value)
+    return assignment
+
+
+def _export_rerun_update(update: StageRuntimeUpdate) -> StageRuntimeUpdate | None:
+    semantic_events = _rerun_supported_semantic_events(update)
+    if not update.visualizations and not semantic_events:
+        return None
+    if len(semantic_events) == len(update.semantic_events):
+        return update
+    return update.model_copy(update={"semantic_events": semantic_events})
+
+
+def _rerun_supported_semantic_events(
+    update: StageRuntimeUpdate,
+) -> list[GroundAlignmentMetadata | TrajectoryAlignmentArtifact | TrajectoryEvaluationManifest]:
+    return [
+        semantic_event
+        for semantic_event in update.semantic_events
+        if isinstance(
+            semantic_event, GroundAlignmentMetadata | TrajectoryAlignmentArtifact | TrajectoryEvaluationManifest
+        )
+    ]
+
+
+def _live_rerun_item_for_policy(item: VisualizationItem, *, run_config: RunConfig) -> VisualizationItem | None:
+    visualization_config = run_config.visualization
+    if item.role == ROLE_SOURCE_RGB and not visualization_config.log_source_rgb:
+        return None
+    if item.role == ROLE_MODEL_CAMERA_RGB and not visualization_config.log_camera_image_rgb:
+        return None
+    if item.role in {ROLE_MODEL_PREVIEW, ROLE_KEYFRAME_PREVIEW} and not visualization_config.log_diagnostic_preview:
+        return None
+    if item.role in {ROLE_KEYFRAME_RGB, ROLE_KEYFRAME_DEPTH, ROLE_KEYFRAME_PREVIEW}:
+        return None
+    if item.role in {ROLE_MODEL_PINHOLE, ROLE_KEYFRAME_PINHOLE} and item.intrinsics is not None:
+        return item.model_copy(update={"payload_refs": {}})
+    return item
+
+
+def _payload_refs_for_update(update: StageRuntimeUpdate) -> list[TransientPayloadRef]:
+    refs: list[TransientPayloadRef] = []
+    seen_handle_ids: set[str] = set()
+    for item in update.visualizations:
+        for ref in item.payload_refs.values():
+            if ref.handle_id in seen_handle_ids:
+                continue
+            seen_handle_ids.add(ref.handle_id)
+            refs.append(ref)
+    return refs
 
 
 __all__ = ["RunCoordinatorActor"]

--- a/src/prml_vslam/pipeline/stages/base/ray.py
+++ b/src/prml_vslam/pipeline/stages/base/ray.py
@@ -1,11 +1,137 @@
-"""Ray-specific helpers for future stage runtime deployment.
+"""Ray-backed stage runtime handles.
 
-This module intentionally exposes no helper API in WP-03. Ray option
-translation and task-ref tracking should be added here when a Ray-hosted
-``StageRuntimeHandle`` actually uses them, keeping Ray details out of generic
-runtime contracts.
+The generic stage runtime protocols are intentionally synchronous and
+deployment-neutral. ``RayStageRuntimeHandle`` is the narrow substrate adapter
+used when a stage runtime already lives inside a Ray actor but the coordinator
+still wants the same high-level lifecycle methods.
 """
 
 from __future__ import annotations
 
-__all__: list[str] = []
+from dataclasses import dataclass, field
+from typing import cast
+
+import numpy as np
+import ray
+from ray.actor import ActorHandle
+
+from prml_vslam.interfaces import Observation
+from prml_vslam.pipeline.contracts.stages import StageKey
+from prml_vslam.pipeline.stages.base.contracts import StageResult, StageRuntimeStatus, StageRuntimeUpdate
+from prml_vslam.pipeline.stages.base.handles import TransientPayloadRef
+from prml_vslam.utils import BaseData, JsonScalar
+
+RuntimeInput = BaseData
+StreamItem = BaseData | Observation
+
+
+@dataclass
+class RayStageRuntimeHandle:
+    """Proxy one Ray-hosted stage runtime through the local runtime surface."""
+
+    stage_key: StageKey
+    actor: ActorHandle
+    executor_id: str | None = "ray"
+    resource_assignment: dict[str, JsonScalar] = field(default_factory=dict)
+    _submitted_count: int = 0
+    _completed_count: int = 0
+    _failed_count: int = 0
+    _in_flight_count: int = 0
+
+    def status(self) -> StageRuntimeStatus:
+        """Return wrapped actor status with proxy-owned counters."""
+        status = cast(StageRuntimeStatus, ray.get(self.actor.status.remote()))
+        return status.model_copy(
+            update={
+                "submitted_count": self._submitted_count,
+                "completed_count": self._completed_count,
+                "failed_count": self._failed_count,
+                "in_flight_count": self._in_flight_count,
+                "executor_id": self.executor_id if self.executor_id is not None else status.executor_id,
+                "resource_assignment": self.resource_assignment or status.resource_assignment,
+            }
+        )
+
+    def stop(self) -> None:
+        """Request actor runtime stop."""
+        ray.get(self.actor.stop.remote())
+
+    def run_offline(self, input_payload: RuntimeInput) -> StageResult:
+        """Run the actor runtime over one bounded input payload."""
+        return self._counted_result(self.actor.run_offline.remote(input_payload))
+
+    def drain_runtime_updates(self, max_items: int | None = None) -> list[StageRuntimeUpdate]:
+        """Drain live updates from the actor runtime."""
+        return ray.get(self.actor.drain_runtime_updates.remote(max_items=max_items))
+
+    def start_streaming(self, input_payload: RuntimeInput) -> None:
+        """Start the actor runtime's streaming session."""
+        self._counted_void(self.actor.start_streaming.remote(input_payload))
+
+    def submit_stream_item(self, item: StreamItem) -> None:
+        """Submit one stream item synchronously."""
+        ref = self.submit_stream_item_async(item)
+        try:
+            ray.get(ref)
+        except Exception:
+            self.mark_async_item_failed()
+            raise
+        self.mark_async_item_completed()
+
+    def submit_stream_item_async(self, item: StreamItem) -> ray.ObjectRef[None]:
+        """Submit one stream item and return its Ray completion ref."""
+        self._submitted_count += 1
+        self._in_flight_count += 1
+        return self.actor.submit_stream_item.remote(item)
+
+    def mark_async_item_completed(self) -> None:
+        """Record successful completion for a previously returned async ref."""
+        self._completed_count += 1
+        self._in_flight_count = max(0, self._in_flight_count - 1)
+
+    def mark_async_item_failed(self) -> None:
+        """Record failed completion for a previously returned async ref."""
+        self._failed_count += 1
+        self._in_flight_count = max(0, self._in_flight_count - 1)
+
+    def finish_streaming(self) -> StageResult:
+        """Finalize streaming execution and return the actor runtime result."""
+        return self._counted_result(self.actor.finish_streaming.remote())
+
+    def read_payload(self, ref: TransientPayloadRef) -> np.ndarray | None:
+        """Resolve one actor-owned transient payload by ref."""
+        payload = cast(np.ndarray | None, ray.get(self.actor.read_payload.remote(ref)))
+        return None if payload is None else np.asarray(payload)
+
+    def read_payload_by_id(self, handle_id: str) -> np.ndarray | None:
+        """Resolve one actor-owned transient payload by handle id."""
+        payload = cast(np.ndarray | None, ray.get(self.actor.read_payload_by_id.remote(handle_id)))
+        return None if payload is None else np.asarray(payload)
+
+    def _counted_result(self, ref: ray.ObjectRef[StageResult]) -> StageResult:
+        self._submitted_count += 1
+        self._in_flight_count += 1
+        try:
+            result: StageResult = ray.get(ref)
+        except Exception:
+            self._failed_count += 1
+            self._in_flight_count = max(0, self._in_flight_count - 1)
+            raise
+        self._completed_count += 1
+        self._in_flight_count = max(0, self._in_flight_count - 1)
+        return result
+
+    def _counted_void(self, ref: ray.ObjectRef[None]) -> None:
+        self._submitted_count += 1
+        self._in_flight_count += 1
+        try:
+            ray.get(ref)
+        except Exception:
+            self._failed_count += 1
+            self._in_flight_count = max(0, self._in_flight_count - 1)
+            raise
+        self._completed_count += 1
+        self._in_flight_count = max(0, self._in_flight_count - 1)
+
+
+__all__ = ["RayStageRuntimeHandle"]

--- a/src/prml_vslam/visualization/rerun_policy.py
+++ b/src/prml_vslam/visualization/rerun_policy.py
@@ -135,6 +135,7 @@ class RerunLoggingPolicy:
     reference_point_cloud_decimation_keep_ratio: float = 1.0
     mesh_decimation_keep_ratio: float = 1.0
     decimation_random_seed: int = 0
+    tracking_trajectory_history_window: int | None = None
     _warned_fallback_intrinsics: bool = field(default=False, init=False, repr=False)
     _tracking_trajectory_xyz: list[tuple[float, float, float]] = field(default_factory=list, init=False, repr=False)
     _logged_tracking_start_axes: bool = field(default=False, init=False, repr=False)
@@ -621,6 +622,8 @@ class RerunLoggingPolicy:
             return
         entity_path = RERUN_SCENE.slam_raw_trajectory_path()
         self._tracking_trajectory_xyz.append((float(pose.tx), float(pose.ty), float(pose.tz)))
+        if self.tracking_trajectory_history_window is not None:
+            self._tracking_trajectory_xyz = self._tracking_trajectory_xyz[-self.tracking_trajectory_history_window :]
         if not self._logged_tracking_start_axes:
             self._log_trajectory_endpoint_markers(
                 stream,

--- a/src/prml_vslam/visualization/rerun_sink.py
+++ b/src/prml_vslam/visualization/rerun_sink.py
@@ -27,6 +27,7 @@ from .rerun_policy import RerunLoggingPolicy
 
 _LOGGER = logging.getLogger(__name__)
 PayloadResolver = Callable[[TransientPayloadRef], np.ndarray | None]
+_LIVE_TRACKING_TRAJECTORY_HISTORY_WINDOW = 256
 
 
 @dataclass(frozen=True, slots=True)
@@ -91,6 +92,17 @@ class _BaseRerunEventSink:
         """Observe one runtime update without durable `RunEvent` wrapping."""
         resolved_payloads = self._resolve_update_payloads(update, payloads=payloads, payload_resolver=payload_resolver)
         self._observe_resolved_update(update, payloads=resolved_payloads)
+
+    def observe_updates(
+        self,
+        updates: list[StageRuntimeUpdate],
+        *,
+        payloads: Mapping[str, np.ndarray] | None = None,
+        payload_resolver: PayloadResolver | None = None,
+    ) -> None:
+        """Observe a batch of runtime updates on one recording stream."""
+        for update in updates:
+            self.observe_update(update, payloads=payloads, payload_resolver=payload_resolver)
 
     def _observe_resolved_update(self, update: StageRuntimeUpdate, *, payloads: Mapping[str, np.ndarray]) -> None:
         self._policy.observe_update(self._stream, update, payloads=payloads)
@@ -157,11 +169,11 @@ class LiveRerunEventSink(_BaseRerunEventSink):
             )
         )
         attach_recording_sinks(self._stream, grpc_url=grpc_url, target_path=None)
+        self._policy.tracking_trajectory_history_window = _LIVE_TRACKING_TRAJECTORY_HISTORY_WINDOW
 
     def _observe_resolved_update(self, update: StageRuntimeUpdate, *, payloads: Mapping[str, np.ndarray]) -> None:
         try:
             super()._observe_resolved_update(update, payloads=payloads)
-            self._stream.flush(blocking=False)
         except Exception as exc:  # pragma: no cover - live viewer is best effort
             _LOGGER.warning("Skipping live Rerun update for stage '%s': %s", update.stage_key.value, exc)
 
@@ -229,6 +241,16 @@ class ExportRerunEventSink(_BaseRerunEventSink):
 
 
 class _ActorPayloadResolverMixin:
+    @staticmethod
+    def _payload_resolver(payload_resolver: ActorHandle | None) -> PayloadResolver | None:
+        if payload_resolver is None:
+            return None
+
+        def resolve_payload(ref: TransientPayloadRef) -> np.ndarray | None:
+            return cast(np.ndarray | None, ray.get(payload_resolver.read_payload.remote(ref.handle_id)))
+
+        return resolve_payload
+
     def _observe_with_actor_resolver(
         self,
         *,
@@ -236,15 +258,23 @@ class _ActorPayloadResolverMixin:
         update: StageRuntimeUpdate,
         payload_resolver: ActorHandle | None,
     ) -> None:
-        def resolve_payload(ref: TransientPayloadRef) -> np.ndarray | None:
-            if payload_resolver is None:
-                return None
-            return cast(np.ndarray | None, ray.get(payload_resolver.read_payload.remote(ref.handle_id)))
-
         try:
-            sink.observe_update(update, payload_resolver=None if payload_resolver is None else resolve_payload)
+            sink.observe_update(update, payload_resolver=self._payload_resolver(payload_resolver))
         except Exception as exc:  # pragma: no cover - best-effort sink guard
             _LOGGER.warning("Skipping Rerun sink runtime update for stage '%s': %s", update.stage_key.value, exc)
+
+    def _observe_updates_with_actor_resolver(
+        self,
+        *,
+        sink: _BaseRerunEventSink,
+        updates: list[StageRuntimeUpdate],
+        payload_resolver: ActorHandle | None,
+    ) -> None:
+        try:
+            sink.observe_updates(updates, payload_resolver=self._payload_resolver(payload_resolver))
+        except Exception as exc:  # pragma: no cover - best-effort sink guard
+            stage_key = "unknown" if not updates else updates[-1].stage_key.value
+            _LOGGER.warning("Skipping Rerun sink runtime update batch ending at stage '%s': %s", stage_key, exc)
 
 
 @ray.remote(num_cpus=1.0, max_restarts=0, max_task_retries=0)
@@ -284,6 +314,14 @@ class LiveRerunSinkActor(_ActorPayloadResolverMixin):
 
     def observe_update(self, *, update: StageRuntimeUpdate, payload_resolver: ActorHandle | None = None) -> None:
         self._observe_with_actor_resolver(sink=self._sink, update=update, payload_resolver=payload_resolver)
+
+    def observe_updates(
+        self,
+        *,
+        updates: list[StageRuntimeUpdate],
+        payload_resolver: ActorHandle | None = None,
+    ) -> None:
+        self._observe_updates_with_actor_resolver(sink=self._sink, updates=updates, payload_resolver=payload_resolver)
 
     def close(self) -> None:
         self._sink.close()
@@ -326,6 +364,14 @@ class ExportRerunSinkActor(_ActorPayloadResolverMixin):
 
     def observe_update(self, *, update: StageRuntimeUpdate, payload_resolver: ActorHandle | None = None) -> None:
         self._observe_with_actor_resolver(sink=self._sink, update=update, payload_resolver=payload_resolver)
+
+    def observe_updates(
+        self,
+        *,
+        updates: list[StageRuntimeUpdate],
+        payload_resolver: ActorHandle | None = None,
+    ) -> None:
+        self._observe_updates_with_actor_resolver(sink=self._sink, updates=updates, payload_resolver=payload_resolver)
 
     def close(self) -> None:
         self._sink.close()

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -25,6 +25,7 @@ from prml_vslam.eval.stage_trajectory.spec import TRAJECTORY_EVALUATION_STAGE_SP
 from prml_vslam.eval.trajectory_contracts import TrajectoryEvaluationManifest
 from prml_vslam.interfaces import (
     CAMERA_RDF_FRAME,
+    CameraIntrinsics,
     FrameTransform,
     Observation,
     ObservationIndexEntry,
@@ -37,6 +38,7 @@ from prml_vslam.interfaces.slam import SlamArtifacts
 from prml_vslam.methods.contracts import SlamUpdate
 from prml_vslam.methods.stage.backend_config import MethodId, VistaSlamBackendConfig
 from prml_vslam.methods.stage.contracts import SlamStageOutput
+from prml_vslam.methods.stage.runtime import SlamStageRuntime
 from prml_vslam.methods.stage.spec import SLAM_STAGE_SPEC
 from prml_vslam.pipeline import PipelineMode
 from prml_vslam.pipeline.backend_ray import RayPipelineBackend
@@ -69,6 +71,7 @@ from prml_vslam.pipeline.stages.base.contracts import (
     VisualizationItem,
 )
 from prml_vslam.pipeline.stages.base.handles import TransientPayloadRef
+from prml_vslam.pipeline.stages.base.ray import RayStageRuntimeHandle
 from prml_vslam.pipeline.stages.summary.spec import SUMMARY_STAGE_SPEC
 from prml_vslam.reconstruction.stage import ReconstructionRuntime, ReconstructionStageInput
 from prml_vslam.sources.config import AdvioSourceConfig, TumRgbdSourceConfig, VideoSourceConfig
@@ -778,6 +781,130 @@ def test_actor_options_explicit_source_placement_overrides_resources() -> None:
     assert options["max_restarts"] == -1
 
 
+def test_run_coordinator_starts_streaming_slam_actor_with_stage_resources(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    coordinator_cls = RunCoordinatorActor.__ray_metadata__.modified_class
+    coordinator = coordinator_cls(run_id="placement-stream", namespace="pytest-unit")
+    run_config = _run_config(
+        experiment_name="placement-stream",
+        mode=PipelineMode.STREAMING,
+        output_dir=tmp_path / ".artifacts",
+        source_backend=VideoSourceConfig(video_path=Path("captures/demo.mp4")),
+        method=MethodId.VISTA,
+    )
+    backend = _test_backend_config(default_cpu=2.0, default_gpu=0.5)
+    slam_config = run_config.stages.slam.model_copy(
+        update={
+            "backend": backend,
+            "num_cpus": 3.0,
+            "num_gpus": 1.0,
+            "custom_resources": {"capture": 0.25},
+        }
+    )
+    run_config = run_config.model_copy(update={"stages": run_config.stages.model_copy(update={"slam": slam_config})})
+    plan = _plan_with_stages(tmp_path=tmp_path, run_config=run_config, stage_keys=[StageKey.SLAM])
+    context = PipelineExecutionContext(
+        run_config=run_config,
+        plan=plan,
+        path_config=PathConfig(root=_repo_root(), artifacts_dir=tmp_path / ".artifacts"),
+        run_paths=RunArtifactPaths.build(plan.artifact_root),
+        results=StageResultStore(),
+        slam_backend=backend,
+    )
+    captured_actor_options: dict[str, Any] = {}
+    captured_start_kwargs: dict[str, Any] = {}
+
+    class FakeRemoteRuntimeClass:
+        @staticmethod
+        def remote() -> str:
+            return "slam-actor"
+
+    def fake_ray_remote(**actor_options: Any):
+        captured_actor_options.update(actor_options)
+
+        def wrap(runtime_factory: type[SlamStageRuntime]) -> type[FakeRemoteRuntimeClass]:
+            assert runtime_factory is SlamStageRuntime
+            return FakeRemoteRuntimeClass
+
+        return wrap
+
+    monkeypatch.setattr("prml_vslam.pipeline.ray_runtime.coordinator.ray.remote", fake_ray_remote)
+    monkeypatch.setattr(
+        coordinator._stage_runner,
+        "start_configured_streaming_stage",
+        lambda **kwargs: captured_start_kwargs.update(kwargs),
+    )
+    runtime_manager = SimpleNamespace(stage_spec=lambda stage_key: SLAM_STAGE_SPEC)
+
+    coordinator._start_streaming_slam_runtime(context=context, runtime_manager=runtime_manager)
+
+    assert captured_actor_options["num_cpus"] == 3.0
+    assert captured_actor_options["num_gpus"] == 1.0
+    assert captured_actor_options["resources"] == {"capture": 0.25}
+    assert captured_start_kwargs["stage_key"] is StageKey.SLAM
+    runtime_proxy = captured_start_kwargs["runtime"]
+    assert runtime_proxy.actor == "slam-actor"
+    assert runtime_proxy.resource_assignment == {
+        "num_cpus": 3.0,
+        "num_gpus": 1.0,
+        "resource:capture": 0.25,
+    }
+
+
+def test_run_coordinator_starts_streaming_slam_actor_with_backend_default_resources(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    coordinator_cls = RunCoordinatorActor.__ray_metadata__.modified_class
+    coordinator = coordinator_cls(run_id="placement-stream-defaults", namespace="pytest-unit")
+    run_config = _run_config(
+        experiment_name="placement-stream-defaults",
+        mode=PipelineMode.STREAMING,
+        output_dir=tmp_path / ".artifacts",
+        source_backend=VideoSourceConfig(video_path=Path("captures/demo.mp4")),
+        method=MethodId.VISTA,
+    )
+    backend = _test_backend_config(default_cpu=2.0, default_gpu=0.5)
+    slam_config = run_config.stages.slam.model_copy(update={"backend": backend})
+    run_config = run_config.model_copy(update={"stages": run_config.stages.model_copy(update={"slam": slam_config})})
+    plan = _plan_with_stages(tmp_path=tmp_path, run_config=run_config, stage_keys=[StageKey.SLAM])
+    context = PipelineExecutionContext(
+        run_config=run_config,
+        plan=plan,
+        path_config=PathConfig(root=_repo_root(), artifacts_dir=tmp_path / ".artifacts"),
+        run_paths=RunArtifactPaths.build(plan.artifact_root),
+        results=StageResultStore(),
+        slam_backend=backend,
+    )
+    captured_actor_options: dict[str, Any] = {}
+
+    class FakeRemoteRuntimeClass:
+        @staticmethod
+        def remote() -> str:
+            return "slam-actor"
+
+    def fake_ray_remote(**actor_options: Any):
+        captured_actor_options.update(actor_options)
+
+        def wrap(runtime_factory: type[SlamStageRuntime]) -> type[FakeRemoteRuntimeClass]:
+            assert runtime_factory is SlamStageRuntime
+            return FakeRemoteRuntimeClass
+
+        return wrap
+
+    monkeypatch.setattr("prml_vslam.pipeline.ray_runtime.coordinator.ray.remote", fake_ray_remote)
+    monkeypatch.setattr(coordinator._stage_runner, "start_configured_streaming_stage", lambda **kwargs: None)
+    runtime_manager = SimpleNamespace(stage_spec=lambda stage_key: SLAM_STAGE_SPEC)
+
+    coordinator._start_streaming_slam_runtime(context=context, runtime_manager=runtime_manager)
+
+    assert captured_actor_options["num_cpus"] == 2.0
+    assert captured_actor_options["num_gpus"] == 0.5
+    assert "resources" not in captured_actor_options
+
+
 def test_clean_actor_options_keeps_nonempty_resources_dict() -> None:
     cleaned = clean_actor_options(
         {
@@ -909,6 +1036,219 @@ def test_run_coordinator_forwards_packet_arrival_timestamp_to_slam_runtime() -> 
     assert submitted[0].arrival_timestamp_s == 123.45
 
 
+def test_run_coordinator_schedules_packet_on_ray_slam_runtime_without_inline_completion() -> None:
+    coordinator_cls = RunCoordinatorActor.__ray_metadata__.modified_class
+    coordinator = coordinator_cls(run_id="demo", namespace="pytest-unit")
+    submitted: list[Observation] = []
+    credits: list[int] = []
+
+    class FakeRaySlamRuntime(RayStageRuntimeHandle):
+        def __init__(self) -> None:
+            self._submitted_count = 0
+            self._completed_count = 0
+            self._failed_count = 0
+            self._in_flight_count = 0
+
+        def submit_stream_item_async(self, item: Observation) -> str:
+            submitted.append(item)
+            return "slam-ref"
+
+    coordinator._slam_runtime_proxy = FakeRaySlamRuntime()
+    coordinator._source_actor = SimpleNamespace(
+        grant_credit=SimpleNamespace(remote=lambda count: credits.append(count)),
+    )
+
+    coordinator.on_packet(
+        packet=Observation(
+            seq=7,
+            timestamp_ns=700,
+            arrival_timestamp_s=123.45,
+            provenance=ObservationProvenance(source_id="source"),
+        ),
+        frame_ref=np.zeros((2, 2, 3), dtype=np.uint8),
+        depth_ref=None,
+        confidence_ref=None,
+        pointmap_ref=None,
+        intrinsics=None,
+        pose=None,
+        provenance=ObservationProvenance(source_id="source"),
+        processed_frame_count=1,
+        measured_fps=30.0,
+    )
+
+    assert len(submitted) == 1
+    assert submitted[0].arrival_timestamp_s == 123.45
+    assert credits == []
+    assert coordinator._in_flight_frames == 1
+    assert coordinator._slam_submission_refs == ["slam-ref"]
+
+
+def test_run_coordinator_releases_streaming_credit_after_ray_slam_completion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    coordinator_cls = RunCoordinatorActor.__ray_metadata__.modified_class
+    coordinator = coordinator_cls(run_id="demo", namespace="pytest-unit")
+    call_order: list[str] = []
+    credits: list[int] = []
+    update = StageRuntimeUpdate(
+        stage_key=StageKey.SLAM,
+        timestamp_ns=1,
+        runtime_status=StageRuntimeStatus(stage_key=StageKey.SLAM, lifecycle_state=StageStatus.RUNNING),
+    )
+
+    class FakeRaySlamRuntime(RayStageRuntimeHandle):
+        def __init__(self) -> None:
+            self.completed = 0
+            self.failed = 0
+
+        def mark_async_item_completed(self) -> None:
+            self.completed += 1
+
+        def mark_async_item_failed(self) -> None:
+            self.failed += 1
+
+        def drain_runtime_updates(self, max_items: int | None = None) -> list[StageRuntimeUpdate]:
+            del max_items
+            return [update]
+
+    coordinator._slam_runtime_proxy = FakeRaySlamRuntime()
+    coordinator._in_flight_frames = 1
+    coordinator._source_actor = SimpleNamespace(
+        grant_credit=SimpleNamespace(remote=lambda count: call_order.append("credit") or credits.append(count)),
+    )
+    monkeypatch.setattr("prml_vslam.pipeline.ray_runtime.coordinator.ray.get", lambda ref: None)
+    monkeypatch.setattr(
+        coordinator,
+        "_publish_slam_runtime_updates",
+        lambda updates: call_order.append("updates") or None,
+    )
+
+    coordinator._complete_slam_submission("slam-ref")
+
+    assert call_order == ["credit", "updates"]
+    assert credits == [1]
+    assert coordinator._slam_runtime_proxy.completed == 1
+    assert coordinator._in_flight_frames == 0
+    assert coordinator._streaming_error is None
+
+
+def test_ray_stage_runtime_handle_hosts_slam_stage_runtime(tmp_path: Path) -> None:
+    ray.init(address="local", include_dashboard=False, num_cpus=1, log_to_driver=False)
+    try:
+
+        class FakeRayStageRuntime:
+            def __init__(self) -> None:
+                self.items: list[Observation] = []
+                self.payload = np.ones((2, 2, 3), dtype=np.uint8)
+                self.payload_ref = TransientPayloadRef(
+                    handle_id="payload-1",
+                    payload_kind="image",
+                    shape=self.payload.shape,
+                    dtype=str(self.payload.dtype),
+                )
+
+            def _output(self) -> SlamStageOutput:
+                trajectory_path = tmp_path / "trajectory.tum"
+                trajectory_path.write_text("0.0 0.0 0.0 0.0 0.0 0.0 0.0 1.0\n", encoding="utf-8")
+                return SlamStageOutput(
+                    artifacts=SlamArtifacts(
+                        trajectory_tum=ArtifactRef(path=trajectory_path, kind="tum", fingerprint="traj"),
+                    )
+                )
+
+            def _result(self) -> StageResult:
+                return StageResult(
+                    stage_key=StageKey.SLAM,
+                    payload=self._output(),
+                    outcome=StageOutcome(
+                        stage_key=StageKey.SLAM,
+                        status=StageStatus.COMPLETED,
+                        config_hash="config",
+                        input_fingerprint="input",
+                    ),
+                    final_runtime_status=StageRuntimeStatus(
+                        stage_key=StageKey.SLAM,
+                        lifecycle_state=StageStatus.COMPLETED,
+                        processed_items=len(self.items),
+                    ),
+                )
+
+            def status(self) -> StageRuntimeStatus:
+                return StageRuntimeStatus(stage_key=StageKey.SLAM, processed_items=len(self.items))
+
+            def stop(self) -> None:
+                return None
+
+            def run_offline(self, input_payload) -> StageResult:
+                del input_payload
+                return self._result()
+
+            def start_streaming(self, input_payload) -> None:
+                del input_payload
+
+            def submit_stream_item(self, item: Observation) -> None:
+                self.items.append(item)
+
+            def drain_runtime_updates(self, max_items: int | None = None) -> list[StageRuntimeUpdate]:
+                del max_items
+                if not self.items:
+                    return []
+                frame = self.items[-1]
+                return [
+                    StageRuntimeUpdate(
+                        stage_key=StageKey.SLAM,
+                        timestamp_ns=frame.timestamp_ns,
+                        visualizations=[
+                            VisualizationItem(
+                                intent=VisualizationIntent.RGB_IMAGE,
+                                role="model_rgb",
+                                payload_refs={"image": self.payload_ref},
+                                frame_index=frame.seq,
+                            )
+                        ],
+                    )
+                ]
+
+            def finish_streaming(self) -> StageResult:
+                return self._result()
+
+            def read_payload(self, ref: TransientPayloadRef) -> np.ndarray | None:
+                return self.payload if ref.handle_id == self.payload_ref.handle_id else None
+
+            def read_payload_by_id(self, handle_id: str) -> np.ndarray | None:
+                return self.payload if handle_id == self.payload_ref.handle_id else None
+
+        remote_runtime_cls = ray.remote(num_cpus=0)(FakeRayStageRuntime)
+        handle = RayStageRuntimeHandle(stage_key=StageKey.SLAM, actor=remote_runtime_cls.remote())
+        start_input = SourceStageOutput(
+            sequence_manifest=SequenceManifest(sequence_id="seq-1"),
+            benchmark_inputs=PreparedBenchmarkInputs(),
+        )
+
+        handle.start_streaming(start_input)
+        handle.submit_stream_item(
+            Observation(
+                seq=1,
+                timestamp_ns=10,
+                rgb=np.zeros((2, 2, 3), dtype=np.uint8),
+                provenance=ObservationProvenance(source_id="source"),
+            )
+        )
+        updates = handle.drain_runtime_updates()
+        status = handle.status()
+
+        assert updates
+        assert status.processed_items == 1
+        refs = [ref for update in updates for item in update.visualizations for ref in item.payload_refs.values()]
+        assert refs
+        assert handle.read_payload(refs[0]) is not None
+        result = handle.finish_streaming()
+        assert result.stage_key is StageKey.SLAM
+        assert isinstance(result.payload, SlamStageOutput)
+    finally:
+        ray.shutdown()
+
+
 def test_run_coordinator_applies_slam_runtime_updates_to_snapshot() -> None:
     coordinator_cls = RunCoordinatorActor.__ray_metadata__.modified_class
     coordinator = coordinator_cls(run_id="run-1", namespace="pytest-unit")
@@ -1018,6 +1358,14 @@ def _attach_fake_rerun_sidecars(
             submitted.append((self._label, update, payload_resolver))
             return f"{self._label}-call-{len(submitted)}"
 
+    class _FakeObserveUpdatesRemote:
+        def __init__(self, label: str) -> None:
+            self._label = label
+
+        def remote(self, *, updates: list[StageRuntimeUpdate], payload_resolver: Any) -> str:
+            submitted.extend((self._label, update, payload_resolver) for update in updates)
+            return f"{self._label}-batch-call-{len(submitted)}"
+
     class _FakeCloseRemote:
         def __init__(self, label: str) -> None:
             self._label = label
@@ -1028,6 +1376,7 @@ def _attach_fake_rerun_sidecars(
     class _FakeActor:
         def __init__(self, label: str) -> None:
             self.observe_update = _FakeObserveUpdateRemote(label)
+            self.observe_updates = _FakeObserveUpdatesRemote(label)
             self.close = _FakeCloseRemote(label)
 
     coordinator._rerun_sinks = [
@@ -1055,9 +1404,18 @@ def test_run_coordinator_submits_rerun_updates_to_separate_live_and_export_sidec
             submitted.append((self._label, update, payload_resolver))
             return f"{self._label}-call"
 
+    class FakeObserveUpdatesRemote:
+        def __init__(self, label: str) -> None:
+            self._label = label
+
+        def remote(self, *, updates: list[StageRuntimeUpdate], payload_resolver: Any) -> str:
+            submitted.extend((self._label, update, payload_resolver) for update in updates)
+            return f"{self._label}-batch-call"
+
     class FakeActor:
         def __init__(self, label: str) -> None:
             self.observe_update = FakeObserveUpdateRemote(label)
+            self.observe_updates = FakeObserveUpdatesRemote(label)
 
     class FakeLiveRerunSinkActor:
         @staticmethod
@@ -1086,7 +1444,17 @@ def test_run_coordinator_submits_rerun_updates_to_separate_live_and_export_sidec
         reference_point_cloud_decimation_keep_ratio=1.0,
     )
     run_paths = RunArtifactPaths.build(tmp_path / "demo")
-    update = StageRuntimeUpdate(stage_key=StageKey.SLAM, timestamp_ns=1)
+    update = StageRuntimeUpdate(
+        stage_key=StageKey.SLAM,
+        timestamp_ns=1,
+        visualizations=[
+            VisualizationItem(
+                intent=VisualizationIntent.TRAJECTORY,
+                role="tracking_trajectory",
+                frame_index=1,
+            )
+        ],
+    )
 
     coordinator._rerun_sinks = coordinator._build_rerun_sinks(run_config=run_config, run_paths=run_paths)
     coordinator._submit_rerun_update(update=update, payload_resolver=None)
@@ -1099,7 +1467,7 @@ def test_run_coordinator_submits_rerun_updates_to_separate_live_and_export_sidec
     assert created[0]["point_cloud_decimation_keep_ratio"] == 0.25
     assert created[0]["reference_point_cloud_decimation_keep_ratio"] == 1.0
     assert submitted == [("live", update, None), ("export", update, None)]
-    assert coordinator._rerun_sinks[0].last_call == "live-call"
+    assert coordinator._rerun_sinks[0].last_call == "live-batch-call"
     assert coordinator._rerun_sinks[1].last_call == "export-call"
 
 
@@ -1110,15 +1478,244 @@ def test_run_coordinator_routes_slam_runtime_updates_to_live_and_export_sidecars
     coordinator = coordinator_cls(run_id="demo", namespace="pytest-unit")
     submitted = _attach_fake_rerun_sidecars(coordinator, kinds=("live", "export"), monkeypatch=monkeypatch)
     monkeypatch.setattr(coordinator, "_self_actor_handle", lambda: "resolver")
+    status_only_update = StageRuntimeUpdate(
+        stage_key=StageKey.SLAM,
+        timestamp_ns=1,
+        runtime_status=StageRuntimeStatus(stage_key=StageKey.SLAM, lifecycle_state=StageStatus.RUNNING),
+    )
+    visual_update = StageRuntimeUpdate(
+        stage_key=StageKey.SLAM,
+        timestamp_ns=2,
+        visualizations=[
+            VisualizationItem(
+                intent=VisualizationIntent.TRAJECTORY,
+                role="tracking_trajectory",
+                frame_index=1,
+            )
+        ],
+    )
+
+    coordinator.on_slam_runtime_updates(updates=[status_only_update])
+
+    assert submitted == []
+    assert coordinator.snapshot().stage_runtime_status[StageKey.SLAM].lifecycle_state is StageStatus.RUNNING
+
+    coordinator.on_slam_runtime_updates(updates=[visual_update])
+
+    assert submitted == [("live", visual_update, "resolver"), ("export", visual_update, "resolver")]
+
+
+def test_run_coordinator_does_not_route_slam_update_semantic_only_updates_to_rerun(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    coordinator_cls = RunCoordinatorActor.__ray_metadata__.modified_class
+    coordinator = coordinator_cls(run_id="demo", namespace="pytest-unit")
+    submitted = _attach_fake_rerun_sidecars(coordinator, kinds=("live", "export"), monkeypatch=monkeypatch)
+    monkeypatch.setattr(coordinator, "_self_actor_handle", lambda: "resolver")
     update = StageRuntimeUpdate(
         stage_key=StageKey.SLAM,
         timestamp_ns=1,
+        semantic_events=[SlamUpdate(seq=1, timestamp_ns=1)],
         runtime_status=StageRuntimeStatus(stage_key=StageKey.SLAM, lifecycle_state=StageStatus.RUNNING),
     )
 
     coordinator.on_slam_runtime_updates(updates=[update])
 
+    assert submitted == []
+    assert coordinator.snapshot().stage_runtime_status[StageKey.SLAM].lifecycle_state is StageStatus.RUNNING
+
+
+def test_run_coordinator_routes_rerun_supported_semantic_events_to_sidecars(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    coordinator_cls = RunCoordinatorActor.__ray_metadata__.modified_class
+    coordinator = coordinator_cls(run_id="demo", namespace="pytest-unit")
+    submitted = _attach_fake_rerun_sidecars(coordinator, kinds=("live", "export"), monkeypatch=monkeypatch)
+    monkeypatch.setattr(coordinator, "_self_actor_handle", lambda: "resolver")
+    alignment = TrajectoryAlignmentArtifact(
+        source_frame="vista_slam_world",
+        target_frame="advio_gt_world",
+        scale=1.0,
+        rotation=np.eye(3).tolist(),
+        translation=[0.0, 0.0, 0.0],
+        matched_pairs=1,
+        rms_error_m=0.0,
+        reference_source="ground_truth",
+        sync_max_diff_s=0.01,
+    )
+    update = StageRuntimeUpdate(stage_key=StageKey.TRAJECTORY_ALIGNMENT, timestamp_ns=1, semantic_events=[alignment])
+
+    coordinator.on_slam_runtime_updates(updates=[update])
+
     assert submitted == [("live", update, "resolver"), ("export", update, "resolver")]
+
+
+def test_run_coordinator_batches_live_updates_without_dropping_export_when_live_is_pending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    coordinator_cls = RunCoordinatorActor.__ray_metadata__.modified_class
+    coordinator = coordinator_cls(run_id="demo", namespace="pytest-unit")
+    live_batches: list[tuple[list[StageRuntimeUpdate], Any]] = []
+    export_updates: list[tuple[StageRuntimeUpdate, Any]] = []
+
+    class FakeObserveUpdatesRemote:
+        def remote(self, *, updates: list[StageRuntimeUpdate], payload_resolver: Any) -> str:
+            live_batches.append((updates, payload_resolver))
+            return "live-batch-call"
+
+    class FakeObserveUpdateRemote:
+        def remote(self, *, update: StageRuntimeUpdate, payload_resolver: Any) -> str:
+            export_updates.append((update, payload_resolver))
+            return f"export-call-{len(export_updates)}"
+
+    live_actor = SimpleNamespace(observe_updates=FakeObserveUpdatesRemote())
+    export_actor = SimpleNamespace(observe_update=FakeObserveUpdateRemote())
+    coordinator._rerun_sinks = [
+        SimpleNamespace(kind="live", actor=live_actor, last_call="pending-live", submission_count=0, pending_count=0),
+        SimpleNamespace(kind="export", actor=export_actor, last_call=None, submission_count=0, pending_count=0),
+    ]
+    monkeypatch.setattr("prml_vslam.pipeline.ray_runtime.coordinator.ray.wait", lambda refs, timeout=0.0: ([], refs))
+    updates = [
+        StageRuntimeUpdate(
+            stage_key=StageKey.SLAM,
+            timestamp_ns=seq,
+            visualizations=[
+                VisualizationItem(
+                    intent=VisualizationIntent.TRAJECTORY,
+                    role="tracking_trajectory",
+                    frame_index=seq,
+                )
+            ],
+        )
+        for seq in (1, 2)
+    ]
+
+    coordinator._submit_rerun_updates(updates=updates, payload_resolver="resolver")
+
+    assert live_batches == [(updates, "resolver")]
+    assert export_updates == [(updates[0], "resolver"), (updates[1], "resolver")]
+    assert coordinator._rerun_sinks[0].last_call == "live-batch-call"
+    assert coordinator._rerun_sinks[1].last_call == "export-call-2"
+
+
+def test_run_coordinator_prunes_disabled_live_rerun_payloads_without_pruning_export(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    coordinator_cls = RunCoordinatorActor.__ray_metadata__.modified_class
+    coordinator = coordinator_cls(run_id="demo", namespace="pytest-unit")
+    submitted = _attach_fake_rerun_sidecars(coordinator, kinds=("live", "export"), monkeypatch=monkeypatch)
+    coordinator._run_config = build_run_config(
+        experiment_name="demo",
+        mode=PipelineMode.STREAMING,
+        output_dir=tmp_path / ".artifacts",
+        source_backend=VideoSourceConfig(video_path=Path("captures/demo.mp4")),
+        method=MethodId.VISTA,
+        connect_live_viewer=True,
+        export_viewer_rrd=True,
+        log_camera_image_rgb=False,
+        log_diagnostic_preview=False,
+    )
+    image_ref = TransientPayloadRef(handle_id="image", payload_kind="image", shape=(2, 2, 3), dtype="uint8")
+    depth_ref = TransientPayloadRef(handle_id="depth", payload_kind="depth", shape=(2, 2), dtype="float32")
+    update = StageRuntimeUpdate(
+        stage_key=StageKey.SLAM,
+        timestamp_ns=1,
+        visualizations=[
+            VisualizationItem(
+                intent=VisualizationIntent.RGB_IMAGE,
+                role="model_camera_rgb",
+                payload_refs={"image": image_ref},
+                frame_index=1,
+            ),
+            VisualizationItem(
+                intent=VisualizationIntent.PINHOLE_CAMERA,
+                role="model_pinhole",
+                payload_refs={"image": image_ref, "depth": depth_ref},
+                intrinsics=CameraIntrinsics(fx=1.0, fy=1.0, cx=0.5, cy=0.5, width_px=2, height_px=2),
+                frame_index=1,
+            ),
+            VisualizationItem(
+                intent=VisualizationIntent.RGB_IMAGE,
+                role="model_rgb",
+                payload_refs={"image": image_ref},
+                frame_index=1,
+            ),
+        ],
+    )
+
+    coordinator._submit_rerun_update(update=update, payload_resolver="resolver")
+
+    assert [label for label, _, _ in submitted] == ["live", "export"]
+    live_update = submitted[0][1]
+    export_update = submitted[1][1]
+    assert [item.role for item in live_update.visualizations] == ["model_pinhole", "model_rgb"]
+    assert live_update.visualizations[0].payload_refs == {}
+    assert export_update is update
+    assert [item.role for item in export_update.visualizations] == [
+        "model_camera_rgb",
+        "model_pinhole",
+        "model_rgb",
+    ]
+    assert export_update.visualizations[1].payload_refs == {"image": image_ref, "depth": depth_ref}
+
+
+def test_run_coordinator_live_only_payload_cache_uses_pruned_rerun_update(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    coordinator_cls = RunCoordinatorActor.__ray_metadata__.modified_class
+    coordinator = coordinator_cls(run_id="demo", namespace="pytest-unit")
+    _attach_fake_rerun_sidecars(coordinator, kinds=("live",), monkeypatch=monkeypatch)
+    coordinator._run_config = build_run_config(
+        experiment_name="demo",
+        mode=PipelineMode.STREAMING,
+        output_dir=tmp_path / ".artifacts",
+        source_backend=VideoSourceConfig(video_path=Path("captures/demo.mp4")),
+        method=MethodId.VISTA,
+        connect_live_viewer=True,
+        log_camera_image_rgb=False,
+        log_diagnostic_preview=False,
+    )
+    coordinator._slam_runtime_proxy = SimpleNamespace()
+    image_ref = TransientPayloadRef(handle_id="image", payload_kind="image", shape=(2, 2, 3), dtype="uint8")
+    depth_ref = TransientPayloadRef(handle_id="depth", payload_kind="depth", shape=(2, 2), dtype="float32")
+    read_handle_ids: list[str] = []
+    monkeypatch.setattr(
+        coordinator,
+        "_read_slam_runtime_payload",
+        lambda ref: read_handle_ids.append(ref.handle_id) or np.zeros((1,), dtype=np.uint8),
+    )
+    monkeypatch.setattr(coordinator, "_self_actor_handle", lambda: "resolver")
+    update = StageRuntimeUpdate(
+        stage_key=StageKey.SLAM,
+        timestamp_ns=1,
+        visualizations=[
+            VisualizationItem(
+                intent=VisualizationIntent.RGB_IMAGE,
+                role="model_camera_rgb",
+                payload_refs={"image": image_ref},
+                frame_index=1,
+            ),
+            VisualizationItem(
+                intent=VisualizationIntent.PINHOLE_CAMERA,
+                role="model_pinhole",
+                payload_refs={"image": image_ref, "depth": depth_ref},
+                intrinsics=CameraIntrinsics(fx=1.0, fy=1.0, cx=0.5, cy=0.5, width_px=2, height_px=2),
+                frame_index=1,
+            ),
+            VisualizationItem(
+                intent=VisualizationIntent.RGB_IMAGE,
+                role="model_rgb",
+                payload_refs={"image": image_ref},
+                frame_index=1,
+            ),
+        ],
+    )
+
+    coordinator.on_slam_runtime_updates(updates=[update])
+
+    assert read_handle_ids == ["image"]
 
 
 def test_run_coordinator_routes_trajectory_evaluation_manifest_to_export_only(
@@ -1334,7 +1931,13 @@ def test_run_coordinator_keeps_live_source_reference_trajectories_before_slam_up
     slam_update = StageRuntimeUpdate(
         stage_key=StageKey.SLAM,
         timestamp_ns=2,
-        runtime_status=StageRuntimeStatus(stage_key=StageKey.SLAM, lifecycle_state=StageStatus.RUNNING),
+        visualizations=[
+            VisualizationItem(
+                intent=VisualizationIntent.TRAJECTORY,
+                role="tracking_trajectory",
+                frame_index=1,
+            )
+        ],
     )
 
     coordinator._submit_source_reference_visualization_update(
@@ -2380,6 +2983,49 @@ def test_ray_backend_submits_via_coordinator_and_reads_via_backend(
     assert backend.read_payload(run_id, TransientPayloadRef(handle_id="payload", payload_kind="image")) is not None
     backend.stop_run(run_id)
     assert stopped == ["backend-unit"]
+
+
+def test_ray_backend_streaming_coordinator_does_not_reserve_slam_resources(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    path_config = PathConfig(root=_repo_root(), artifacts_dir=tmp_path / ".artifacts")
+    backend = RayPipelineBackend(path_config=path_config, namespace="pytest-unit")
+    run_config = _run_config(
+        experiment_name="backend-streaming-unit",
+        mode=PipelineMode.STREAMING,
+        output_dir=path_config.artifacts_dir,
+        source_backend=VideoSourceConfig(video_path=Path("captures/dummy.mp4")),
+        method=MethodId.VISTA,
+    ).model_copy(update={"ray_log_to_driver": False})
+    coordinator_options: dict[str, Any] = {}
+
+    class _Remote:
+        def __init__(self, fn):
+            self.remote = fn
+
+    fake_coordinator = type(
+        "Coordinator",
+        (),
+        {
+            "start": _Remote(lambda **kwargs: None),
+            "shutdown": _Remote(lambda: None),
+        },
+    )()
+
+    monkeypatch.setattr(backend, "_ensure_ray", lambda: None)
+
+    def fake_create_coordinator(run_id: str, *, actor_options: dict[str, Any]):
+        del run_id
+        coordinator_options.update(actor_options)
+        return fake_coordinator
+
+    monkeypatch.setattr(backend, "_create_coordinator", fake_create_coordinator)
+
+    backend.submit_run(run_config=run_config, runtime_source="runtime")
+
+    assert coordinator_options["num_cpus"] == 1.0
+    assert coordinator_options["num_gpus"] == 0.0
 
 
 def test_ray_backend_submit_run_rejects_unavailable_stage_after_planning(

--- a/tests/test_streaming_visualization.py
+++ b/tests/test_streaming_visualization.py
@@ -1000,6 +1000,36 @@ def test_rerun_sink_logs_source_rgb_and_tracking_pose(tmp_path: Path, monkeypatc
     assert tracking_axis_lengths["world/slam/live/tracking/camera"] == 0.0
 
 
+def test_live_rerun_sink_caps_tracking_trajectory_line_strip(monkeypatch) -> None:
+    line_strips: list[np.ndarray] = []
+
+    monkeypatch.setattr(rerun_sink_module, "create_recording_stream", lambda **_: _FakeRecordingStream())
+    monkeypatch.setattr(rerun_sink_module, "attach_recording_sinks", lambda *args, **kwargs: None)
+    monkeypatch.setattr(rerun_helpers, "log_transform", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        rerun_helpers,
+        "log_line_strip3d",
+        lambda stream, *, entity_path, positions_xyz, **kwargs: line_strips.append(
+            np.asarray(positions_xyz, dtype=np.float32).copy()
+        ),
+    )
+    sink = LiveRerunEventSink(grpc_url="rerun+http://127.0.0.1:9876/proxy")
+    sink._policy.tracking_trajectory_history_window = 2
+
+    for seq in range(3):
+        sink.observe_update(
+            _slam_pose_update(
+                source_seq=seq,
+                pose=FrameTransform(qx=0.0, qy=0.0, qz=0.0, qw=1.0, tx=float(seq), ty=0.0, tz=0.0),
+            ),
+            payloads={},
+        )
+
+    assert [len(line_strip) for line_strip in line_strips] == [1, 2, 2]
+    np.testing.assert_allclose(line_strips[-1][:, 0], np.array([1.0, 2.0], dtype=np.float32))
+    sink.close()
+
+
 def test_rerun_sink_keeps_source_rgb_separate_from_model_raster_payloads(tmp_path: Path, monkeypatch) -> None:
     calls: list[tuple[str, str, tuple[int, ...], int | None, int | None]] = []
 
@@ -1109,7 +1139,7 @@ def test_rerun_sink_actor_reserves_full_cpu() -> None:
     assert ExportRerunSinkActor._default_options["num_cpus"] == 1.0
 
 
-def test_rerun_event_sink_flushes_live_stream_after_update(monkeypatch) -> None:
+def test_rerun_event_sink_defers_live_stream_flush_until_close(monkeypatch) -> None:
     live_stream = _FakeRecordingStream()
     monkeypatch.setattr(rerun_sink_module, "create_recording_stream", lambda **_: live_stream)
     monkeypatch.setattr(rerun_sink_module, "attach_recording_sinks", lambda *args, **kwargs: None)
@@ -1118,7 +1148,35 @@ def test_rerun_event_sink_flushes_live_stream_after_update(monkeypatch) -> None:
 
     sink.observe_update(StageRuntimeUpdate(stage_key=StageKey.SLAM, timestamp_ns=1))
 
-    assert live_stream.flush_calls == [False]
+    assert live_stream.flush_calls == []
+    sink.close()
+    assert live_stream.flush_calls == [True]
+
+
+def test_rerun_event_sink_observes_live_update_batches_in_order(monkeypatch) -> None:
+    observed: list[int] = []
+
+    class FakePolicy:
+        def observe_update(self, stream, update, *, payloads=None) -> None:
+            del stream, payloads
+            observed.append(update.timestamp_ns)
+
+    live_stream = _FakeRecordingStream()
+    monkeypatch.setattr(rerun_sink_module, "create_recording_stream", lambda **_: live_stream)
+    monkeypatch.setattr(rerun_sink_module, "attach_recording_sinks", lambda *args, **kwargs: None)
+    monkeypatch.setattr(rerun_sink_module, "RerunLoggingPolicy", lambda **_: FakePolicy())
+
+    sink = LiveRerunEventSink(grpc_url="rerun+http://127.0.0.1:9876/proxy")
+
+    sink.observe_updates(
+        [
+            StageRuntimeUpdate(stage_key=StageKey.SLAM, timestamp_ns=1),
+            StageRuntimeUpdate(stage_key=StageKey.SLAM, timestamp_ns=2),
+        ]
+    )
+
+    assert observed == [1, 2]
+    assert live_stream.flush_calls == []
     sink.close()
 
 
@@ -1156,6 +1214,46 @@ def test_rerun_sink_actor_forwards_stage_runtime_updates_without_payload_resolve
     assert observed["init"]["recording_id"] == "demo"
     assert observed["init"]["show_tracking_trajectory"] is False
     assert observed["update"] == update
+    assert observed["closed"] is True
+
+
+def test_live_rerun_sink_actor_forwards_batched_updates_without_payload_resolver(monkeypatch) -> None:
+    observed: dict[str, object] = {}
+
+    class FakeLocalSink:
+        def __init__(self, **kwargs: object) -> None:
+            observed["init"] = kwargs
+
+        def observe_updates(self, updates, *, payload_resolver=None, payloads=None) -> None:
+            del payload_resolver, payloads
+            observed["updates"] = updates
+
+        def close(self) -> None:
+            observed["closed"] = True
+
+    monkeypatch.setattr(rerun_sink_module, "LiveRerunEventSink", FakeLocalSink)
+    monkeypatch.setattr(
+        rerun_sink_module.ray,
+        "get",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("sink actor must not call ray.get")),
+    )
+
+    actor_cls = LiveRerunSinkActor.__ray_metadata__.modified_class
+    actor = actor_cls(
+        grpc_url="rerun+http://127.0.0.1:9876/proxy",
+        recording_id="demo",
+        show_tracking_trajectory=False,
+    )
+    updates = [
+        StageRuntimeUpdate(stage_key=StageKey.SLAM, timestamp_ns=1),
+        StageRuntimeUpdate(stage_key=StageKey.SLAM, timestamp_ns=2),
+    ]
+    actor.observe_updates(updates=updates, payload_resolver=None)
+    actor.close()
+
+    assert observed["init"]["recording_id"] == "demo"
+    assert observed["init"]["show_tracking_trajectory"] is False
+    assert observed["updates"] == updates
     assert observed["closed"] is True
 
 


### PR DESCRIPTION
## Summary
This PR ports the relevant `main-up` runtime fix onto `sweep-runs`: streaming SLAM work now runs in its own Ray actor with explicit placement resources, while the coordinator remains responsible for orchestration, backpressure, and Rerun routing. The branch intentionally keeps the diff narrow to the runtime/Rerun surfaces and regression tests needed for sweep execution.

Focused verification completed:
- `prml-vslam-worktree-env run uv run ruff check src/prml_vslam/pipeline/backend_ray.py src/prml_vslam/pipeline/placement.py src/prml_vslam/pipeline/ray_runtime/coordinator.py src/prml_vslam/pipeline/stages/base/ray.py src/prml_vslam/visualization/rerun_policy.py src/prml_vslam/visualization/rerun_sink.py tests/test_pipeline.py tests/test_streaming_visualization.py`
- `prml-vslam-worktree-env run uv run mypy src/prml_vslam/pipeline/backend_ray.py src/prml_vslam/pipeline/stages/base/ray.py src/prml_vslam/pipeline/ray_runtime/coordinator.py src/prml_vslam/pipeline/placement.py`
- `prml-vslam-worktree-env run uv run pytest tests/test_pipeline.py::test_ray_stage_runtime_handle_hosts_slam_stage_runtime -q`
- `prml-vslam-worktree-env run uv run pytest tests/test_pipeline.py tests/test_streaming_visualization.py -q`
- `prml-vslam-worktree-env run make ci`
- `prml-vslam-worktree-env run make graphify-rebuild`

## Work Packages
| WP | Scope | Primary surfaces | Status |
| --- | --- | --- | --- |
| WP1 | Ray placement boundary | `pipeline/placement.py`, `pipeline/backend_ray.py` | resolved |
| WP2 | Streaming SLAM actor runtime | `pipeline/stages/base/ray.py`, `pipeline/ray_runtime/coordinator.py` | resolved |
| WP3 | Batched Rerun streaming and regression coverage | `visualization/rerun_*`, `tests/test_pipeline.py`, `tests/test_streaming_visualization.py` | resolved |

## WP1 — Ray Placement Boundary
### Scope
- Narrows Ray placement typing to the `default_resources` surface the backend actually needs.
- Keeps SLAM resource inheritance on the offline coordinator path, while streaming mode lets the dedicated SLAM actor own SLAM resources.

### Key files
- `src/prml_vslam/pipeline/placement.py`
- `src/prml_vslam/pipeline/backend_ray.py`

### Initial success criteria resolution
- `sweep-runs can keep coordinator resources separate from method actor resources`: `resolved`
- `placement typing remains explicit enough for mypy`: `resolved`

## WP2 — Streaming SLAM Actor Runtime
### Scope
- Adds a Ray runtime handle for actor-hosted stage runtimes.
- Routes streaming SLAM submissions through async Ray refs, tracks completion/failure counts, and releases stream credits only after actor-side completion.
- Preserves coordinator-owned orchestration, snapshot, and failure reporting behavior.

### Key files
- `src/prml_vslam/pipeline/stages/base/ray.py`
- `src/prml_vslam/pipeline/ray_runtime/coordinator.py`

### Initial success criteria resolution
- `streaming SLAM no longer executes inline inside the coordinator actor`: `resolved`
- `backpressure accounts for actor completion rather than submission only`: `resolved`
- `Ray-hosted runtime can serve payloads and runtime updates through the existing coordinator path`: `resolved`

## WP3 — Batched Rerun Streaming And Regression Coverage
### Scope
- Adds batched Rerun update routing so live/export sinks receive grouped updates instead of one flush per item.
- Caps live tracking trajectory history while preserving export behavior.
- Adds focused tests for placement resources, Ray-hosted SLAM runtime behavior, async credit release, batched visualization routing, and live trajectory history capping.

### Key files
- `src/prml_vslam/visualization/rerun_policy.py`
- `src/prml_vslam/visualization/rerun_sink.py`
- `tests/test_pipeline.py`
- `tests/test_streaming_visualization.py`

### Initial success criteria resolution
- `live visualization avoids unbounded trajectory history growth`: `resolved`
- `Rerun update routing remains ordered under batching`: `resolved`
- `regression tests cover the sweep-relevant runtime boundary`: `resolved`
